### PR TITLE
Add closing backtick to `java.lang.Process` in doc

### DIFF
--- a/docs/pages/6 - Extending Mill.md
+++ b/docs/pages/6 - Extending Mill.md
@@ -20,7 +20,7 @@ you're done.
 
 For subprocess/filesystem operations, you can use the
 [Ammonite-Ops](http://ammonite.io/#Ammonite-Ops) library that comes bundled with
-Mill, or even plain `java.nio`/`java.lang.Process. Each target gets it's own
+Mill, or even plain `java.nio`/`java.lang.Process`. Each target gets it's own
 [T.ctx().dest](http://www.lihaoyi.com/mill/page/tasks#millutilctxdestctx) folder
 that you can use to place files without worrying about colliding with other
 targets.


### PR DESCRIPTION
It deserves it.