### PR TITLE
Build: Bump sbt version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16


### PR DESCRIPTION
The compilation fails with sbt v0.13.15 on some terminals:

```
[ERROR] Failed to construct terminal; falling back to unsupported
java.lang.NumberFormatException: For input string: "0x100"
```