### PR TITLE
try to fix classloading issues on runLocal and test with java 9

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -25,6 +25,9 @@ trait MillPublishModule extends PublishModule{
       Developer("lihaoyi", "Li Haoyi","https://github.com/lihaoyi")
     )
   )
+
+  def javacOptions = Seq("-source", "1.8", "-target", "1.8")
+
 }
 object moduledefs extends MillPublishModule{
   def ivyDeps = Agg(

--- a/core/src/mill/util/ClassLoader.scala
+++ b/core/src/mill/util/ClassLoader.scala
@@ -5,22 +5,33 @@ import java.net.{URL, URLClassLoader}
 import io.github.retronym.java9rtexport.Export
 
 object ClassLoader {
-  def create(urls: Seq[URL],
-             parent: java.lang.ClassLoader)
-            (implicit ctx: Ctx.Home): URLClassLoader = {
-    val cl = new URLClassLoader(urls.toArray, parent)
-    if (!ammonite.util.Util.java9OrAbove) return cl
-    try {
-      cl.loadClass("javax.script.ScriptEngineManager")
-      cl
-    } catch {
-      case _: ClassNotFoundException =>
-        val path = ctx.home
-        val rtFile = new java.io.File(path.toIO, s"rt-${System.getProperty("java.version")}.jar")
-        if (!rtFile.exists) {
-          java.nio.file.Files.copy(Export.export().toPath, rtFile.toPath)
-        }
-        new URLClassLoader((urls ++ Some(rtFile.toURI.toURL)).toArray, parent)
+  def create(urls: Seq[URL], parent: java.lang.ClassLoader)(
+      implicit ctx: Ctx.Home): URLClassLoader = {
+    if (ammonite.util.Util.java9OrAbove) {
+      val platformParent =
+        if (parent == null)
+          classOf[ClassLoader]
+            .getMethod("getPlatformClassLoader")
+            .invoke(null)
+            .asInstanceOf[ClassLoader]
+        else parent
+      val cl = new URLClassLoader(urls.toArray, platformParent)
+      try {
+        cl.loadClass("javax.script.ScriptEngineManager")
+        cl
+      } catch {
+        case _: ClassNotFoundException =>
+          val path = ctx.home
+          val rtFile = new java.io.File(
+            path.toIO,
+            s"rt-${System.getProperty("java.version")}.jar")
+          if (!rtFile.exists) {
+            java.nio.file.Files.copy(Export.export().toPath, rtFile.toPath)
+          }
+          new URLClassLoader((urls ++ Some(rtFile.toURI.toURL)).toArray, parent)
+      }
+    } else {
+      new URLClassLoader(urls.toArray, parent)
     }
   }
 }

--- a/core/src/mill/util/ClassLoader.scala
+++ b/core/src/mill/util/ClassLoader.scala
@@ -6,24 +6,51 @@ import ammonite.ops._
 import io.github.retronym.java9rtexport.Export
 
 object ClassLoader {
+
   def create(urls: Seq[URL], parent: java.lang.ClassLoader)(
       implicit ctx: Ctx.Home): URLClassLoader = {
-    if (ammonite.util.Util.java9OrAbove) {
-      val platformParent =
-        if (parent == null)
-          classOf[ClassLoader]
-            .getMethod("getPlatformClassLoader")
-            .invoke(null)
-            .asInstanceOf[ClassLoader]
-        else parent
+    new URLClassLoader(
+      makeUrls(urls).toArray,
+      refinePlatformParent(parent)
+    )
+  }
 
+  def create(urls: Seq[URL],
+             parent: java.lang.ClassLoader,
+             customFindClass: String => Option[Class[_]])(
+      implicit ctx: Ctx.Home): URLClassLoader = {
+    new URLClassLoader(
+      makeUrls(urls).toArray,
+      refinePlatformParent(parent)
+    ) {
+      override def findClass(name: String): Class[_] = {
+        customFindClass(name).getOrElse(super.findClass(name))
+      }
+    }
+  }
+
+  private def refinePlatformParent(parent: java.lang.ClassLoader): ClassLoader = {
+    if (ammonite.util.Util.java9OrAbove) {
+      if (parent == null)
+        classOf[ClassLoader]
+          .getMethod("getPlatformClassLoader")
+          .invoke(null)
+          .asInstanceOf[ClassLoader]
+      else parent
+    } else {
+      parent
+    }
+  }
+
+  private def makeUrls(urls: Seq[URL])(implicit ctx: Ctx.Home): Seq[URL] = {
+    if (ammonite.util.Util.java9OrAbove) {
       val rtFile = ctx.home / s"rt-${System.getProperty("java.version")}.jar"
       if (!exists(rtFile)) {
         cp(Path(Export.export()), rtFile)
       }
-      new URLClassLoader((urls :+ rtFile.toNIO.toUri.toURL).toArray,platformParent)
+      urls :+ rtFile.toNIO.toUri.toURL
     } else {
-      new URLClassLoader(urls.toArray, parent)
+      urls
     }
   }
 }

--- a/core/src/mill/util/ClassLoader.scala
+++ b/core/src/mill/util/ClassLoader.scala
@@ -29,6 +29,14 @@ object ClassLoader {
     }
   }
 
+  /**
+    *  Return `ClassLoader.getPlatformClassLoader` for java 9 and above, if parent class loader is null,
+    *  otherwise return same parent class loader.
+    *  More details: https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-A868D0B9-026F-4D46-B979-901834343F9E
+    *
+    *  `ClassLoader.getPlatformClassLoader` call is implemented via runtime reflection, cause otherwise
+    *  mill could be compiled only with jdk 9 or above. We don't want to introduce this restriction now.
+    */
   private def refinePlatformParent(parent: java.lang.ClassLoader): ClassLoader = {
     if (ammonite.util.Util.java9OrAbove) {
       if (parent == null)

--- a/scalalib/test/resources/hello-world/core/src/Main.scala
+++ b/scalalib/test/resources/hello-world/core/src/Main.scala
@@ -1,5 +1,8 @@
 import scala.collection._
 import java.nio.file.{Files, Paths}
+import java.sql.Date
+import java.time.LocalDate
+import javax.swing.JButton
 
 import Main.{args, greeting}
 object Main0{
@@ -10,7 +13,9 @@ object Main0{
   }
 }
 object Main extends App {
-
+  new JButton("hello from javax")
+  val now = Date.valueOf(LocalDate.now())
+  println(s"Today is the date: ${now}")
   val person = Person.fromString("rockjam:25")
   val greeting = s"hello ${person.name}, your age is: ${person.age}"
   println(greeting)

--- a/scalalib/test/resources/hello-world/core/src/Main.scala
+++ b/scalalib/test/resources/hello-world/core/src/Main.scala
@@ -13,6 +13,8 @@ object Main0{
   }
 }
 object Main extends App {
+  // testing correct loading of java standard modules in java 9
+  // https://github.com/lihaoyi/mill/issues/251
   new JButton("hello from javax")
   val now = Date.valueOf(LocalDate.now())
   println(s"Today is the date: ${now}")


### PR DESCRIPTION
This PR changes the behavior of mill.util.Classloader for jdk 9 and above. We use `ClassLoader.getPlatformClassLoader` as parent classloader if parent class loader is null (https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-A868D0B9-026F-4D46-B979-901834343F9E). Also we always add rt.jar in class loader.

fixes #251 