### PR TITLE
don't fail with match error on empty selector

### DIFF
--- a/core/src/main/scala/mill/main/RunScript.scala
+++ b/core/src/main/scala/mill/main/RunScript.scala
@@ -94,7 +94,9 @@ object RunScript{
   def evaluateTarget[T](evaluator: Evaluator[_],
                         scriptArgs: Seq[String]) = {
 
-    val Seq(selectorString, rest @_*) = scriptArgs
+    val selectorString = scriptArgs.headOption.getOrElse("")
+    val rest = scriptArgs.drop(1)
+
     for {
       sel <- parseArgs(selectorString)
       crossSelectors = sel.map{


### PR DESCRIPTION
Currently, mill fails with match error when the selector is empty:
```
➜  mill-zinc git:(master) ✗ mill
Compiling (synthetic)/ammonite/predef/interpBridge.sc
Compiling (synthetic)/ammonite/predef/DefaultPredef.sc
Compiling /Users/rockjam/projects/mill-zinc/build.sc
Exception in thread "main" scala.MatchError: List() (of class scala.collection.immutable.Nil$)
	at mill.main.RunScript$.evaluateTarget(RunScript.scala:97)
	at mill.main.RunScript$.$anonfun$runScript$2(RunScript.scala:44)
	at ammonite.util.Res$Success.flatMap(Res.scala:61)
	at mill.main.RunScript$.runScript(RunScript.scala:41)
	at mill.main.MainRunner.$anonfun$runScript$1(MainRunner.scala:36)
	at ammonite.MainRunner.watchLoop(Main.scala:350)
	at mill.main.MainRunner.runScript(MainRunner.scala:28)
	at mill.Main$.main(Main.scala:63)
	at mill.Main.main(Main.scala)
```

This PR replaces match error with a proper error message from selector validation:
```
➜  mill-zinc git:(master) ✗ mill
Compiling (synthetic)/ammonite/predef/interpBridge.sc
Compiling (synthetic)/ammonite/predef/DefaultPredef.sc
Compiling /Users/rockjam/projects/mill-zinc/build.sc
Selector cannot be empty
```

I'm not sure that this is the best error message. We certainly can do better, for example, give a user the clue what task he can execute.