### PR TITLE
Allows users to customize Node.js (Scala.js' NodeJSEnv) in ScalaJSModule

### DIFF
--- a/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -26,8 +26,13 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
     linker.link(sourceSJSIRs ++ jarSJSIRs, initializer.toSeq, destFile, logger)
   }
 
-  def run(linkedFile: File): Unit = {
-    new NodeJSEnv()
+  def run(config: NodeJSConfig, linkedFile: File): Unit = {
+    new NodeJSEnv(
+      NodeJSEnv.Config()
+        .withExecutable(config.executable)
+        .withArgs(config.args)
+        .withEnv(config.env)
+        .withSourceMap(config.sourceMap))
       .jsRunner(FileVirtualJSFile(linkedFile))
       .run(new ScalaConsoleLogger, ConsoleJSConsole)
   }

--- a/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -37,15 +37,22 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
       .run(new ScalaConsoleLogger, ConsoleJSConsole)
   }
 
-  def getFramework(frameworkName: String,
+  def getFramework(config: NodeJSConfig,
+                   frameworkName: String,
                    linkedFile: File): sbt.testing.Framework = {
-    val env = new NodeJSEnv().loadLibs(
-      Seq(ResolvedJSDependency.minimal(new FileVirtualJSFile(linkedFile)))
-    )
+    val env = new NodeJSEnv(
+      NodeJSEnv.Config()
+        .withExecutable(config.executable)
+        .withArgs(config.args)
+        .withEnv(config.env)
+        .withSourceMap(config.sourceMap))
+      .loadLibs(
+        Seq(ResolvedJSDependency.minimal(new FileVirtualJSFile(linkedFile)))
+      )
 
-    val config = TestAdapter.Config().withLogger(new ScalaConsoleLogger)
+    val tconfig = TestAdapter.Config().withLogger(new ScalaConsoleLogger)
     val adapter =
-      new TestAdapter(env, config)
+      new TestAdapter(env, tconfig)
 
     adapter
       .loadFrameworks(List(List(frameworkName)))

--- a/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -35,10 +35,9 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
   def getFramework(config: NodeJSConfig,
                    frameworkName: String,
                    linkedFile: File): sbt.testing.Framework = {
-    val env = nodeJSEnv(config)
-      .loadLibs(
-        Seq(ResolvedJSDependency.minimal(new FileVirtualJSFile(linkedFile)))
-      )
+    val env = nodeJSEnv(config).loadLibs(
+      Seq(ResolvedJSDependency.minimal(new FileVirtualJSFile(linkedFile)))
+    )
 
     val tconfig = TestAdapter.Config().withLogger(new ScalaConsoleLogger)
     val adapter =

--- a/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -27,12 +27,7 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
   }
 
   def run(config: NodeJSConfig, linkedFile: File): Unit = {
-    new NodeJSEnv(
-      NodeJSEnv.Config()
-        .withExecutable(config.executable)
-        .withArgs(config.args)
-        .withEnv(config.env)
-        .withSourceMap(config.sourceMap))
+    nodeJSEnv(config)
       .jsRunner(FileVirtualJSFile(linkedFile))
       .run(new ScalaConsoleLogger, ConsoleJSConsole)
   }
@@ -40,12 +35,7 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
   def getFramework(config: NodeJSConfig,
                    frameworkName: String,
                    linkedFile: File): sbt.testing.Framework = {
-    val env = new NodeJSEnv(
-      NodeJSEnv.Config()
-        .withExecutable(config.executable)
-        .withArgs(config.args)
-        .withEnv(config.env)
-        .withSourceMap(config.sourceMap))
+    val env = nodeJSEnv(config)
       .loadLibs(
         Seq(ResolvedJSDependency.minimal(new FileVirtualJSFile(linkedFile)))
       )
@@ -59,5 +49,14 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
       .flatten
       .headOption
       .getOrElse(throw new RuntimeException("Failed to get framework"))
+  }
+
+  def nodeJSEnv(config: NodeJSConfig): NodeJSEnv = {
+    new NodeJSEnv(
+      NodeJSEnv.Config()
+        .withExecutable(config.executable)
+        .withArgs(config.args)
+        .withEnv(config.env)
+        .withSourceMap(config.sourceMap))
   }
 }

--- a/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -26,12 +26,7 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
   }
 
   def run(config: NodeJSConfig, linkedFile: File): Unit = {
-    new NodeJSEnv(
-      NodeJSEnv.Config()
-        .withExecutable(config.executable)
-        .withArgs(config.args)
-        .withEnv(config.env)
-        .withSourceMap(config.sourceMap))
+    nodeJSEnv(config)
       .jsRunner(Seq(FileVirtualJSFile(linkedFile)))
       .run(new ScalaConsoleLogger, ConsoleJSConsole)
   }
