### PR TITLE
Fixes for Windows (tested on Windows 10 with MSYS2)

### DIFF
--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -1,6 +1,6 @@
 package mill.modules
 
-import java.io.{ByteArrayInputStream, FileOutputStream}
+import java.io.{ByteArrayInputStream, FileOutputStream, File}
 import java.lang.reflect.Modifier
 import java.net.{URI, URLClassLoader}
 import java.nio.file.{FileSystems, Files, OpenOption, StandardOpenOption}
@@ -28,7 +28,7 @@ object Jvm {
     baseInteractiveSubprocess(
       Vector("java") ++
         jvmArgs ++
-        Vector("-cp", classPath.mkString(":"), mainClass) ++
+        Vector("-cp", classPath.mkString(File.pathSeparator), mainClass) ++
         mainArgs,
       envArgs,
       workingDir
@@ -137,7 +137,7 @@ object Jvm {
     val commandArgs =
       Vector("java") ++
       jvmArgs ++
-      Vector("-cp", classPath.mkString(":"), mainClass) ++
+      Vector("-cp", classPath.mkString(File.pathSeparator), mainClass) ++
       mainArgs
 
     val workingDir1 = Option(workingDir).getOrElse(ctx.dest)


### PR DESCRIPTION
This pull request addresses #157. 

**Note:** mill interactive mode (`-i`) should always be used in Windows.

I've tested this only on Windows 10 (with MSYS2) to compile and run JVM and JS tests for my project.  It would be great if someone can help setup the "official" mill tests on Windows platform (perhaps using AppVeyor).
