### PR TITLE
WIP: Infer version from Git

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -7,7 +7,7 @@ import mill._
 import mill.scalalib._, publish._
 import mill.modules.Jvm.createAssembly
 
-trait MillPublishModule extends PublishModule{
+trait MillPublishModule extends PublishModule with GitVersionModule{
   def scalaVersion = "2.12.4"
   def artifactName = "mill-" + super.artifactName()
   def pomSettings = PomSettings(

--- a/scalalib/src/mill/scalalib/GitVersionModule.scala
+++ b/scalalib/src/mill/scalalib/GitVersionModule.scala
@@ -1,0 +1,109 @@
+package mill
+package scalalib
+
+import ammonite.ops.ImplicitWd._
+import ammonite.ops._
+import mill.scalalib.semver.{ReleaseVersion, Version}
+
+import scala.util.matching.Regex
+
+object GitVersionModule {
+
+  val MinorMessage: Regex = """(?i)\[minor\].*""".r
+  val MajorMessage: Regex = """(?i)\[major\].*""".r
+
+  case class CommitInfo(hash: String, message: String, version: Option[Version])
+
+  def tagVersions(tags: Seq[(String, String)]): Seq[(String, Version)] =
+    tags.flatMap { case (commit, tag) =>
+      Version.parse(tag).map(commit -> _)
+    }
+
+  def releaseVersions(versions: Seq[Version]): Seq[ReleaseVersion] =
+    versions.collect { case r: ReleaseVersion => r }
+
+  def latestReleaseVersion(versions: Seq[ReleaseVersion]): Option[ReleaseVersion] =
+    if (versions.nonEmpty) Some(versions.max) else None
+
+  def latestReleaseCommit(tagVersions: Seq[(String, Version)]): Option[(String, ReleaseVersion)] = {
+    latestReleaseVersion(releaseVersions(tagVersions.map(_._2))).flatMap { latest =>
+      tagVersions.find(_._2 == latest).map(_._1 -> latest)
+    }
+  }
+
+  def bumpCommitVersion(lastRelease: ReleaseVersion,
+                        commit: CommitInfo): ReleaseVersion = {
+    commit.version match {
+      case Some(cv) => cv.baseVersion
+      case None => commit.message match {
+        case MajorMessage() => lastRelease.copy(major = lastRelease.major + 1, 0, 0)
+        case MinorMessage() => lastRelease.copy(minor = lastRelease.minor + 1, patch = 0)
+        case _ => lastRelease.copy(patch = lastRelease.patch + 1)
+      }
+    }
+  }
+
+  def inferVersion(git: Git): String = {
+    val tags = git.tags
+    val versions = tagVersions(tags)
+    val (since, releaseVersion) = GitVersionModule.latestReleaseCommit(versions) match {
+      case Some((c, v)) => Some(c) -> v
+      case None => None -> ReleaseVersion(0, 0, 0)
+    }
+    val commits = git.commitsBetween(since, None)
+    if (commits.isEmpty) "0.0.0" else {
+      val versionsMap = versions.toMap
+      val (currentHash, _) = commits.last
+      versionsMap.get(currentHash) match {
+        case Some(tagged) => tagged.toString
+        case None =>
+          val bumpedBase = commits.map {
+            case (commit, message) =>
+              val commitVersion = versionsMap.get(commit)
+              bumpCommitVersion(releaseVersion, CommitInfo(commit, message, commitVersion))
+          }.max
+          s"$bumpedBase-${commits.length - since.size}+${currentHash.take(8)}"
+      }
+    }
+  }
+
+}
+
+trait GitVersionModule extends mill.Module {
+  this: PublishModule =>
+
+  lazy val git: Git = new GitCLI
+
+  override def publishVersion: T[String] = T {
+    GitVersionModule.inferVersion(git)
+  }
+
+}
+
+trait Git {
+  // Returns tuple of (commit hash, tag)
+  def tags: Seq[(String, String)]
+  // Returns tuple of (commit hash, message)
+  def commitsBetween(refFrom: Option[String], refTo: Option[String]): Seq[(String, String)]
+}
+
+class GitCLI extends Git {
+
+  private def split(s: String): Option[(String, String)] = s.split(" ", 2) match {
+    case Array(a, b) => Some(a -> b)
+    case _ => None
+  }
+
+  def tags: Seq[(String, String)] =
+    %%("git", "tag", "--color=never", "--list", "--format=%(objectname) %(refname:strip=2)")
+      .out.lines.flatMap(split)
+
+  def commitsBetween(refFrom: Option[String], refTo: Option[String]): Seq[(String, String)] = {
+    val cmd =
+      Seq("git", "log", "--color=never", "--pretty=%H %s") ++
+        refFrom.map("^" + _) :+
+        refTo.getOrElse("HEAD")
+    %%(cmd).out.lines.flatMap(split)
+  }
+
+}

--- a/scalalib/src/mill/scalalib/semver/Version.scala
+++ b/scalalib/src/mill/scalalib/semver/Version.scala
@@ -1,0 +1,45 @@
+package mill.scalalib.semver
+
+import scala.util.matching.Regex
+
+sealed trait Version {
+
+  def major: BigInt
+  def minor: BigInt
+  def patch: BigInt
+
+  def baseVersion: ReleaseVersion = ReleaseVersion(major, minor, patch)
+
+}
+
+object Version {
+  val VersionPattern: Regex = """(\d+)\.(\d+)\.(\d+)([-+].*)?""".r
+
+  def parse(s: String): Option[Version] = s match {
+    case VersionPattern(major, minor, patch, null) => Some(ReleaseVersion(BigInt(major), BigInt(minor), BigInt(patch)))
+    case VersionPattern(major, minor, patch, suffix) => Some(PreReleaseVersion(BigInt(major), BigInt(minor), BigInt(patch), suffix))
+    case _ => None
+  }
+
+}
+
+object ReleaseVersion {
+
+  implicit object Ordering extends Ordering[ReleaseVersion] {
+    override def compare(x: ReleaseVersion, y: ReleaseVersion): Int = {
+      val cmp1 = x.major compare y.major
+      if (cmp1 != 0) return cmp1
+      val cmp2 = x.minor compare y.minor
+      if (cmp2 != 0) return cmp2
+      x.patch compare y.patch
+    }
+  }
+
+}
+
+case class ReleaseVersion(major: BigInt, minor: BigInt, patch: BigInt) extends Version {
+  override def toString: String = s"$major.$minor.$patch"
+}
+case class PreReleaseVersion(major: BigInt, minor: BigInt, patch: BigInt, suffix: String) extends Version {
+  override def toString: String = s"$major.$minor.$patch$suffix"
+}

--- a/scalalib/test/src/mill/scalalib/GitVersioningTests.scala
+++ b/scalalib/test/src/mill/scalalib/GitVersioningTests.scala
@@ -1,0 +1,60 @@
+package mill.scalalib
+
+import mill.scalalib.semver.{PreReleaseVersion, ReleaseVersion, Version}
+import utest._
+
+object GitVersioningTests extends TestSuite {
+  def tests: Tests = Tests {
+    'gitVersioning - {
+      'version - {
+        'parse - {
+          'releaseVersion - {
+            val parsed = Version.parse("1.2.3")
+            assert(parsed.contains(ReleaseVersion(1, 2, 3)))
+          }
+          'preReleaseVersion - {
+            val parsed = Version.parse("1.2.3-rc.1")
+            assert(parsed.contains(PreReleaseVersion(1, 2, 3, "-rc.1")))
+          }
+          'wrongVersion - {
+            val parsed = Version.parse("1.2.3.4")
+            assert(parsed.isEmpty)
+          }
+        }
+        'infer - {
+          val commits = Seq(
+            ("0001", "initial commit", None, "0.0.1-1+0001"),
+            ("0002", "initial release", Some("0.5.0"), "0.5.0"),
+            ("0003", "patch", None, "0.5.1-1+0003"),
+            ("0004", "[minor] minor change", None, "0.6.0-2+0004"),
+            ("0005", "[major] major change", None, "1.0.0-3+0005"),
+            ("0006", "release candidate", Some("2.0.0-rc.1"), "2.0.0-rc.1"),
+            ("0007", "patch 2", None, "2.0.0-5+0007"),
+            ("0008", "release", Some("2.0.0"), "2.0.0")
+          )
+
+          def git(max: Int) = new Git {
+            private val visibleCommits = commits.take(max)
+            override def commitsBetween(refFrom: Option[String], refTo: Option[String]): Seq[(String, String)] = {
+              val from = refFrom.fold(0)(from => visibleCommits.indexWhere(_._1 == from))
+              val until = refTo.fold(visibleCommits.length)(to => visibleCommits.indexWhere(_._1 == to) + 1)
+              assert(from >= 0, until >= 0)
+              visibleCommits.slice(from, until).map {
+                case (hash, msg, _, _) => hash -> msg
+              }
+            }
+            override def tags: Seq[(String, String)] = {
+              visibleCommits.collect {
+                case (hash, _, Some(tag), _) => hash -> tag
+              }
+            }
+          }
+
+          val versions = (0 to commits.length).map(c => GitVersionModule.inferVersion(git(c)))
+          val expected = "0.0.0" +: commits.map(_._4)
+          assert(versions == expected)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Infer project version from Git commits/tags. Example versioning:
```
0.0.1-1+9b23217f  * Initial commit
                  |
0.0.1-2+bab9dc56  * Commit 1
                  |
0.5.0             * Commit 2 [tag = 0.5.0]
                  |
0.5.1-1+3de44fd4  * Commit 3
                  |
0.6.0-2+0e769733  * [minor] Commit with a minor change
                  |
1.0.0-3+c9e2260d  * [major] Commit with a major change
                  |
2.0.0-4+6bfee6ef  * Commit 4 [tag = 2.0.0-rc.1]
                  |
2.0.0-5+bbecdadd  * Commit 5
                  |
2.0.0             * Commit 6 [tag = 2.0.0]
```

The exact rules are:
 * Tagged commits are versioned by the tag,
 * Untagged commits are versioned as `<latest-release-bumped>-<nr-of-commits>+<commit-hash>`,
 * By default `<latest-release-bumped>` is the latest released version with patch part incremented,
 * Pre-release tags like `x.y.z-rc.1` increase `<latest-release-bumped>` to `x.y.z`,
 * Commits with `[minor]` prefix in the message bump the `minor` part of the last release,
 * Commits with `[major]` prefix bump the `major` part of the last release.

Relates to #122.