@@ -39,12 +34,7 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
   def getFramework(config: NodeJSConfig,
                    frameworkName: String,
                    linkedFile: File): sbt.testing.Framework = {
-    val env = new NodeJSEnv(
-      NodeJSEnv.Config()
-        .withExecutable(config.executable)
-        .withArgs(config.args)
-        .withEnv(config.env)
-        .withSourceMap(config.sourceMap))
+    val env = nodeJSEnv(config)
     val tconfig = TestAdapter.Config().withLogger(new ScalaConsoleLogger)
 
     val adapter =
@@ -55,5 +45,14 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
       .flatten
       .headOption
       .getOrElse(throw new RuntimeException("Failed to get framework"))
+  }
+
+  def nodeJSEnv(config: NodeJSConfig): NodeJSEnv = {
+    new NodeJSEnv(
+      NodeJSEnv.Config()
+        .withExecutable(config.executable)
+        .withArgs(config.args)
+        .withEnv(config.env)
+        .withSourceMap(config.sourceMap))
   }
 }

--- a/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -25,8 +25,13 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
     linker.link(sourceIRs ++ libraryIRs, initializer.toSeq, destFile, logger)
   }
 
-  def run(linkedFile: File): Unit = {
-    new NodeJSEnv()
+  def run(config: NodeJSConfig, linkedFile: File): Unit = {
+    new NodeJSEnv(
+      NodeJSEnv.Config()
+        .withExecutable(config.executable)
+        .withArgs(config.args)
+        .withEnv(config.env)
+        .withSourceMap(config.sourceMap))
       .jsRunner(Seq(FileVirtualJSFile(linkedFile)))
       .run(new ScalaConsoleLogger, ConsoleJSConsole)
   }

--- a/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -36,13 +36,19 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
       .run(new ScalaConsoleLogger, ConsoleJSConsole)
   }
 
