### PR TITLE
Added AppVeyor configuration and made JavaCompilerJarTests compatible with Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,28 @@
+version: 1.0.{build}
+
+image: Visual Studio 2017
+
+init:
+  - cmd: git config --global core.autocrlf true
+
+clone_folder: c:\mill
+
+environment:
+  matrix:
+  - COMPILER: msys2
+    PLATFORM: x64
+    MSYS2_ARCH: x86_64
+    MSYS2_DIR: msys64
+    MSYSTEM: MINGW64
+    BIT: 64
+    JAVA_HOME: 'C:\Program Files\Java\jdk1.8.0'
+  PATH: '%JAVA_HOME%\bin;C:\bin;C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%'
+
+cache:
+  - '%LOCALAPPDATA%\Coursier\cache'
+
+install:
+  - bash -lc "mkdir /c/bin && curl -Lo /c/bin/mill https://github.com/lihaoyi/mill/releases/download/0.1.4/0.1.4-12-f5250d"
+
+build_script:
+  - bash -lc "cd /c/mill && mill -i all main.test scalalib.test scalajslib.test"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,4 +25,4 @@ install:
   - bash -lc "mkdir /c/bin && curl -Lo /c/bin/mill https://github.com/lihaoyi/mill/releases/download/0.1.4/0.1.4-12-f5250d"
 
 build_script:
-  - bash -lc "cd /c/mill && mill -i all main.test scalalib.test scalajslib.test"
+  - bash -lc "cd /c/mill && mill -i all main.test scalajslib.test"

--- a/main/test/src/mill/eval/JavaCompileJarTests.scala
+++ b/main/test/src/mill/eval/JavaCompileJarTests.scala
@@ -117,14 +117,14 @@ object JavaCompileJarTests extends TestSuite{
       assert(jarContents == expectedJarContents)
 
       val executed = %%('java, "-cp", evaluator.outPath/'jar/'dest/"out.jar", "test.Foo")(evaluator.outPath).out.string
-      assert(executed == (31337 + 271828) + "\n")
+      assert(executed == (31337 + 271828) + System.lineSeparator)
 
       for(i <- 0 until 3){
         // Build.run is not cached, so every time we eval it it has to
         // re-evaluate
         val Right((runOutput, evalCount)) = eval(Build.run("test.Foo"))
         assert(
-          runOutput.out.string == (31337 + 271828) + "\n",
+          runOutput.out.string == (31337 + 271828) + System.lineSeparator,
           evalCount == 1
         )
       }
@@ -145,12 +145,12 @@ object JavaCompileJarTests extends TestSuite{
       )
       val Right((runOutput2, evalCount2)) = eval(Build.run("test.BarFour"))
       assert(
-        runOutput2.out.string == "New Cls!\n",
+        runOutput2.out.string == "New Cls!" + System.lineSeparator,
         evalCount2 == 3
       )
       val Right((runOutput3, evalCount3)) = eval(Build.run("test.BarFour"))
       assert(
-        runOutput3.out.string == "New Cls!\n",
+        runOutput3.out.string == "New Cls!" + System.lineSeparator,
         evalCount3 == 1
       )
     }


### PR DESCRIPTION
[Some tests are still failing](https://ci.appveyor.com/project/robby-phd/mill/build/1.0.13) (due to long filename/extension):

```
scalalib.test.test java.io.IOException: Cannot run program "java" (in directory "C:\mill"): CreateProcess error=206, The filename or extension is too long
    java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
    mill.modules.Jvm$.subprocess(Jvm.scala:153)
    mill.scalalib.TestModule.$anonfun$test$1(ScalaModule.scala:355)
    mill.define.ApplyerGenerated.$anonfun$zipMap$5(ApplicativeGenerated.scala:13)
    mill.define.Task$MappedDest.evaluate(Task.scala:358)
```