### PR TITLE
Fix invalid git HEAD ref name in build.sc#gitHead

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -289,7 +289,7 @@ val isMasterCommit = {
 
 def gitHead = T.input{
   sys.env.get("TRAVIS_COMMIT").getOrElse(
-    %%('git, "rev-parse", "head")(pwd).out.string.trim()
+    %%('git, "rev-parse", "HEAD")(pwd).out.string.trim()
   )
 }
 


### PR DESCRIPTION
The `mill show gitHead` and dependent tasks fail on systems with case sensitive filesystem:

> fatal: ambiguous argument 'head': unknown revision or path not in the working tree.

because the default git ref name for current head is "HEAD", in upper case.

This fix should not affect users with case insensitive filesystems.