### PR TITLE
Changes to make {clientserver,main,scalalib,scalajslib}.test work under Java 9

### DIFF
--- a/core/src/mill/util/ClassLoader.scala
+++ b/core/src/mill/util/ClassLoader.scala
@@ -1,0 +1,14 @@
+package mill.util
+
+import java.net.URL
+
+import io.github.retronym.java9rtexport.Export
+
+import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
+
+object ClassLoader {
+  def create(urls: Seq[URL], parent: java.lang.ClassLoader): URLClassLoader = {
+    val rtOpt = if (ammonite.util.Util.java9OrAbove) Some(Export.export().toURI.toURL) else None
+    new URLClassLoader(urls ++ rtOpt, parent)
+  }
+}

--- a/core/src/mill/util/ClassLoader.scala
+++ b/core/src/mill/util/ClassLoader.scala
@@ -1,14 +1,12 @@
 package mill.util
 
-import java.net.URL
+import java.net.{URL, URLClassLoader}
 
 import io.github.retronym.java9rtexport.Export
-
-import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 
 object ClassLoader {
   def create(urls: Seq[URL], parent: java.lang.ClassLoader): URLClassLoader = {
     val rtOpt = if (ammonite.util.Util.java9OrAbove) Some(Export.export().toURI.toURL) else None
-    new URLClassLoader(urls ++ rtOpt, parent)
+    new URLClassLoader((urls ++ rtOpt).toArray, parent)
   }
 }

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -104,7 +104,7 @@ object Jvm {
                    body: ClassLoader => T): T = {
     val cl = if (classLoaderOverrideSbtTesting) {
       val outerClassLoader = getClass.getClassLoader
-      new URLClassLoader(classPath.map(_.toIO.toURI.toURL).toArray, null){
+      new URLClassLoader(classPath.map(_.toIO.toURI.toURL).toArray, mill.util.ClassLoader.create(Seq(), null)){
         override def findClass(name: String) = {
           if (name.startsWith("sbt.testing.")){
             outerClassLoader.loadClass(name)
@@ -114,7 +114,7 @@ object Jvm {
         }
       }
     } else {
-      new URLClassLoader(classPath.map(_.toIO.toURI.toURL).toArray, null)
+      mill.util.ClassLoader.create(classPath.map(_.toIO.toURI.toURL).toVector, null)
     }
     val oldCl = Thread.currentThread().getContextClassLoader
     Thread.currentThread().setContextClassLoader(cl)

--- a/main/test/src/mill/util/TestUtil.scala
+++ b/main/test/src/mill/util/TestUtil.scala
@@ -78,4 +78,9 @@ object TestUtil {
       }
     }
   }
+  def disableInJava9OrAbove(f: => Any): Unit = {
+    if (!ammonite.util.Util.java9OrAbove) {
+      f
+    }
+  }
 }

--- a/scalajslib/src/mill/scalajslib/ScalaJSBridge.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSBridge.scala
@@ -27,8 +27,8 @@ class ScalaJSWorker {
     scalaInstanceCache match {
       case Some((sig, bridge)) if sig == classloaderSig => bridge
       case _ =>
-        val cl = new URLClassLoader(
-          toolsClasspath.map(_.toIO.toURI.toURL).toArray,
+        val cl = mill.util.ClassLoader.create(
+          toolsClasspath.map(_.toIO.toURI.toURL).toVector,
           getClass.getClassLoader
         )
         val bridge = cl

--- a/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
@@ -102,7 +102,7 @@ object HelloJSWorldTests extends TestSuite {
 
       'fromScratch_2124_0622 - testCompileFromScratch("2.12.4", "0.6.22")
       'fromScratch_2123_0622 - testCompileFromScratch("2.12.3", "0.6.22")
-      'fromScratch_2118_0622 - testCompileFromScratch("2.11.8", "0.6.22")
+      'fromScratch_2118_0622 - TestUtil.disableInJava9OrAbove(testCompileFromScratch("2.11.8", "0.6.22"))
       'fromScratch_2124_100M2 - testCompileFromScratch("2.12.4", "1.0.0-M2")
     }
 
@@ -119,16 +119,16 @@ object HelloJSWorldTests extends TestSuite {
     }
 
     'fullOpt - {
-      'run_2124_0622 - testRun("2.12.4", "0.6.22", FullOpt)
-      'run_2123_0622 - testRun("2.12.3", "0.6.22", FullOpt)
-      'run_2118_0622 - testRun("2.11.8", "0.6.22", FullOpt)
-      'run_2124_100M2 - testRun("2.12.4", "1.0.0-M2", FullOpt)
+      'run_2124_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "0.6.22", FullOpt))
+      'run_2123_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.3", "0.6.22", FullOpt))
+      'run_2118_0622 - TestUtil.disableInJava9OrAbove(testRun("2.11.8", "0.6.22", FullOpt))
+      'run_2124_100M2 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "1.0.0-M2", FullOpt))
     }
     'fastOpt - {
-      'run_2124_0622 - testRun("2.12.4", "0.6.22", FastOpt)
-      'run_2123_0622 - testRun("2.12.3", "0.6.22", FastOpt)
-      'run_2118_0622 - testRun("2.11.8", "0.6.22", FastOpt)
-      'run_2124_100M2 - testRun("2.12.4", "1.0.0-M2", FastOpt)
+      'run_2124_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "0.6.22", FastOpt))
+      'run_2123_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.3", "0.6.22", FastOpt))
+      'run_2118_0622 - TestUtil.disableInJava9OrAbove(testRun("2.11.8", "0.6.22", FastOpt))
+      'run_2124_100M2 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "1.0.0-M2", FastOpt))
     }
     'jar - {
       'containsSJSIRs - {
@@ -192,12 +192,12 @@ object HelloJSWorldTests extends TestSuite {
         )
       }
 
-      'utest_2118_0622 - checkUtest("2.11.8", "0.6.22")
+      'utest_2118_0622 - TestUtil.disableInJava9OrAbove(checkUtest("2.11.8", "0.6.22"))
       'utest_2124_0622 - checkUtest("2.12.4", "0.6.22")
-      'utest_2118_100M2 - checkUtest("2.11.8", "1.0.0-M2")
+      'utest_2118_100M2 - TestUtil.disableInJava9OrAbove(checkUtest("2.11.8", "1.0.0-M2"))
       'utest_2124_100M2 - checkUtest("2.12.4", "1.0.0-M2")
 
-      'scalaTest_2118_0622 - checkScalaTest("2.11.8", "0.6.22")
+      'scalaTest_2118_0622 - TestUtil.disableInJava9OrAbove(checkScalaTest("2.11.8", "0.6.22"))
       'scalaTest_2124_0622 - checkScalaTest("2.12.4", "0.6.22")
 //      No scalatest artifact for scala.js 1.0.0-M2 published yet
 //      'scalaTest_2118_100M2 - checkScalaTest("2.11.8", "1.0.0-M2")
@@ -222,9 +222,9 @@ object HelloJSWorldTests extends TestSuite {
     }
 
     'run - {
-      'run_2118_0622  - checkRun("2.11.8", "0.6.22")
+      'run_2118_0622  - TestUtil.disableInJava9OrAbove(checkRun("2.11.8", "0.6.22"))
       'run_2124_0622  - checkRun("2.12.4", "0.6.22")
-      'run_2118_100M2 - checkRun("2.11.8", "1.0.0-M2")
+      'run_2118_100M2 - TestUtil.disableInJava9OrAbove(checkRun("2.11.8", "1.0.0-M2"))
       'run_2124_100M2 - checkRun("2.12.4", "1.0.0-M2")
     }
   }

