### PR TITLE
Discover main class(es) via zinc #124

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaWorkerApi.scala
+++ b/scalalib/src/mill/scalalib/ScalaWorkerApi.scala
@@ -62,4 +62,6 @@ trait ScalaWorkerApi {
                testClassfilePath: Agg[Path],
                args: Seq[String])
               (implicit ctx: mill.util.Ctx.Log): (String, Seq[Result])
+
+  def discoverMainClasses(compilationResult: CompilationResult)(implicit ctx: mill.util.Ctx): Seq[String]
 }

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -33,6 +33,15 @@ object HelloWorldTests extends TestSuite {
     class HelloWorldCross(val crossScalaVersion: String) extends CrossScalaModule
   }
 
+  object HelloWorldDefaultMain extends HelloBase {
+    object core extends HelloWorldModule
+  }
+
+  object HelloWorldWithoutMain extends HelloBase {
+    object core extends HelloWorldModule{
+      def mainClass = None
+    }
+  }
 
   object HelloWorldWithMain extends HelloBase {
     object core extends HelloWorldModule{
@@ -291,8 +300,8 @@ object HelloWorldTests extends TestSuite {
           read(runResult) == "hello rockjam, your age is: 25"
         )
       }
-      'notRunWithoutMainClass - workspaceTest(HelloWorld){eval =>
-        val Left(Result.Exception(err, _)) = eval.apply(HelloWorld.core.run())
+      'notRunWithoutMainClass - workspaceTest(HelloWorldWithoutMain){eval =>
+        val Left(Result.Exception(err, _)) = eval.apply(HelloWorldWithoutMain.core.run())
 
         assert(
           err.isInstanceOf[RuntimeException]
@@ -314,8 +323,22 @@ object HelloWorldTests extends TestSuite {
           read(runResult) == "hello rockjam, your age is: 25"
         )
       }
-      'notRunWithoutMainClass - workspaceTest(HelloWorld){eval =>
-        val Left(Result.Exception(err, _)) = eval.apply(HelloWorld.core.runLocal())
+      'runWithDefaultMain - workspaceTest(HelloWorldDefaultMain){eval =>
+        val runResult = eval.outPath / 'core / 'run / 'dest / "hello-mill"
+        val Right((_, evalCount)) = eval.apply(
+          HelloWorldDefaultMain.core.runLocal(runResult.toString)
+        )
+
+        assert(evalCount > 0)
+
+
+        assert(
+          exists(runResult),
+          read(runResult) == "hello rockjam, your age is: 25"
+        )
+      }
+      'notRunWithoutMainClass - workspaceTest(HelloWorldWithoutMain){eval =>
+        val Left(Result.Exception(err, _)) = eval.apply(HelloWorldWithoutMain.core.runLocal())
 
         assert(
           err.isInstanceOf[RuntimeException]

--- a/scalaworker/src/mill/scalaworker/ScalaWorker.scala
+++ b/scalaworker/src/mill/scalaworker/ScalaWorker.scala
@@ -99,6 +99,22 @@ class ScalaWorker(ctx0: mill.util.Ctx,
     compiledDest
   }
 
+
+
+  def discoverMainClasses(compilationResult: CompilationResult)(implicit ctx: mill.util.Ctx): Seq[String] = {
+    def toScala[A](o: Optional[A]): Option[A] = if (o.isPresent) Some(o.get) else None
+
+    toScala(FileAnalysisStore.binary(compilationResult.analysisFile.toIO).get())
+      .map(_.getAnalysis)
+      .flatMap{
+        case analysis: Analysis =>
+          Some(analysis.infos.allInfos.values.map(_.getMainClasses).flatten.toSeq.sorted)
+        case _ =>
+          None
+      }
+      .getOrElse(Seq.empty[String])
+  }
+
   def compileScala(scalaVersion: String,
                    sources: Agg[Path],
                    compileBridgeSources: Agg[Path],


### PR DESCRIPTION
Main methods are discovered using zinc (like sbt). All discovered main methods can be found with `discoverMainClasses`. `mainClass` now defaults if there is exactly one discovered main class.