### PR TITLE
Add out/{module_name} as a content root in generated IntelliJ project

### DIFF
--- a/scalalib/src/mill/scalalib/GenIdea.scala
+++ b/scalalib/src/mill/scalalib/GenIdea.scala
@@ -190,6 +190,10 @@ object GenIdea {
         mod.compile.ctx.segments
       )
       val Seq(scalaVersion: String) = evaluator.evaluate(Agg(mod.scalaVersion)).values
+      val generatedSourceOutPath = Evaluator.resolveDestPaths(
+        evaluator.outPath,
+        mod.generatedSources.ctx.segments
+      )
 
       val elem = moduleXmlTemplate(
         mod.millModuleBasePath.value,
@@ -198,6 +202,7 @@ object GenIdea {
         Strict.Agg.from(normalSourcePaths),
         Strict.Agg.from(generatedSourcePaths),
         paths.out,
+        generatedSourceOutPath.dest,
         Strict.Agg.from(resolvedDeps.map(pathToLibName)),
         Strict.Agg.from(mod.moduleDeps.map{ m => moduleName(moduleLabels(m))}.distinct)
       )
@@ -291,13 +296,15 @@ object GenIdea {
                         resourcePaths: Strict.Agg[Path],
                         normalSourcePaths: Strict.Agg[Path],
                         generatedSourcePaths: Strict.Agg[Path],
-                        outputPath: Path,
+                        compileOutputPath: Path,
+                        generatedSourceOutputPath: Path,
                         libNames: Strict.Agg[String],
                         depNames: Strict.Agg[String]) = {
     <module type="JAVA_MODULE" version="4">
       <component name="NewModuleRootManager">
-        <output url={"file://$MODULE_DIR$/" + relify(outputPath) + "/dest/classes"} />
+        <output url={"file://$MODULE_DIR$/" + relify(compileOutputPath) + "/dest/classes"} />
         <exclude-output />
+        <content url={"file://$MODULE_DIR$/" + relify(generatedSourceOutputPath)} />
         <content url={"file://$MODULE_DIR$/" + relify(basePath)}>
           {
           for (normalSourcePath <- normalSourcePaths.toSeq.sorted)

--- a/scalalib/test/resources/gen-idea/idea_modules/iml
+++ b/scalalib/test/resources/gen-idea/idea_modules/iml
@@ -2,6 +2,7 @@
     <component name="NewModuleRootManager">
         <output url="file://$MODULE_DIR$/../target/workspace/mill/scalalib/GenIdeaTests/helloWorldEvaluator/compile/dest/classes"/>
         <exclude-output/>
+        <content url="file://$MODULE_DIR$/../target/workspace/mill/scalalib/GenIdeaTests/helloWorldEvaluator/generatedSources/dest"/>
         <content url="file://$MODULE_DIR$/../target/workspace/gen-idea">
             <sourceFolder url="file://$MODULE_DIR$/../target/workspace/gen-idea/src" isTestSource="false"/>
             <sourceFolder url="file://$MODULE_DIR$/../target/workspace/gen-idea/resources" isTestSource="false" type="java-resource"/>


### PR DESCRIPTION
The "/.." thing here feels janky to me, but I wasn't sure how to better obtain the "out/{module_name}" dir.

Without this, IntelliJ doesn't notice generated sources, presumably because they are not beneath any "content root", but I'm not sure exactly what the format of these .iml files are because I couldn't find any documentation 😕 