### PR TITLE
Better error messages when publishing to Sonatype

### DIFF
--- a/docs/pages/1 - Intro to Mill.md
+++ b/docs/pages/1 - Intro to Mill.md
@@ -513,7 +513,7 @@ Missing arguments: (--sonatypeCreds: String, --gpgPassphrase: String, --release:
 Arguments provided did not match expected signature:
 
 publish
-  --sonatypeCreds  String
+  --sonatypeCreds  String (format: "username:password")
   --gpgPassphrase  String
   --release        Boolean
 ```

--- a/scalalib/src/mill/scalalib/publish/SonatypeHttpApi.scala
+++ b/scalalib/src/mill/scalalib/publish/SonatypeHttpApi.scala
@@ -30,6 +30,7 @@ class SonatypeHttpApi(uri: String, credentials: String) {
   def getStagingProfileUri(groupId: String): String = {
     val response = withRetry(
       PatientHttp(s"$uri/staging/profiles").headers(commonHeaders))
+        .throwError
 
     val resourceUri =
       json
@@ -49,6 +50,7 @@ class SonatypeHttpApi(uri: String, credentials: String) {
       .option(HttpOptions.readTimeout(60000))
       .headers(commonHeaders)
       .asString
+      .throwError
 
     json.read(response.body)("type").str.toString
   }
@@ -59,6 +61,7 @@ class SonatypeHttpApi(uri: String, credentials: String) {
       .headers(commonHeaders)
       .postData(
         s"""{"data": {"description": "fresh staging profile for ${groupId}"}}"""))
+      .throwError
 
     json.read(response.body)("data")("stagedRepositoryId").str.toString
   }

--- a/scalalib/src/mill/scalalib/publish/SonatypePublisher.scala
+++ b/scalalib/src/mill/scalalib/publish/SonatypePublisher.scala
@@ -106,7 +106,7 @@ class SonatypePublisher(uri: String,
   private def reportPublishResults(publishResults: Seq[HttpResponse[String]],
                                    artifacts: Seq[Artifact]) = {
     if (publishResults.forall(_.is2xx)) {
-      log.info(s"Published v${artifacts.map(_.id).mkString(", ")} to Sonatype")
+      log.info(s"Published ${artifacts.map(_.id).mkString(", ")} to Sonatype")
     } else {
       val errors = publishResults.filterNot(_.is2xx).map { response =>
         s"Code: ${response.code}, message: ${response.body}"


### PR DESCRIPTION
Now you get an exception:

    1 targets failed
    dgraph.publish scalaj.http.HttpStatusException: 401 Error: HTTP/1.1 401 Unauthorized
         scalaj.http.HttpResponse.throwIf(Http.scala:156)
         ....

instead of a upickle error