--- a/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
@@ -54,8 +54,8 @@ object MultiModuleTests extends TestSuite {
       )
     }
 
-    'fastOpt - checkOpt(FastOpt)
-    'fullOpt - checkOpt(FullOpt)
+    'fastOpt - TestUtil.disableInJava9OrAbove(checkOpt(FastOpt))
+    'fullOpt - TestUtil.disableInJava9OrAbove(checkOpt(FullOpt))
 
     'test - {
       val Right(((_, testResults), evalCount)) = evaluator(MultiModule.client.test.test())

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -246,8 +246,8 @@ object HelloWorldTests extends TestSuite {
             read(runResult) == expectedOut
           )
         }
-        'v210 - workspaceTest(CrossHelloWorld)(cross(_, "2.10.6", "2.10.6 rox"))
-        'v211 - workspaceTest(CrossHelloWorld)(cross(_, "2.11.11", "2.11.11 pwns"))
+        'v210 - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(_, "2.10.6", "2.10.6 rox")))
+        'v211 - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(_, "2.11.11", "2.11.11 pwns")))
         'v2123 - workspaceTest(CrossHelloWorld)(cross(_, "2.12.3", "2.12.3 leet"))
         'v2124 - workspaceTest(CrossHelloWorld)(cross(_, "2.12.4", "2.12.4 leet"))
       }

