### PR TITLE
Propagate more properties into Tests module

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -19,6 +19,9 @@ trait ScalaModule extends mill.Module with TaskModule { outer =>
   def defaultCommandName() = "run"
   trait Tests extends TestModule{
     def scalaVersion = outer.scalaVersion()
+    override def repositories = outer.repositories
+    override def scalacPluginIvyDeps = outer.scalacPluginIvyDeps
+    override def scalacOptions = outer.scalacOptions
     override def scalaWorker = outer.scalaWorker
     override def moduleDeps = Seq(outer)
   }


### PR DESCRIPTION
This PR adds propagation of these settings from the outer `ScalaModule` to the `Tests` module:

- repositories
- scalacPluginIvyDeps
- scalacOptions
- javacOptions

For these values, I think it's reasonable that they are the same as the parent module by default. If the tests have specific needs, they can be easily overridden.