### PR TITLE
Support to switch between NoModule and CommonJSModule ModuleKinds

### DIFF
--- a/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -7,19 +7,27 @@ import java.io.File
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
-import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker, Semantics}
+import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker, Semantics, ModuleKind => ScalaJSModuleKind}
 import org.scalajs.core.tools.logging.ScalaConsoleLogger
 import org.scalajs.jsenv._
 import org.scalajs.jsenv.nodejs._
 import org.scalajs.testadapter.TestAdapter
 
 class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
-  def link(sources: Array[File], libraries: Array[File], dest: File, main: String, fullOpt: Boolean): Unit = {
+  def link(sources: Array[File], libraries: Array[File], dest: File, main: String, fullOpt: Boolean, moduleKind: ModuleKind): Unit = {
     val semantics = fullOpt match {
         case true => Semantics.Defaults.optimized
         case false => Semantics.Defaults
     }
-    val config = StandardLinker.Config().withOptimizer(fullOpt).withClosureCompilerIfAvailable(fullOpt).withSemantics(semantics)
+    val scalaJSModuleKind = moduleKind match {
+      case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
+      case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
+    }
+    val config = StandardLinker.Config()
+      .withOptimizer(fullOpt)
+      .withClosureCompilerIfAvailable(fullOpt)
+      .withSemantics(semantics)
+      .withModuleKind(scalaJSModuleKind)
     val linker = StandardLinker(config)
     val sourceSJSIRs = sources.map(new FileVirtualScalaJSIRFile(_))
     val jars = libraries.map(jar => IRContainer.Jar(new FileVirtualBinaryFile(jar) with VirtualJarFile))

--- a/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -5,19 +5,27 @@ package bridge
 import java.io.File
 
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker, Semantics}
+import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker, Semantics, ModuleKind => ScalaJSModuleKind}
 import org.scalajs.core.tools.logging.ScalaConsoleLogger
 import org.scalajs.jsenv.ConsoleJSConsole
 import org.scalajs.jsenv.nodejs._
 import org.scalajs.testadapter.TestAdapter
 
 class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
-  def link(sources: Array[File], libraries: Array[File], dest: File, main: String, fullOpt: Boolean): Unit = {
+  def link(sources: Array[File], libraries: Array[File], dest: File, main: String, fullOpt: Boolean, moduleKind: ModuleKind): Unit = {
     val semantics = fullOpt match {
         case true => Semantics.Defaults.optimized
         case false => Semantics.Defaults
     }
-    val config = StandardLinker.Config().withOptimizer(fullOpt).withClosureCompilerIfAvailable(fullOpt).withSemantics(semantics)
+    val scalaJSModuleKind = moduleKind match {
+      case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
+      case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
+    }
+    val config = StandardLinker.Config()
+      .withOptimizer(fullOpt)
+      .withClosureCompilerIfAvailable(fullOpt)
+      .withSemantics(semantics)
+      .withModuleKind(scalaJSModuleKind)
     val linker = StandardLinker(config)
     val cache = new IRFileCache().newCache
     val sourceIRs = sources.map(FileVirtualScalaJSIRFile)

--- a/scalajslib/src/mill/scalajslib/ScalaJSBridge.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSBridge.scala
@@ -12,6 +12,12 @@ sealed trait OptimizeMode
 object FastOpt extends OptimizeMode
 object FullOpt extends OptimizeMode
 
+sealed trait ModuleKind
+object ModuleKind{
+  object NoModule extends ModuleKind
+  object CommonJSModule extends ModuleKind
+}
+
 class ScalaJSWorker {
   private var scalaInstanceCache = Option.empty[(Long, ScalaJSBridge)]
 
@@ -40,13 +46,15 @@ class ScalaJSWorker {
            libraries: Agg[Path],
            dest: File,
            main: Option[String],
-           fullOpt: Boolean): Unit = {
+           fullOpt: Boolean,
+           moduleKind: ModuleKind): Unit = {
     bridge(toolsClasspath).link(
       sources.items.map(_.toIO).toArray,
       libraries.items.map(_.toIO).toArray,
       dest,
       main.orNull,
-      fullOpt
+      fullOpt,
+      moduleKind
     )
   }
 
@@ -68,7 +76,8 @@ trait ScalaJSBridge {
            libraries: Array[File],
            dest: File,
            main: String,
-           fullOpt: Boolean): Unit
+           fullOpt: Boolean,
+           moduleKind: ModuleKind): Unit
 
   def run(config: NodeJSConfig, linkedFile: File): Unit
 

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -72,7 +72,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       toolsClasspath(),
       runClasspath(),
       finalMainClassOpt().toOption,
-      FastOpt
+      FastOpt,
+      moduleKind()
     )
   }
 
@@ -82,7 +83,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       toolsClasspath(),
       runClasspath(),
       finalMainClassOpt().toOption,
-      FullOpt
+      FullOpt,
+      moduleKind()
     )
   }
 
@@ -114,7 +116,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
            toolsClasspath: Agg[PathRef],
            runClasspath: Agg[PathRef],
            mainClass: Option[String],
-           mode: OptimizeMode)(implicit ctx: Ctx.Dest): PathRef = {
+           mode: OptimizeMode,
+           moduleKind: ModuleKind)(implicit ctx: Ctx.Dest): PathRef = {
     val outputPath = ctx.dest / "out.js"
 
     mkdir(ctx.dest)
@@ -132,7 +135,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       libraries,
       outputPath.toIO,
       mainClass,
-      mode == FullOpt
+      mode == FullOpt,
+      moduleKind
     )
     PathRef(outputPath)
   }
@@ -159,6 +163,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   override def platformSuffix = s"_sjs${artifactScalaJSVersion()}"
 
   def nodeJSConfig = T { NodeJSConfig() }
+
+  def moduleKind: T[ModuleKind] = T { ModuleKind.NoModule }
 }
 
 trait TestScalaJSModule extends ScalaJSModule with TestModule {
@@ -177,7 +183,8 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
       toolsClasspath(),
       scalaJSTestDeps() ++ runClasspath(),
       None,
-      FastOpt
+      FastOpt,
+      moduleKind()
     )
   }
 


### PR DESCRIPTION
ScalaJS can generate CommonJS modules to use with bundlers like [Browserify](http://browserify.org) and [WebPack](https://webpack.js.org).
Now you can select the `CommonJSModule` mode in a `ScalaJSModule`:
```scala
object Foo extends ScalaJSModule {
  def scalaJSVersion = "0.6.22"
  def scalaVersion = "2.12.4"
  def moduleKind = ModuleKind.CommonJSModule
}
```
The default is `ModuleKind.NoModule` which exports to the global scope.