### PR TITLE
Support scala milestone releases (with fixes for 2.13.0-M3)

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -7,7 +7,7 @@ import coursier.maven.MavenRepository
 import mill.eval.{PathRef, Result}
 import mill.eval.Result.Success
 import mill.scalalib.Lib.resolveDependencies
-import mill.scalalib.{CompilationResult, Dep, DepSyntax, TestModule}
+import mill.scalalib.{DepSyntax, Lib, TestModule}
 import mill.util.{Ctx, Loose}
 
 trait ScalaJSModule extends scalalib.ScalaModule { outer =>
@@ -21,16 +21,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     override def moduleDeps = Seq(outer)
   }
 
-  private val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
-  private val MinorSnapshotVersion = raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
-
-  def scalaJSBinaryVersion = T{
-    scalaJSVersion() match {
-      case ReleaseVersion(major, minor, _) => s"$major.$minor"
-      case MinorSnapshotVersion(major, minor, _) => s"$major.$minor"
-      case _ => scalaJSVersion()
-    }
-  }
+  def scalaJSBinaryVersion = T { Lib.scalaBinaryVersion(scalaJSVersion()) }
 
   def scalaJSBridgeVersion = T{ scalaJSVersion().split('.').dropRight(1).mkString(".") }
 

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -16,7 +16,16 @@ case class CompilationResult(analysisFile: Path, classes: PathRef)
 
 object Lib{
 
-  def scalaBinaryVersion(scalaVersion: String) = scalaVersion.split('.').dropRight(1).mkString(".")
+  private val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
+  private val MinorSnapshotVersion = raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
+
+  def scalaBinaryVersion(scalaVersion: String) = {
+    scalaVersion match {
+      case ReleaseVersion(major, minor, _) => s"$major.$minor"
+      case MinorSnapshotVersion(major, minor, _) => s"$major.$minor"
+      case _ => scalaVersion
+    }
+  }
 
   def grepJar(classPath: Agg[Path], s: String) = {
     classPath

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -98,12 +98,13 @@ trait ScalaModule extends mill.Module with TaskModule { outer =>
 
   def platformSuffix = T{ "" }
 
+  private val Milestone213 = raw"""2.13.(\d+)-M(\d+)""".r
+
   def scalaCompilerBridgeSources = T {
-    val (scalaVersion0, scalaBinaryVersion0) =
-      if (scalaVersion().startsWith("2.13."))
-        ("2.13.0-M2", "2.13.0-M2")
-      else
-        (scalaVersion(), Lib.scalaBinaryVersion(scalaVersion()))
+    val (scalaVersion0, scalaBinaryVersion0) = scalaVersion() match {
+      case Milestone213(_, _) => ("2.13.0-M2", "2.13.0-M2")
+      case _ => (scalaVersion(), Lib.scalaBinaryVersion(scalaVersion()))
+    }
 
     resolveDependencies(
       repositories,

--- a/scalalib/src/mill/scalalib/ScalaWorkerApi.scala
+++ b/scalalib/src/mill/scalalib/ScalaWorkerApi.scala
@@ -54,7 +54,7 @@ trait ScalaWorkerModule extends mill.Module{
 trait ScalaWorkerApi {
   def compileScala(scalaVersion: String,
                    sources: Agg[Path],
-                   compileBridgeSources: Agg[Path],
+                   compilerBridgeSources: Path,
                    compileClasspath: Agg[Path],
                    compilerClasspath: Agg[Path],
                    scalacOptions: Seq[String],

--- a/scalalib/test/resources/hello-world/core/src-2.13/Shim.scala
+++ b/scalalib/test/resources/hello-world/core/src-2.13/Shim.scala
@@ -1,0 +1,5 @@
+object Shim{
+  def main(args: Array[String]): Unit = {
+    Main0(args(0), scala.util.Properties.versionNumberString + " idk")
+  }
+}

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -30,7 +30,7 @@ object HelloWorldTests extends TestSuite {
     object core extends HelloWorldModule
   }
   object CrossHelloWorld extends HelloBase {
-    object core extends Cross[HelloWorldCross]("2.10.6", "2.11.11", "2.12.3", "2.12.4")
+    object core extends Cross[HelloWorldCross]("2.10.6", "2.11.11", "2.12.3", "2.12.4", "2.13.0-M3")
     class HelloWorldCross(val crossScalaVersion: String) extends CrossScalaModule
   }
 
@@ -250,6 +250,7 @@ object HelloWorldTests extends TestSuite {
         'v211 - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(_, "2.11.11", "2.11.11 pwns")))
         'v2123 - workspaceTest(CrossHelloWorld)(cross(_, "2.12.3", "2.12.3 leet"))
         'v2124 - workspaceTest(CrossHelloWorld)(cross(_, "2.12.4", "2.12.4 leet"))
+        'v2130M3 - workspaceTest(CrossHelloWorld)(cross(_, "2.13.0-M3", "2.13.0-M3 idk"))
       }
 
 

--- a/scalaworker/src/mill/scalaworker/ScalaWorker.scala
+++ b/scalaworker/src/mill/scalaworker/ScalaWorker.scala
@@ -77,7 +77,7 @@ class ScalaWorker(ctx0: mill.util.Ctx,
   @volatile var scalaInstanceCache = Option.empty[(Long, ScalaInstance)]
 
   def compileZincBridge(scalaVersion: String,
-                        compileBridgeSources: Agg[Path],
+                        sourcesJar: Path,
                         compilerJars: Array[File]) = {
     val workingDir = ctx0.dest / scalaVersion
     val compiledDest = workingDir / 'compiled
@@ -88,11 +88,7 @@ class ScalaWorker(ctx0: mill.util.Ctx,
       mkdir(workingDir)
       mkdir(compiledDest)
 
-      val sourceJar = compileBridgeSources
-        .find(_.last == s"compiler-bridge_${Lib.scalaBinaryVersion(scalaVersion)}-1.1.0-sources.jar")
-        .get
-
-      val sourceFolder = mill.modules.Util.unpackZip(sourceJar)(workingDir)
+      val sourceFolder = mill.modules.Util.unpackZip(sourcesJar)(workingDir)
       val classloader = mill.util.ClassLoader.create(compilerJars.map(_.toURI.toURL), null)(ctx0)
       val scalacMain = classloader.loadClass("scala.tools.nsc.Main")
       val argsArray = Array[String](
@@ -127,7 +123,7 @@ class ScalaWorker(ctx0: mill.util.Ctx,
 
   def compileScala(scalaVersion: String,
                    sources: Agg[Path],
-                   compileBridgeSources: Agg[Path],
+                   compilerBridgeSources: Path,
                    compileClasspath: Agg[Path],
                    compilerClasspath: Agg[Path],
                    scalacOptions: Seq[String],
@@ -138,7 +134,7 @@ class ScalaWorker(ctx0: mill.util.Ctx,
     val compileClasspathFiles = compileClasspath.map(_.toIO).toArray
     val compilerJars = compilerClasspath.toArray.map(_.toIO)
 
-    val compilerBridge = compileZincBridge(scalaVersion, compileBridgeSources, compilerJars)
+    val compilerBridge = compileZincBridge(scalaVersion, compilerBridgeSources, compilerJars)
 
     val pluginJars = scalacPluginClasspath.toArray.map(_.toIO)
 


### PR DESCRIPTION
This PR lets us use scala milestone releases, like `2.13.0-M3` in mill. Didn't work before 