### PR TITLE
ScalaModule: Added ivyDepsTree command

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -71,6 +71,7 @@ trait ScalaModule extends mill.Module with TaskModule { outer =>
   def transitiveIvyDeps: T[Agg[Dep]] = T{
     ivyDeps() ++ Task.traverse(moduleDeps)(_.transitiveIvyDeps)().flatten
   }
+
   def upstreamCompileOutput = T{
     Task.traverse(moduleDeps)(_.compile)
   }
@@ -245,6 +246,20 @@ trait ScalaModule extends mill.Module with TaskModule { outer =>
         forkArgs()
       )
     )
+  }
+
+  def ivyDepsTree(inverse: Boolean = false) = T.command {
+    import coursier.{Cache, Fetch, Resolution}
+
+    val flattened = ivyDeps().map(depToDependency(_, scalaVersion(), platformSuffix())).toSeq
+    val start = Resolution(flattened.toSet)
+    val fetch = Fetch.from(repositories, Cache.fetch())
+    val resolution = start.process.run(fetch).unsafePerformSync
+
+    println(coursier.util.Print.dependencyTree(flattened, resolution,
+      printExclusions = false, reverse = inverse))
+
+    Result.Success()
   }
 
   def runLocal(args: String*) = T.command {


### PR DESCRIPTION
Trying to fix #199 

```
@ core.ivyDepsTree()() 
[4/4] core.ivyDepsTree 
├─ com.lihaoyi:sourcecode_2.12:0.1.4
│  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
├─ com.lihaoyi:ammonite_2.12.4:1.0.5
│  ├─ com.github.scopt:scopt_2.12:3.5.0
│  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  ├─ com.lihaoyi:ammonite-compiler_2.12.4:1.0.5
│  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  ├─ com.lihaoyi:ammonite-runtime_2.12:1.0.5
│  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  ├─ com.lihaoyi:ammonite-util_2.12:1.0.5
│  │  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:pprint_2.12:0.5.2
│  │  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:upickle_2.12:0.5.1
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  │  │  └─ org.spire-math:jawn-parser_2.12:0.11.0
│  │  │  │  │     └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  ├─ io.get-coursier:coursier-cache_2.12:1.0.0
│  │  │  │  ├─ io.get-coursier:coursier_2.12:1.0.0
│  │  │  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  │  │  ├─ org.scala-lang.modules:scala-xml_2.12:1.0.6
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │  │     └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  │  └─ org.scalaz:scalaz-concurrent_2.12:7.2.16
│  │  │  │     ├─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │     ├─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │     │  └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │     └─ org.scalaz:scalaz-effect_2.12:7.2.16
│  │  │  │        ├─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │        └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │           └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  ├─ io.get-coursier:coursier_2.12:1.0.0
│  │  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  │  ├─ org.scala-lang.modules:scala-xml_2.12:1.0.6
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │     └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  └─ org.scalaj:scalaj-http_2.12:2.3.0
│  │  │     └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  ├─ com.lihaoyi:ammonite-util_2.12:1.0.5
│  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  ├─ com.lihaoyi:pprint_2.12:0.5.2
│  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  ├─ com.lihaoyi:upickle_2.12:0.5.1
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  │  └─ org.spire-math:jawn-parser_2.12:0.11.0
│  │  │  │     └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  ├─ com.lihaoyi:scalaparse_2.12:1.0.0
│  │  │  ├─ com.lihaoyi:fastparse_2.12:1.0.0
│  │  │  │  ├─ com.lihaoyi:fastparse-utils_2.12:1.0.0
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  ├─ org.javassist:javassist:3.21.0-GA
│  │  ├─ org.scala-lang:scala-compiler:2.12.4
│  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  ├─ org.scala-lang:scala-reflect:2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  └─ org.scala-lang.modules:scala-xml_2.12:1.0.6
│  │  │     └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  └─ org.scala-lang:scala-reflect:2.12.4
│  │     └─ org.scala-lang:scala-library:2.12.4
│  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  └─ org.scala-lang:scala-library:2.12.4
│  ├─ com.lihaoyi:ammonite-repl_2.12.4:1.0.5
│  │  ├─ com.github.javaparser:javaparser-core:3.2.5
│  │  ├─ com.lihaoyi:ammonite-compiler_2.12.4:1.0.5
│  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  ├─ com.lihaoyi:ammonite-runtime_2.12:1.0.5
│  │  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  │  ├─ com.lihaoyi:ammonite-util_2.12:1.0.5
│  │  │  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  ├─ com.lihaoyi:pprint_2.12:0.5.2
│  │  │  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  ├─ com.lihaoyi:upickle_2.12:0.5.1
│  │  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  │  │  │  └─ org.spire-math:jawn-parser_2.12:0.11.0
│  │  │  │  │  │     └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  │  ├─ io.get-coursier:coursier-cache_2.12:1.0.0
│  │  │  │  │  ├─ io.get-coursier:coursier_2.12:1.0.0
│  │  │  │  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  │  │  │  ├─ org.scala-lang.modules:scala-xml_2.12:1.0.6
│  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  │  └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │  │  │     └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  │  │  └─ org.scalaz:scalaz-concurrent_2.12:7.2.16
│  │  │  │  │     ├─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  │     ├─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │  │     │  └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  │     └─ org.scalaz:scalaz-effect_2.12:7.2.16
│  │  │  │  │        ├─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  │        └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │  │           └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  ├─ io.get-coursier:coursier_2.12:1.0.0
│  │  │  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  │  │  ├─ org.scala-lang.modules:scala-xml_2.12:1.0.6
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │  │     └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  │  └─ org.scalaj:scalaj-http_2.12:2.3.0
│  │  │  │     └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  ├─ com.lihaoyi:ammonite-util_2.12:1.0.5
│  │  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:pprint_2.12:0.5.2
│  │  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:upickle_2.12:0.5.1
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  │  │  └─ org.spire-math:jawn-parser_2.12:0.11.0
│  │  │  │  │     └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  ├─ com.lihaoyi:scalaparse_2.12:1.0.0
│  │  │  │  ├─ com.lihaoyi:fastparse_2.12:1.0.0
│  │  │  │  │  ├─ com.lihaoyi:fastparse-utils_2.12:1.0.0
│  │  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.4
│  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  ├─ org.javassist:javassist:3.21.0-GA
│  │  │  ├─ org.scala-lang:scala-compiler:2.12.4
│  │  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  │  ├─ org.scala-lang:scala-reflect:2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  │  └─ org.scala-lang.modules:scala-xml_2.12:1.0.6
│  │  │  │     └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  └─ org.scala-lang:scala-reflect:2.12.4
│  │  │     └─ org.scala-lang:scala-library:2.12.4
│  │  ├─ com.lihaoyi:ammonite-runtime_2.12:1.0.5
│  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  ├─ com.lihaoyi:ammonite-util_2.12:1.0.5
│  │  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:pprint_2.12:0.5.2
│  │  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:upickle_2.12:0.5.1
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  │  │  └─ org.spire-math:jawn-parser_2.12:0.11.0
│  │  │  │  │     └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  ├─ io.get-coursier:coursier-cache_2.12:1.0.0
│  │  │  │  ├─ io.get-coursier:coursier_2.12:1.0.0
│  │  │  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  │  │  ├─ org.scala-lang.modules:scala-xml_2.12:1.0.6
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  │  └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │  │     └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  │  └─ org.scalaz:scalaz-concurrent_2.12:7.2.16
│  │  │  │     ├─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │     ├─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │     │  └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │     └─ org.scalaz:scalaz-effect_2.12:7.2.16
│  │  │  │        ├─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  │        └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │           └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  ├─ io.get-coursier:coursier_2.12:1.0.0
│  │  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  │  ├─ org.scala-lang.modules:scala-xml_2.12:1.0.6
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │     └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  └─ org.scalaj:scalaj-http_2.12:2.3.0
│  │  │     └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  ├─ com.lihaoyi:ammonite-terminal_2.12:1.0.5
│  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.3 -> 0.2.4
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  ├─ com.lihaoyi:ammonite-util_2.12:1.0.5
│  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  ├─ com.lihaoyi:pprint_2.12:0.5.2
│  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  ├─ com.lihaoyi:upickle_2.12:0.5.1
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  │  └─ org.spire-math:jawn-parser_2.12:0.11.0
│  │  │  │     └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  ├─ jline:jline:2.14.5
│  │  └─ org.scala-lang:scala-library:2.12.4
│  ├─ com.lihaoyi:ammonite-runtime_2.12:1.0.5
│  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  ├─ com.lihaoyi:ammonite-util_2.12:1.0.5
│  │  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  ├─ com.lihaoyi:pprint_2.12:0.5.2
│  │  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  ├─ com.lihaoyi:upickle_2.12:0.5.1
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  │  └─ org.spire-math:jawn-parser_2.12:0.11.0
│  │  │  │     └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  ├─ io.get-coursier:coursier-cache_2.12:1.0.0
│  │  │  ├─ io.get-coursier:coursier_2.12:1.0.0
│  │  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  │  ├─ org.scala-lang.modules:scala-xml_2.12:1.0.6
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  │  └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │  │     └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  └─ org.scalaz:scalaz-concurrent_2.12:7.2.16
│  │  │     ├─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │     ├─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │     │  └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │     └─ org.scalaz:scalaz-effect_2.12:7.2.16
│  │  │        ├─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  │        └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │           └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  ├─ io.get-coursier:coursier_2.12:1.0.0
│  │  │  ├─ org.scala-lang:scala-library:2.12.1 -> 2.12.4
│  │  │  ├─ org.scala-lang.modules:scala-xml_2.12:1.0.6
│  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  └─ org.scalaz:scalaz-core_2.12:7.2.16
│  │  │     └─ org.scala-lang:scala-library:2.12.3 -> 2.12.4
│  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  └─ org.scalaj:scalaj-http_2.12:2.3.0
│  │     └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  ├─ com.lihaoyi:ammonite-terminal_2.12:1.0.5
│  │  ├─ com.lihaoyi:fansi_2.12:0.2.3 -> 0.2.4
│  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  └─ org.scala-lang:scala-library:2.12.4
│  ├─ com.lihaoyi:ammonite-util_2.12:1.0.5
│  │  ├─ com.lihaoyi:ammonite-ops_2.12:1.0.5
│  │  │  ├─ com.lihaoyi:geny_2.12:0.1.2
│  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.4
│  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  ├─ com.lihaoyi:pprint_2.12:0.5.2
│  │  │  ├─ com.lihaoyi:fansi_2.12:0.2.4
│  │  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.0 -> 2.12.4
│  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  ├─ com.lihaoyi:upickle_2.12:0.5.1
│  │  │  ├─ com.lihaoyi:sourcecode_2.12:0.1.3 -> 0.1.4
│  │  │  │  └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  │  ├─ org.scala-lang:scala-library:2.12.4
│  │  │  └─ org.spire-math:jawn-parser_2.12:0.11.0
│  │  │     └─ org.scala-lang:scala-library:2.12.2 -> 2.12.4
│  │  └─ org.scala-lang:scala-library:2.12.4
│  └─ org.scala-lang:scala-library:2.12.4
└─ jline:jline:2.14.5


```