-  def getFramework(frameworkName: String,
+  def getFramework(config: NodeJSConfig,
+                   frameworkName: String,
                    linkedFile: File): sbt.testing.Framework = {
-    val env = new NodeJSEnv()
-    val config = TestAdapter.Config().withLogger(new ScalaConsoleLogger)
+    val env = new NodeJSEnv(
+      NodeJSEnv.Config()
+        .withExecutable(config.executable)
+        .withArgs(config.args)
+        .withEnv(config.env)
+        .withSourceMap(config.sourceMap))
+    val tconfig = TestAdapter.Config().withLogger(new ScalaConsoleLogger)
 
     val adapter =
-      new TestAdapter(env, Seq(FileVirtualJSFile(linkedFile)), config)
+      new TestAdapter(env, Seq(FileVirtualJSFile(linkedFile)), tconfig)
 
     adapter
       .loadFrameworks(List(List(frameworkName)))

--- a/scalajslib/src/mill/scalajslib/NodeJSConfig.scala
+++ b/scalajslib/src/mill/scalajslib/NodeJSConfig.scala
@@ -1,0 +1,11 @@
+package mill.scalajslib
+
+object NodeJSConfig {
+  import upickle.default.{ReadWriter => RW, macroRW}
+  implicit def rw: RW[NodeJSConfig] = macroRW
+}
+
+final case class NodeJSConfig(executable: String = "node",
+                              args: List[String] = Nil,
+                              env: Map[String, String] = Map.empty,
+                              sourceMap: Boolean = true)

--- a/scalajslib/src/mill/scalajslib/ScalaJSBridge.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSBridge.scala
@@ -55,9 +55,10 @@ class ScalaJSWorker {
   }
 
   def getFramework(toolsClasspath: Agg[Path],
+                   config: NodeJSConfig,
                    frameworkName: String,
                    linkedFile: File): sbt.testing.Framework = {
-    bridge(toolsClasspath).getFramework(frameworkName, linkedFile)
+    bridge(toolsClasspath).getFramework(config, frameworkName, linkedFile)
   }
 
 }
@@ -71,7 +72,8 @@ trait ScalaJSBridge {
 
   def run(config: NodeJSConfig, linkedFile: File): Unit
 
-  def getFramework(frameworkName: String,
+  def getFramework(config: NodeJSConfig,
+                   frameworkName: String,
                    linkedFile: File): sbt.testing.Framework
 
 }

--- a/scalajslib/src/mill/scalajslib/ScalaJSBridge.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSBridge.scala
@@ -50,8 +50,8 @@ class ScalaJSWorker {
     )
   }
 
-  def run(toolsClasspath: Agg[Path], linkedFile: File): Unit = {
-    bridge(toolsClasspath).run(linkedFile)
+  def run(toolsClasspath: Agg[Path], config: NodeJSConfig, linkedFile: File): Unit = {
+    bridge(toolsClasspath).run(config, linkedFile)
   }
 
   def getFramework(toolsClasspath: Agg[Path],
@@ -69,7 +69,7 @@ trait ScalaJSBridge {
            main: String,
            fullOpt: Boolean): Unit
 
-  def run(linkedFile: File): Unit
+  def run(config: NodeJSConfig, linkedFile: File): Unit
 
   def getFramework(frameworkName: String,
                    linkedFile: File): sbt.testing.Framework

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -94,7 +94,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       case Right(_) =>
         ScalaJSBridge.scalaJSBridge().run(
           toolsClasspath().map(_.path),
-          nodeJsConfig(),
+          nodeJSConfig(),
           fastOpt().path.toIO
         )
         Result.Success(())
@@ -158,7 +158,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   override def platformSuffix = s"_sjs${artifactScalaJSVersion()}"
 
-  def nodeJsConfig = T { NodeJSConfig() }
+  def nodeJSConfig = T { NodeJSConfig() }
 }
 
 trait TestScalaJSModule extends ScalaJSModule with TestModule {
@@ -186,6 +186,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
   override def test(args: String*) = T.command {
     val framework = mill.scalajslib.ScalaJSBridge.scalaJSBridge().getFramework(
         toolsClasspath().map(_.path),
+        nodeJSConfig(),
         testFrameworks().head,
         fastOptTest().path.toIO
       )

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -94,6 +94,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       case Right(_) =>
         ScalaJSBridge.scalaJSBridge().run(
           toolsClasspath().map(_.path),
+          nodeJsConfig(),
           fastOpt().path.toIO
         )
         Result.Success(())
@@ -156,6 +157,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   }
 
   override def platformSuffix = s"_sjs${artifactScalaJSVersion()}"
+
+  def nodeJsConfig = T { NodeJSConfig() }
 }
 
 trait TestScalaJSModule extends ScalaJSModule with TestModule {

--- a/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
@@ -1,0 +1,118 @@
+package mill.scalajslib
+
+import ammonite.ops._
+import mill._
+import mill.define.Discover
+import mill.eval.Evaluator
+import mill.scalalib.{CrossScalaModule, DepSyntax}
+import mill.util.{TestEvaluator, TestUtil}
+import utest._
+
+
+object NodeJSConfigTests extends TestSuite {
+  val workspacePath =  TestUtil.getOutPathStatic() / "hello-js-world"
+  val scalaVersion = "2.12.4"
+  val scalaJSVersion = "0.6.22"
+  val utestVersion = "0.6.3"
+  val scalaTestVersion = "3.0.4"
+  val nodeArg2G = "--max-old-space-size=2048"
+
+  trait HelloJSWorldModule extends CrossScalaModule with ScalaJSModule {
+    override def millSourcePath = workspacePath
+    def publishVersion = "0.0.1-SNAPSHOT"
+    override def mainClass = Some("Main")
+  }
+
+  object HelloJSWorld extends TestUtil.BaseModule {
+    val matrix = for {
+      scala <- Seq(scalaVersion)
+      nodeArgs <- Seq(Seq(), Seq(nodeArg2G))
+    } yield (scala, nodeArgs)
+
+    object helloJsWorld extends Cross[BuildModule](matrix:_*)
+    class BuildModule(val crossScalaVersion: String, nodeArgs: List[String]) extends HelloJSWorldModule {
+      override def artifactName = "hello-js-world"
+      def scalaJSVersion = NodeJSConfigTests.scalaJSVersion
+      override def nodeJSConfig = T { NodeJSConfig(args = nodeArgs) }
+    }
+
+    object buildUTest extends Cross[BuildModuleUtest](matrix:_*)
+    class BuildModuleUtest(crossScalaVersion: String, nodeArgs: List[String])
+      extends BuildModule(crossScalaVersion, nodeArgs) {
+      object test extends super.Tests {
+        override def sources = T.sources{ millSourcePath / 'src / 'utest }
+        def testFrameworks = Seq("utest.runner.Framework")
+        override def ivyDeps = Agg(
+          ivy"com.lihaoyi::utest::$utestVersion"
+        )
+        override def nodeJSConfig = T { NodeJSConfig(args = nodeArgs) }
+      }
+    }
+
+    object buildScalaTest extends Cross[BuildModuleScalaTest](matrix:_*)
+    class BuildModuleScalaTest(crossScalaVersion: String, nodeArgs: List[String])
+      extends BuildModule(crossScalaVersion, nodeArgs) {
+      object test extends super.Tests {
+        override def sources = T.sources{ millSourcePath / 'src / 'scalatest }
+        def testFrameworks = Seq("org.scalatest.tools.Framework")
+        override def ivyDeps = Agg(
+          ivy"org.scalatest::scalatest::$scalaTestVersion"
+        )
+        override def nodeJSConfig = T { NodeJSConfig(args = nodeArgs) }
+      }
+    }
+    override lazy val millDiscover = Discover[this.type]
+  }
+
+  val millSourcePath = pwd / 'scalajslib / 'test / 'resources / "hello-js-world"
+
+  val helloWorldEvaluator = TestEvaluator.static(HelloJSWorld)
+
+  val mainObject = helloWorldEvaluator.outPath / 'src / "Main.scala"
+
+  def tests: Tests = Tests {
+    prepareWorkspace()
+
+    def checkLog(command: define.Command[_], nodeArgs: List[String]) = {
+      helloWorldEvaluator(command)
+      val paths = Evaluator.resolveDestPaths(
+        helloWorldEvaluator.outPath,
+        command.ctx.segments
+      )
+      val log = read(paths.log)
+      assert(nodeArgs.forall(log.contains))
+    }
+
+    'test - {
+
+      def checkUtest(nodeArgs: List[String]) = {
+        checkLog(HelloJSWorld.buildUTest(scalaVersion, nodeArgs).test.test(), nodeArgs)
+      }
+
+      def checkScalaTest(nodeArgs: List[String]) = {
+        checkLog(HelloJSWorld.buildScalaTest(scalaVersion, nodeArgs).test.test(), nodeArgs)
+      }
+
+      'utest - checkUtest(List())
+      'utest_2G - checkUtest(List(nodeArg2G))
+      'scalaTest - checkScalaTest(List())
+      'scalaTest_2G - checkScalaTest(List(nodeArg2G))
+    }
+
+    def checkRun(nodeArgs: List[String]): Unit = {
+      checkLog(HelloJSWorld.helloJsWorld(scalaVersion, nodeArgs).run(), nodeArgs)
+    }
+
+    'run - {
+      'run - checkRun(List())
+      'run_2G  - checkRun(List(nodeArg2G))
+    }
+  }
+
+  def prepareWorkspace(): Unit = {
+    rm(workspacePath)
+    mkdir(workspacePath / up)
+    cp(millSourcePath, workspacePath)
+  }
+
+}


### PR DESCRIPTION
This pull request allows users to configure Node.js in ScalaJSModule such as for passing arguments to increase heap memory, executable, etc., as allowed in Scala.js NodeJSEnv.