### PR TITLE
Improve fullOpt behavior

### DIFF
--- a/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -7,7 +7,7 @@ import java.io.File
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
-import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker}
+import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker, Semantics}
 import org.scalajs.core.tools.logging.ScalaConsoleLogger
 import org.scalajs.jsenv._
 import org.scalajs.jsenv.nodejs._
@@ -15,7 +15,11 @@ import org.scalajs.testadapter.TestAdapter
 
 class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
   def link(sources: Array[File], libraries: Array[File], dest: File, main: String, fullOpt: Boolean): Unit = {
-    val config = StandardLinker.Config().withOptimizer(fullOpt)
+    val semantics = fullOpt match {
+        case true => Semantics.Defaults.optimized
+        case false => Semantics.Defaults
+    }
+    val config = StandardLinker.Config().withOptimizer(fullOpt).withClosureCompilerIfAvailable(fullOpt).withSemantics(semantics)
     val linker = StandardLinker(config)
     val sourceSJSIRs = sources.map(new FileVirtualScalaJSIRFile(_))
     val jars = libraries.map(jar => IRContainer.Jar(new FileVirtualBinaryFile(jar) with VirtualJarFile))

--- a/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -5,7 +5,7 @@ package bridge
 import java.io.File
 
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker}
+import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker, Semantics}
 import org.scalajs.core.tools.logging.ScalaConsoleLogger
 import org.scalajs.jsenv.ConsoleJSConsole
 import org.scalajs.jsenv.nodejs._
@@ -13,7 +13,11 @@ import org.scalajs.testadapter.TestAdapter
 
 class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
   def link(sources: Array[File], libraries: Array[File], dest: File, main: String, fullOpt: Boolean): Unit = {
-    val config = StandardLinker.Config().withOptimizer(fullOpt)
+    val semantics = fullOpt match {
+        case true => Semantics.Defaults.optimized
+        case false => Semantics.Defaults
+    }
+    val config = StandardLinker.Config().withOptimizer(fullOpt).withClosureCompilerIfAvailable(fullOpt).withSemantics(semantics)
     val linker = StandardLinker(config)
     val cache = new IRFileCache().newCache
     val sourceIRs = sources.map(FileVirtualScalaJSIRFile)


### PR DESCRIPTION
Specifically, fix 2 issues in order to better mirror the behavior of "sbt fullOptJS"

- Invoke the Google Closure Compiler after generating the optimized Javascript output

- Set scala.scalajs.LinkingInfo.developmentMode = false (and productionMode = true) when
building fullOpt in order to allow Scala.js code to distinguish between development
and production mode.

Fixes #189 