### PR TITLE
Only one task could access the dest

### DIFF
--- a/core/src/main/scala/mill/util/Ctx.scala
+++ b/core/src/main/scala/mill/util/Ctx.scala
@@ -33,13 +33,15 @@ object Ctx{
   }
 }
 class Ctx(val args: IndexedSeq[_],
-          val dest: Path,
+          _dest: Path,
           val log: Logger,
           workerCtx0: Ctx.LoaderCtx)
   extends DestCtx
   with LogCtx
   with ArgCtx
   with LoaderCtx{
+
+  override def dest: Path = _dest
 
   def load[T](x: Ctx.Loader[T]): T = workerCtx0.load(x)
   def length = args.length


### PR DESCRIPTION
currently, could not cache which task which is using it, only a counter is used, and need users to cache the dest him/her self, but we could enable that with `import acyclic.skipped`.

I also fixed up the tests and build.sc 

Plus it with Chinese envs' error message.