### PR TITLE
fixes #173; use default(compile) configuration for deps as default

### DIFF
--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -20,6 +20,8 @@ sealed trait Dep {
 }
 object Dep{
 
+  val DefaultConfiguration = "default(compile)"
+
   implicit def parse(signature: String) = {
     val parts = signature.split(';')
     val module = parts.head
@@ -41,7 +43,7 @@ object Dep{
     }).configure(attributes = attributes)
   }
   def apply(org: String, name: String, version: String, cross: Boolean): Dep = {
-    this(coursier.Dependency(coursier.Module(org, name), version), cross)
+    this(coursier.Dependency(coursier.Module(org, name), version, DefaultConfiguration), cross)
   }
   case class Java(dep: coursier.Dependency, cross: Boolean) extends Dep {
     def configure(attributes: coursier.Attributes): Dep = copy(dep = dep.copy(attributes = attributes))
@@ -49,7 +51,7 @@ object Dep{
   object Java{
     implicit def rw: RW[Java] = macroRW
     def apply(org: String, name: String, version: String, cross: Boolean): Dep = {
-      Java(coursier.Dependency(coursier.Module(org, name), version), cross)
+      Java(coursier.Dependency(coursier.Module(org, name), version, DefaultConfiguration), cross)
     }
   }
   implicit def default(dep: coursier.Dependency): Dep = new Java(dep, false)
@@ -60,7 +62,7 @@ object Dep{
   object Scala{
     implicit def rw: RW[Scala] = macroRW
     def apply(org: String, name: String, version: String, cross: Boolean): Dep = {
-      Scala(coursier.Dependency(coursier.Module(org, name), version), cross)
+      Scala(coursier.Dependency(coursier.Module(org, name), version, DefaultConfiguration), cross)
     }
   }
   case class Point(dep: coursier.Dependency, cross: Boolean) extends Dep {
@@ -69,7 +71,7 @@ object Dep{
   object Point{
     implicit def rw: RW[Point] = macroRW
     def apply(org: String, name: String, version: String, cross: Boolean): Dep = {
-      Point(coursier.Dependency(coursier.Module(org, name), version), cross)
+      Point(coursier.Dependency(coursier.Module(org, name), version, DefaultConfiguration), cross)
     }
   }
   implicit def rw = RW.merge[Dep](

--- a/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
@@ -26,6 +26,14 @@ object ResolveDepsTests extends TestSuite {
       assert(paths.items.next.path.toString.contains("natives-macos"))
     }
 
+    'resolveTransitiveRuntimeDeps - {
+      val deps = Agg(ivy"org.mockito:mockito-core:2.7.22")
+      val Success(paths) = evalDeps(deps)
+      assert(paths.nonEmpty)
+      assert(paths.exists(_.path.toString.contains("objenesis")))
+      assert(paths.exists(_.path.toString.contains("byte-buddy")))
+    }
+
     'excludeTransitiveDeps - {
       val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3".exclude("com.lihaoyi" -> "fansi_2.12"))
       val Success(paths) = evalDeps(deps)


### PR DESCRIPTION
This PR fixes https://github.com/lihaoyi/mill/issues/173 by setting default dependency configuration to `default(compile)`. That's what coursier does in it's CLI: https://github.com/coursier/coursier/blob/master/cli/src/main/scala-2.12/coursier/cli/options/CommonOptions.scala#L69 and also advised by coursier's author here: https://github.com/coursier/coursier/issues/552#issuecomment-310133532