### PR TITLE
Skip signature files in assembly

### DIFF
--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -258,13 +258,18 @@ object Jvm {
     manifest.write(manifestOut)
     manifestOut.close()
 
+    def isSignatureFile(mapping: String): Boolean =
+      Set("sf", "rsa", "dsa").exists(ext => mapping.toLowerCase.endsWith(s".$ext"))
+
     for(v <- classpathIterator(inputPaths)){
       val (file, mapping) = v
       val p = zipFs.getPath(mapping)
       if (p.getParent != null) Files.createDirectories(p.getParent)
-      val outputStream = newOutputStream(p)
-      IO.stream(file, outputStream)
-      outputStream.close()
+      if (!isSignatureFile(mapping)) {
+        val outputStream = newOutputStream(p)
+        IO.stream(file, outputStream)
+        outputStream.close()
+      }
       file.close()
     }
     zipFs.close()


### PR DESCRIPTION
This PR fixes #231

If the fat jar produced by `assembly` contains signature files (see: https://docs.oracle.com/javase/tutorial/deployment/jar/signing.html), running it will throw a `SecurityException`.

The solution (copied by [what sbt-assembly does](https://github.com/sbt/sbt-assembly/blob/2ff7635afc27a7d2255167dedf1d56a58fb8d651/src/main/scala/sbtassembly/MergeStrategy.scala#L137)) is to explicitly skip those files (which end in `.sf`, `.rsa` and `.dsa`).

I've tested this locally (with `mill dev`) on a project which has a signed jar (bouncycastle) and now the exception is not thrown anymore 🎉 