--- a/scalaworker/src/mill/scalaworker/ScalaWorker.scala
+++ b/scalaworker/src/mill/scalaworker/ScalaWorker.scala
@@ -89,7 +89,7 @@ class ScalaWorker(ctx0: mill.util.Ctx,
         .get
 
       val sourceFolder = mill.modules.Util.unpackZip(sourceJar)(workingDir)
-      val classloader = new URLClassLoader(compilerJars.map(_.toURI.toURL), null)
+      val classloader = mill.util.ClassLoader.create(compilerJars.map(_.toURI.toURL), null)
       val scalacMain = classloader.loadClass("scala.tools.nsc.Main")
       val argsArray = Array[String](
         "-d", compiledDest.toString,
@@ -145,7 +145,7 @@ class ScalaWorker(ctx0: mill.util.Ctx,
     val compilerClassLoader = scalaClassloaderCache match{
       case Some((k, v)) if k == compilerClassloaderSig => v
       case _ =>
-        val classloader = new URLClassLoader(compilerJars.map(_.toURI.toURL), null)
+        val classloader = mill.util.ClassLoader.create(compilerJars.map(_.toURI.toURL), null)
         scalaClassloaderCache = Some((compilerClassloaderSig, classloader))
         classloader
     }
@@ -155,7 +155,7 @@ class ScalaWorker(ctx0: mill.util.Ctx,
       case _ =>
         val scalaInstance = new ScalaInstance(
           version = scalaVersion,
-          loader = new URLClassLoader(pluginJars.map(_.toURI.toURL), compilerClassLoader),
+          loader = mill.util.ClassLoader.create(pluginJars.map(_.toURI.toURL), compilerClassLoader),
           libraryJar = grepJar(compilerClasspath, s"scala-library-$scalaVersion.jar"),
           compilerJar = grepJar(compilerClasspath, s"scala-compiler-$scalaVersion.jar"),
           allJars = compilerJars ++ pluginJars,


### PR DESCRIPTION
While pull request #215 enables mill to run under Java 9 and 10, it turns out more changes are needed to make `{clientserver,main,scalalib,scalajslib}.test` work under Java 9-10.

Basically, creation of `URLClassLoader` has to take into account "exported rt.jar" (see lihaoyi/Ammonite#761); a helper object method is added to facilitate this.

Note that the following tests are disabled under Java 9 or above (require further investigations):

* Tests using Scala 2.10 and 2.11 (cannot find xsbt.CompilerInterface)

* Tests using ScalaJsUtil.runJs (null when retrieving nashorn script engine)

Integrating this pull request builds a mill release that can be used to run `test-mill-0.sh` using oraclejdk9 in travis.