### PR TITLE
Add message to inform users mill is compiling

### DIFF
--- a/scalaworker/src/mill/scalaworker/ScalaWorker.scala
+++ b/scalaworker/src/mill/scalaworker/ScalaWorker.scala
@@ -76,6 +76,8 @@ class ScalaWorker(ctx0: mill.util.Ctx,
     val compiledDest = workingDir / 'compiled
     if (!exists(workingDir)) {
 
+      println("Compiling compiler interface...")
+
       mkdir(workingDir)
       mkdir(compiledDest)
 


### PR DESCRIPTION
A recurrent thing that confuses users is when mill is compiling and
warnings such as "there were 5 deprecation warnings in total; re-run
with -deprecation for details" pop up.
@lihaoyi suggested to add a `println` call when this happens, so
users know the error does not come from their code.