### PR TITLE
Batch (.bat) file generation for assembly, launcher, and release

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -261,8 +261,9 @@ object dev extends MillModule{
   }
 
   def assembly = T{
-    mv(super.assembly().path, T.ctx().dest / 'mill)
-    PathRef(T.ctx().dest / 'mill)
+    val filename = if (scala.util.Properties.isWin) "mill.bat" else "mill"
+    mv(super.assembly().path, T.ctx().dest / filename)
+    PathRef(T.ctx().dest / filename)
   }
 
   def prependShellScript = launcherScript(scala.util.Properties.isWin, forkArgs(), runClasspath().map(_.path.toString))
@@ -312,7 +313,15 @@ def release = T{
     T.ctx().dest,
     dev.runClasspath().map(_.path),
     publishVersion()._2,
-    scala.util.Properties.isWin)
+    false)
+}
+
+def releaseBatch = T{
+  releaseHelper(
+    T.ctx().dest,
+    dev.runClasspath().map(_.path),
+    publishVersion()._2,
+    true)
 }
 
 def releaseAll = T{

--- a/build.sc
+++ b/build.sc
@@ -219,7 +219,12 @@ def launcherScript(isWin: Boolean,
        |if "%1" == "-i" set _I_=true
        |if "%1" == "--interactive" set _I_=true
        |if defined _I_ (
-       |  java $jvmArgsStr %JAVA_OPTS% -cp "$classPathStr" mill.Main %*
+       |  if "%2" == "" (
+       |    echo mill repl is currently only available on a sh environment
+       |    exit /B 1
+       |  ) else (
+       |    java $jvmArgsStr %JAVA_OPTS% -cp "$classPathStr" mill.Main %*
+       |  )
        |) else (
        |  java $jvmArgsStr %JAVA_OPTS% -cp "$classPathStr" mill.clientserver.Client %*
        |)

--- a/main/src/mill/Main.scala
+++ b/main/src/mill/Main.scala
@@ -27,8 +27,12 @@ object ServerMain extends mill.clientserver.ServerMain[Evaluator.State]{
 object Main {
 
   def main(args: Array[String]): Unit = {
+    val as = args match {
+      case Array(s, _*) if s == "-i" || s == "--interactive" => args.tail
+      case _ => args
+    }
     val (result, _) = main0(
-      args,
+      as,
       None,
       ammonite.Main.isInteractive(),
       System.in,

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -331,7 +331,7 @@ object Jvm {
       s"""@echo off
          |
          |java ${jvmArgs.mkString(" ")} %JAVA_OPTS% -cp "$cp" $mainClass %*
-       """.stripMargin
+       """.stripMargin.split('\n').mkString("\r\n")
     else
       s"""#!/usr/bin/env sh
          |

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -126,9 +126,11 @@ trait ScalaModule extends mill.Module with TaskModule { outer =>
     mainClass() match{
       case None => ""
       case Some(cls) =>
+        val isWin = scala.util.Properties.isWin
         mill.modules.Jvm.launcherShellScript(
+          isWin,
           cls,
-          Agg("$0"),
+          Agg(if (isWin) "%~dp0%~nx0" else "$0"),
           forkArgs()
         )
     }


### PR DESCRIPTION
This PR adds batch file generation for Windows, thus, enabling Window users to run mill without a sh environment (no repl support at the moment; see below). The resulting assembly and release .bat files are similar to the sh version where their corresponding jar file is embedded in it.

Notes:

* Shifting of command line argument for interactive mode is moved to Main.main because it's difficult to do in batch for arguments with special characters 

* Support for ANSI color is disabled by default in Windows 10 Console; it requires a native API call to enable it. It's best to use terminal replacement such as [ConEmu](https://conemu.github.io).

* mill repl does not work because Ammonite repl assumes [sh/Unix environment](https://github.com/lihaoyi/Ammonite/blob/ac754ee65a2760bf6c442ab9d5a30777757ed063/terminal/src/main/scala/ammonite/terminal/Utils.scala#L94). I think there is still value to offer non-repl .bat version as mill CLI tools are quite nice to use and the client/server mode now provides quick turnaround to probe mill build.