### PR TITLE
Give modules a name

### DIFF
--- a/core/src/mill/define/Module.scala
+++ b/core/src/mill/define/Module.scala
@@ -30,7 +30,8 @@ class Module(implicit outerCtx0: mill.define.Ctx)
   implicit def millModuleSegments: Segments = {
     millOuterCtx.segments ++ Seq(millOuterCtx.segment)
   }
-  override def toString = millModuleSegments.render
+  def name: String = millModuleSegments.render
+  override def toString = name
 }
 
 object Module{


### PR DESCRIPTION
Can `Module`s have a name? It's nicer to use than `toString` or `millModuleSegments.render` when doing module introspection.