### PR TITLE
Fixed small bug in example

### DIFF
--- a/docs/pages/2 - Configuring Mill.md
+++ b/docs/pages/2 - Configuring Mill.md
@@ -208,7 +208,7 @@ object foo extends ScalaModule {
 
 def lineCount = T{
   import ammonite.ops._
-  foo.sources().flatMap(ref => ls.rec(ref.path)).flatMap(read.lines).size
+  foo.sources().flatMap(ref => ls.rec(ref.path)).filter(_.isFile).flatMap(read.lines).size
 }
 
 def printLineCount() = T.command{


### PR DESCRIPTION
_.isFile Filter was missing:

def lineCount = T{
  import ammonite.ops._
  foo.sources().flatMap( r =>  ls.rec(r.path)).filter(_.isFile).flatMap(read.lines).size
}