### PR TITLE
Java 9 optimization by caching rt.jar

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -69,7 +69,7 @@ trait MillModule extends MillPublishModule{ outer =>
 
 object clientserver extends MillModule{
   def ivyDeps = Agg(
-    ivy"com.lihaoyi:::ammonite:1.0.5-4-c0cdbaf",
+    ivy"com.lihaoyi:::ammonite:1.0.5-7-f032887",
     ivy"org.scala-sbt.ipcsocket:ipcsocket:1.0.0"
   )
   val test = new Tests(implicitly)
@@ -84,7 +84,7 @@ object core extends MillModule {
 
   def ivyDeps = Agg(
     ivy"com.lihaoyi::sourcecode:0.1.4",
-    ivy"com.lihaoyi:::ammonite:1.0.5-4-c0cdbaf",
+    ivy"com.lihaoyi:::ammonite:1.0.5-7-f032887",
     ivy"jline:jline:2.14.5"
   )
 

--- a/core/src/mill/util/ClassLoader.scala
+++ b/core/src/mill/util/ClassLoader.scala
@@ -2,9 +2,17 @@ package mill.util
 
 import java.net.{URL, URLClassLoader}
 
+import ammonite.ops.Path
 import io.github.retronym.java9rtexport.Export
 
 object ClassLoader {
+  private val home = new ThreadLocal[Path]
+
+  def withHome[T](home: Path)(f: => T): T = {
+    ClassLoader.home.set(home)
+    try f finally ClassLoader.home.remove()
+  }
+
   def create(urls: Seq[URL], parent: java.lang.ClassLoader): URLClassLoader = {
     val cl = new URLClassLoader(urls.toArray, parent)
     if (!ammonite.util.Util.java9OrAbove) return cl
@@ -13,7 +21,17 @@ object ClassLoader {
       cl
     } catch {
       case _: ClassNotFoundException =>
-        new URLClassLoader((urls ++ Some(Export.export().toURI.toURL)).toArray, parent)
+        val rtFile = {
+          val path = home.get
+          if (path == null) Export.export() else {
+            val f = new java.io.File(path.toIO, s"rt-${System.getProperty("java.version")}.jar")
+            if (!f.exists) {
+              java.nio.file.Files.copy(Export.export().toPath, f.toPath)
+            }
+            f
+          }
+        }
+        new URLClassLoader((urls ++ Some(rtFile.toURI.toURL)).toArray, parent)
     }
   }
 }

--- a/main/src/mill/Main.scala
+++ b/main/src/mill/Main.scala
@@ -112,11 +112,13 @@ object Main {
             stateCache
           )
 
-          if (repl){
-            runner.printInfo("Loading...")
-            (runner.watchLoop(isRepl = true, printing = false, _.run()), runner.stateCache)
-          } else {
-            (runner.runScript(pwd / "build.sc", leftoverArgs), runner.stateCache)
+          mill.util.ClassLoader.withHome(millHome) {
+            if (repl) {
+              runner.printInfo("Loading...")
+              (runner.watchLoop(isRepl = true, printing = false, _.run()), runner.stateCache)
+            } else {
+              (runner.runScript(pwd / "build.sc", leftoverArgs), runner.stateCache)
+            }
           }
       }
 

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -316,7 +316,7 @@ trait ScalaModule extends mill.Module with TaskModule { outer =>
   }
 
   def ammoniteReplClasspath = T{
-    resolveDeps(T.task{Agg(ivy"com.lihaoyi:::ammonite:1.0.5-4-c0cdbaf")})()
+    resolveDeps(T.task{Agg(ivy"com.lihaoyi:::ammonite:1.0.5-7-f032887")})()
   }
   def repl() = T.command{
     if (T.ctx().log.inStream == DummyInputStream){


### PR DESCRIPTION
This PR adds Java 9 optimization by caching rt.jar.

On interactive mode, `mill.util.ClassLoader` is adjusted to have thread-local home path context enclosing the execution of `MainRunner` (if home context is not set, then `mill.util.ClassLoader.create` falls back to previous behavior). This approach was chosen in order to avoid making pervasive changes to many callers of `mill.util.ClassLoader.create` which would mean propagation of mill's home path originating from `Main.main0` such as to `Jvm`, `ScalaModule`, etc.

On client/server mode, this is provided by upgrading to Ammonite 1.0.5-7-f032887 which includes lihaoyi/Ammonite#773 (and changes made previously in #221).
