### PR TITLE
Support for Java 9 (and 10)

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -83,7 +83,7 @@ object core extends MillModule {
 
   def ivyDeps = Agg(
     ivy"com.lihaoyi::sourcecode:0.1.4",
-    ivy"com.lihaoyi:::ammonite:1.0.5",
+    ivy"com.lihaoyi:::ammonite:1.0.5-1-819bc80",
     ivy"jline:jline:2.14.5"
   )
 


### PR DESCRIPTION
This pull request addresses #156 by upgrading ammonite to (at least) [1.0.5-1-819bc80](https://github.com/lihaoyi/Ammonite/commit/819bc803fd0b95993246560a2a4a595998545c73).

Integrating this pull request builds a mill release that's compatible with Java 9 and 10, which can be used, for example, to include tests in travis using oraclejdk9 (in a separate pull request).