### PR TITLE
Allow specifying classifiers in ivy deps

### DIFF
--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -1,11 +1,22 @@
 package mill.scalalib
 import mill.util.JsonFormatters._
 import upickle.default.{macroRW, ReadWriter => RW}
-sealed trait Dep
+sealed trait Dep {
+  def configure(attributes: coursier.Attributes): Dep
+}
 object Dep{
 
   implicit def parse(signature: String) = {
-    signature.split(':') match{
+    val parts = signature.split(';')
+    val module = parts.head
+    val attributes = parts.tail.foldLeft(coursier.Attributes()) { (as, s) =>
+      s.split('=') match {
+        case Array("classifier", v) => as.copy(classifier = v)
+        case Array(k, v) => throw new Exception(s"Unrecognized attribute: [$s]")
+        case _ => throw new Exception(s"Unable to parse attribute specifier: [$s]")
+      }
+    }
+    (module.split(':') match {
       case Array(a, b, c) => Dep.Java(a, b, c, cross = false)
       case Array(a, b, "", c) => Dep.Java(a, b, c, cross = true)
       case Array(a, "", b, c) => Dep.Scala(a, b, c, cross = false)
@@ -13,12 +24,14 @@ object Dep{
       case Array(a, "", "", b, c) => Dep.Point(a, b, c, cross = false)
       case Array(a, "", "", b, "", c) => Dep.Point(a, b, c, cross = true)
       case _ => throw new Exception(s"Unable to parse signature: [$signature]")
-    }
+    }).configure(attributes = attributes)
   }
   def apply(org: String, name: String, version: String, cross: Boolean): Dep = {
     this(coursier.Dependency(coursier.Module(org, name), version), cross)
   }
-  case class Java(dep: coursier.Dependency, cross: Boolean) extends Dep
+  case class Java(dep: coursier.Dependency, cross: Boolean) extends Dep {
+    def configure(attributes: coursier.Attributes): Dep = copy(dep = dep.copy(attributes = attributes))
+  }
   object Java{
     implicit def rw: RW[Java] = macroRW
     def apply(org: String, name: String, version: String, cross: Boolean): Dep = {
@@ -27,14 +40,18 @@ object Dep{
   }
   implicit def default(dep: coursier.Dependency): Dep = new Java(dep, false)
   def apply(dep: coursier.Dependency, cross: Boolean) = Scala(dep, cross)
-  case class Scala(dep: coursier.Dependency, cross: Boolean) extends Dep
+  case class Scala(dep: coursier.Dependency, cross: Boolean) extends Dep {
+    def configure(attributes: coursier.Attributes): Dep = copy(dep = dep.copy(attributes = attributes))
+  }
   object Scala{
     implicit def rw: RW[Scala] = macroRW
     def apply(org: String, name: String, version: String, cross: Boolean): Dep = {
       Scala(coursier.Dependency(coursier.Module(org, name), version), cross)
     }
   }
-  case class Point(dep: coursier.Dependency, cross: Boolean) extends Dep
+  case class Point(dep: coursier.Dependency, cross: Boolean) extends Dep {
+    def configure(attributes: coursier.Attributes): Dep = copy(dep = dep.copy(attributes = attributes))
+  }
   object Point{
     implicit def rw: RW[Point] = macroRW
     def apply(org: String, name: String, version: String, cross: Boolean): Dep = {

--- a/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
@@ -19,6 +19,13 @@ object ResolveDepsTests extends TestSuite {
       assert(paths.nonEmpty)
     }
 
+    'resolveValidDepsWithClassifier - {
+      val deps = Agg(ivy"org.lwjgl:lwjgl:3.1.1;classifier=natives-macos")
+      val Success(paths) = evalDeps(deps)
+      assert(paths.nonEmpty)
+      assert(paths.items.next.path.toString.contains("natives-macos"))
+    }
+
     'errOnInvalidOrgDeps - {
       val deps = Agg(ivy"xxx.yyy.invalid::pprint:0.5.3")
       val Failure(errMsg, _) = evalDeps(deps)


### PR DESCRIPTION
Syntax:

```scala
ivy"org.lwjgl:lwjgl:3.1.1;classifier=natives-macos"
```

or:

```scala
ivy"org.lwjgl:lwjgl:3.1.1".configure(attributes = coursier.Attributes(classifier = "natives-macos"))
```

I wasn't sure what the best way to test the parser was, let me know if I can write a narrower test!