### PR TITLE
Test mill (client/server) non-interactive on Windows and set jna.nosys=true as default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,8 @@ cache:
 install:
   - cmd: SET PATH=%JAVA_HOME%\bin;C:\bin;C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%
   - cmd: java -version
-  - bash -lc "mkdir /c/bin && curl -Lo /c/bin/mill https://github.com/lihaoyi/mill/releases/download/0.1.6/0.1.6"
+  - bash -lc "mkdir /c/bin && curl -Lo /c/bin/mill https://github.com/lihaoyi/mill/releases/download/0.1.6/0.1.6-2-712f33"
 
 build_script:
-  - bash -lc "cd /c/mill && mill -i all main.test scalajslib.test"
+  - bash -lc "cd /c/mill && mill -i all __.publishLocal release"
+  - bash -lc "cd /c/mill && out/release/dest/mill all main.test scalajslib.test"

--- a/clientserver/src/mill/clientserver/Client.java
+++ b/clientserver/src/mill/clientserver/Client.java
@@ -44,6 +44,7 @@ public class Client {
             String k = keys.next();
             if (k.startsWith("MILL_")) l.add("-D" + k + "=" + props.getProperty(k));
         }
+        l.add("-Djna.nosys=true");
         l.add("-cp");
         l.add(String.join(File.pathSeparator, selfJars));
         l.add("mill.ServerMain");
@@ -55,6 +56,7 @@ public class Client {
                 .start();
     }
     public static void main(String[] args) throws Exception{
+        System.setProperty("jna.nosys", "true");
         int index = 0;
         while (index < 5) {
             index += 1;

--- a/clientserver/src/mill/clientserver/Client.java
+++ b/clientserver/src/mill/clientserver/Client.java
@@ -15,8 +15,7 @@ import java.util.Iterator;
 import java.util.Properties;
 
 public class Client {
-
-    static void initServer(String lockBase) throws IOException,URISyntaxException{
+    static void initServer(String lockBase, boolean setJnaNoSys) throws IOException,URISyntaxException{
         ArrayList<String> selfJars = new ArrayList<String>();
         ClassLoader current = Client.class.getClassLoader();
         while(current != null){
@@ -44,7 +43,9 @@ public class Client {
             String k = keys.next();
             if (k.startsWith("MILL_")) l.add("-D" + k + "=" + props.getProperty(k));
         }
-        l.add("-Djna.nosys=true");
+        if (setJnaNoSys) {
+            l.add("-Djna.nosys=true");
+        }
         l.add("-cp");
         l.add(String.join(File.pathSeparator, selfJars));
         l.add("mill.ServerMain");
@@ -56,7 +57,10 @@ public class Client {
                 .start();
     }
     public static void main(String[] args) throws Exception{
-        System.setProperty("jna.nosys", "true");
+        boolean setJnaNoSys = System.getProperty("jna.nosys") == null;
+        if (setJnaNoSys) {
+            System.setProperty("jna.nosys", "true");
+        }
         int index = 0;
         while (index < 5) {
             index += 1;
@@ -75,7 +79,7 @@ public class Client {
                             @Override
                             public void run() {
                                 try{
-                                    initServer(lockBase);
+                                    initServer(lockBase, setJnaNoSys);
                                 }catch(Exception e){
                                     throw new RuntimeException(e);
                                 }


### PR DESCRIPTION
Set `jna.nosys` to `true` if unspecified to avoid JNA incompatibility (see java-native-access/jna#384).

Test mill non-interactive on Windows.