### PR TITLE
Add a TwirlModule to compile Twirl templates

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -70,6 +70,7 @@ object testng extends MillPublishModule{
     ivy"org.scala-sbt:test-interface:1.0",
     ivy"org.testng:testng:6.11"
   )
+  val test = new Tests(implicitly)
 }
 
 object core extends MillModule {
@@ -111,6 +112,7 @@ object main extends MillModule {
       Seq(PathRef(shared.generateCoreTestSources(T.ctx().dest)))
     }
   }
+}
 
   object client extends MillPublishModule{
     def ivyDeps = Agg(
@@ -194,6 +196,12 @@ object scalajslib extends MillModule {
         )
     }
   }
+}
+
+object twirllib extends MillModule {
+
+  def moduleDeps = Seq(scalalib)
+
 }
 
 def testRepos = T{

--- a/build.sc
+++ b/build.sc
@@ -70,7 +70,6 @@ object testng extends MillPublishModule{
     ivy"org.scala-sbt:test-interface:1.0",
     ivy"org.testng:testng:6.11"
   )
-  val test = new Tests(implicitly)
 }
 
 object core extends MillModule {
@@ -112,7 +111,6 @@ object main extends MillModule {
       Seq(PathRef(shared.generateCoreTestSources(T.ctx().dest)))
     }
   }
-}
 
   object client extends MillPublishModule{
     def ivyDeps = Agg(

--- a/ci/test-mill-0.sh
+++ b/ci/test-mill-0.sh
@@ -6,4 +6,4 @@ set -eux
 git clean -xdf
 
 # Run tests
-mill -i all {main,scalalib,scalajslib,main.client}.test
+mill -i all {main,scalalib,scalajslib,twirllib,main.client}.test

--- a/ci/test-mill-dev.sh
+++ b/ci/test-mill-dev.sh
@@ -11,5 +11,5 @@ mill -i dev.assembly
 rm -rf ~/.mill
 
 # Second build & run tests
-out/dev/assembly/dest/mill -i all {main,scalalib,scalajslib}.test
+out/dev/assembly/dest/mill -i all {main,scalalib,scalajslib,twirllib}.test
 

--- a/main/test/src/mill/define/CacherTests.scala
+++ b/main/test/src/mill/define/CacherTests.scala
@@ -17,7 +17,7 @@ object CacherTests extends TestSuite{
   }
   object Middle extends Middle
   trait Middle extends Base{
-    def value = T{ super.value() + 2}
+    override def value = T{ super.value() + 2}
     def overriden = T{ super.value()}
   }
   object Terminal extends  Terminal

--- a/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -22,7 +22,7 @@ trait TwirlModule extends mill.Module {
         Cache.ivy2Local,
         MavenRepository("https://repo1.maven.org/maven2")
       ),
-      "2.12.4",
+      Lib.depToDependency(_, "2.12.4"),
       Seq(ivy"com.typesafe.play::twirl-compiler:${twirlVersion()}")
     )
   }

--- a/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -1,55 +1,40 @@
 package mill
 package twirllib
 
-import java.io.File
-import ammonite.ops.{Path, ls, mkdir, rm}
-import mill.util.{Ctx, Loose}
+import coursier.{Cache, MavenRepository}
+import mill.define.Sources
+import mill.eval.PathRef
 import mill.scalalib.Lib.resolveDependencies
 import mill.scalalib._
-import mill.eval.PathRef
-import coursier.{Cache, MavenRepository, Repository}
-
+import mill.util.Loose
 
 trait TwirlModule extends mill.Module {
 
   def twirlVersion: T[String]
-  
-  def repositories: Seq[Repository] = Seq(
-    Cache.ivy2Local,
-    MavenRepository("https://repo1.maven.org/maven2")
-  )  
-  def sources = T.input{ Agg(PathRef(basePath / 'src / 'main / 'twirl)) }
-  
-  def twirlClasspath : T[Loose.Agg[PathRef]] = T{
+
+  def twirlSources: Sources = T.sources {
+    millSourcePath / 'views
+  }
+
+  def twirlClasspath: T[Loose.Agg[PathRef]] = T {
     resolveDependencies(
-      repositories,
+      Seq(
+        Cache.ivy2Local,
+        MavenRepository("https://repo1.maven.org/maven2")
+      ),
       "2.12.4",
-      "2.12",    
       Seq(ivy"com.typesafe.play::twirl-compiler:${twirlVersion()}")
-      )
-  }
-  
-  def compile(worker: TwirlWorker,
-              twirlClasspath: Agg[PathRef],
-              input: Agg[Path])
-              (implicit ctx: Ctx.DestCtx) : T[PathRef] = T.persistent{
-    worker.compile(
-      twirlClasspath.map(_.path),
-      input.toSeq,
-      ctx.dest)
-    PathRef(ctx.dest)
-  }
-  
-  def fullGen = T {
-    compile(
-        TwirlWorkerApi.twirlWorker(),
-        twirlClasspath(),
-        sources().map(_.path)
     )
   }
 
+  def compileTwirl: T[CompilationResult] = T.persistent {
+    TwirlWorkerApi.twirlWorker
+      .compile(
+        twirlClasspath().map(_.path),
+        twirlSources().map(_.path),
+        T.ctx().dest)
+  }
 }
 
 trait TestTwirlModule extends TwirlModule with TestModule {
-
 }

--- a/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -23,7 +23,10 @@ trait TwirlModule extends mill.Module {
         MavenRepository("https://repo1.maven.org/maven2")
       ),
       Lib.depToDependency(_, "2.12.4"),
-      Seq(ivy"com.typesafe.play::twirl-compiler:${twirlVersion()}")
+      Seq(
+        ivy"com.typesafe.play::twirl-compiler:${twirlVersion()}",
+        ivy"org.scala-lang.modules::scala-parser-combinators:1.0.5"
+      )
     )
   }
 

--- a/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -1,0 +1,55 @@
+package mill
+package twirllib
+
+import java.io.File
+import ammonite.ops.{Path, ls, mkdir, rm}
+import mill.util.{Ctx, Loose}
+import mill.scalalib.Lib.resolveDependencies
+import mill.scalalib._
+import mill.eval.PathRef
+import coursier.{Cache, MavenRepository, Repository}
+
+
+trait TwirlModule extends mill.Module {
+
+  def twirlVersion: T[String]
+  
+  def repositories: Seq[Repository] = Seq(
+    Cache.ivy2Local,
+    MavenRepository("https://repo1.maven.org/maven2")
+  )  
+  def sources = T.input{ Agg(PathRef(basePath / 'src / 'main / 'twirl)) }
+  
+  def twirlClasspath : T[Loose.Agg[PathRef]] = T{
+    resolveDependencies(
+      repositories,
+      "2.12.4",
+      "2.12",    
+      Seq(ivy"com.typesafe.play::twirl-compiler:${twirlVersion()}")
+      )
+  }
+  
+  def compile(worker: TwirlWorker,
+              twirlClasspath: Agg[PathRef],
+              input: Agg[Path])
+              (implicit ctx: Ctx.DestCtx) : T[PathRef] = T.persistent{
+    worker.compile(
+      twirlClasspath.map(_.path),
+      input.toSeq,
+      ctx.dest)
+    PathRef(ctx.dest)
+  }
+  
+  def fullGen = T {
+    compile(
+        TwirlWorkerApi.twirlWorker(),
+        twirlClasspath(),
+        sources().map(_.path)
+    )
+  }
+
+}
+
+trait TestTwirlModule extends TwirlModule with TestModule {
+
+}

--- a/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -8,6 +8,9 @@ import mill.scalalib.Lib.resolveDependencies
 import mill.scalalib._
 import mill.util.Loose
 
+import scala.io.Codec
+import scala.util.Properties
+
 trait TwirlModule extends mill.Module {
 
   def twirlVersion: T[String]
@@ -25,16 +28,29 @@ trait TwirlModule extends mill.Module {
       Lib.depToDependency(_, "2.12.4"),
       Seq(
         ivy"com.typesafe.play::twirl-compiler:${twirlVersion()}",
-        ivy"org.scala-lang.modules::scala-parser-combinators:1.0.5"
+        ivy"org.scala-lang.modules::scala-parser-combinators:1.1.0"
       )
     )
   }
+
+  // REMIND currently it's not possible to override these default settings
+  private def twirlAdditionalImports: Seq[String] = Nil
+
+  private def twirlConstructorAnnotations: Seq[String] = Nil
+
+  private def twirlCodec: Codec = Codec(Properties.sourceEncoding)
+
+  private def twirlInclusiveDot: Boolean = false
 
   def compileTwirl: T[CompilationResult] = T.persistent {
     TwirlWorkerApi.twirlWorker
       .compile(
         twirlClasspath().map(_.path),
         twirlSources().map(_.path),
-        T.ctx().dest)
+        T.ctx().dest,
+        twirlAdditionalImports,
+        twirlConstructorAnnotations,
+        twirlCodec,
+        twirlInclusiveDot)
   }
 }

--- a/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -35,6 +35,3 @@ trait TwirlModule extends mill.Module {
         T.ctx().dest)
   }
 }
-
-trait TestTwirlModule extends TwirlModule with TestModule {
-}

--- a/twirllib/src/mill/twirllib/TwirlWorker.scala
+++ b/twirllib/src/mill/twirllib/TwirlWorker.scala
@@ -3,66 +3,104 @@ package twirllib
 
 import java.io.File
 import java.net.URLClassLoader
-import ammonite.ops.{Path,ls}
 
+import ammonite.ops.{Path, ls}
+import mill.eval.PathRef
+import mill.scalalib.CompilationResult
 
-class TwirlWorker  {
+import scala.io.Codec
+import scala.reflect.runtime.universe._
+
+class TwirlWorker {
 
   private var twirlInstanceCache = Option.empty[(Long, TwirlWorkerApi)]
 
   private def twirl(twirlClasspath: Agg[Path]) = {
-    val classloaderSig =
-      twirlClasspath.map(p => p.toString().hashCode + p.mtime.toMillis).sum
+    val classloaderSig = twirlClasspath.map(p => p.toString().hashCode + p.mtime.toMillis).sum
     twirlInstanceCache match {
       case Some((sig, instance)) if sig == classloaderSig => instance
       case _ =>
-        val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
-        val clt = cl.loadClass("play.twirl.compiler.TwirlCompiler")
-        val instance = clt.getDeclaredConstructor().newInstance()
-          .asInstanceOf[TwirlWorkerApi]
+        val instance = new TwirlWorkerApi {
+          override def compileTwirl(source: File,
+                                    sourceDirectory: File,
+                                    generatedDirectory: File,
+                                    formatterType: String,
+                                    additionalImports: Seq[String] = Nil,
+                                    constructorAnnotations: Seq[String] = Nil,
+                                    codec: Codec = Codec(scala.util.Properties.sourceEncoding),
+                                    inclusiveDot: Boolean = false) {
+            val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
+            val runtime = runtimeMirror(cl)
+            val moduleMirror = runtime.reflectModule(runtime.staticModule("play.twirl.compiler.TwirlCompiler"))
+            val moduleInstance = moduleMirror.instance
+            val instanceMirror = runtime.reflect(moduleInstance)
+            val compileSymbol = instanceMirror.symbol.typeSignature.member(TermName("compile")).asMethod
+            // FIXME: type erasure, unable to call "play.twirl.compiler.TwirlCompiler.compile" function
+            // https://github.com/playframework/twirl/blob/dd56444cf9ea2f95ef3961d3af911561f846df50/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L167
+
+            // scala.MatchError: List() (of class scala.collection.immutable.Nil$)
+            // at scala.reflect.runtime.JavaMirrors$JavaMirror$DerivedValueClassMetadata.unboxer$lzycompute(JavaMirrors.scala:270)
+            // at scala.reflect.runtime.JavaMirrors$JavaMirror$DerivedValueClassMetadata.unboxer(JavaMirrors.scala:269)
+            // at scala.reflect.runtime.JavaMirrors$JavaMirror$MethodMetadata.paramUnboxers(JavaMirrors.scala:416)
+            // at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaTransformingMethodMirror.apply(JavaMirrors.scala:435)
+            instanceMirror.reflectMethod(compileSymbol)(source,
+              sourceDirectory,
+              generatedDirectory,
+              formatterType,
+              additionalImports,
+              constructorAnnotations,
+              codec,
+              inclusiveDot)
+          }
+        }
         twirlInstanceCache = Some((classloaderSig, instance))
         instance
     }
   }
-  
-  def compile(twirlClasspath: Agg[Path],
-              sourceDirectories: Seq[Path],
-              dest: Path) : Unit = {
-    val compiler = twirl(twirlClasspath)
-    def compileTwirlDir(inputDir: Path) = {
-      val twirlFiles = ls.rec(inputDir).filter(_.name.matches(".*.scala.(html|xml|js|txt)"))
-      twirlFiles.map { tFile =>
-        val extFormat = twirlExtensionFormat(tFile.name)
-        compiler.compile( tFile.toIO,
-                          inputDir.toIO,
-                          dest.toIO,
-                          s"play.twirl.api.${extFormat}"
-        )
-      }
-    }
-    sourceDirectories.map(compileTwirlDir)
-  }
- 
- private def twirlExtensionFormat(name: String) =
-        if (name.endsWith("html"))     "HtmlFormat"
-        else if (name.endsWith("xml")) "XmlFormat"
-        else if (name.endsWith("js"))  "JavaScriptFormat"
-        else "TxtFormat"
 
+  def compile(twirlClasspath: Agg[Path], sourceDirectories: Seq[Path], dest: Path)
+             (implicit ctx: mill.util.Ctx): mill.eval.Result[CompilationResult] = {
+    val compiler = twirl(twirlClasspath)
+
+    def compileTwirlDir(inputDir: Path) {
+      ls.rec(inputDir).filter(_.name.matches(".*.scala.(html|xml|js|txt)"))
+        .foreach { template =>
+          val extFormat = twirlExtensionFormat(template.name)
+          compiler.compileTwirl(template.toIO,
+            inputDir.toIO,
+            dest.toIO,
+            s"play.twirl.api.$extFormat"
+          )
+        }
+    }
+
+    sourceDirectories.foreach(compileTwirlDir)
+
+    val zincFile = ctx.dest / 'zinc
+    val classesDir = ctx.dest / 'html
+
+    mill.eval.Result.Success(CompilationResult(zincFile, PathRef(classesDir)))
+  }
+
+  private def twirlExtensionFormat(name: String) =
+    if (name.endsWith("html")) "HtmlFormat"
+    else if (name.endsWith("xml")) "XmlFormat"
+    else if (name.endsWith("js")) "JavaScriptFormat"
+    else "TxtFormat"
 }
 
 trait TwirlWorkerApi {
-  def compile(source: File,
-              sourceDirectory: File,
-              generatedDirectory: File,
-              formatterType: String,
-              additionalImports: Seq[String] = Nil,
-              constructorAnnotations: Seq[String] = Nil,
-  //            codec: Codec = TwirlIO.defaultCodec,
-              inclusiveDot: Boolean = false): Unit   
+  def compileTwirl(source: File,
+                   sourceDirectory: File,
+                   generatedDirectory: File,
+                   formatterType: String,
+                   additionalImports: Seq[String] = Nil,
+                   constructorAnnotations: Seq[String] = Nil,
+                   codec: Codec = Codec(scala.util.Properties.sourceEncoding),
+                   inclusiveDot: Boolean = false)
 }
 
-object TwirlWorkerApi extends mill.define.BaseModule(ammonite.ops.pwd) {
+object TwirlWorkerApi {
 
-  def twirlWorker = T.worker { new TwirlWorker() }
+  def twirlWorker = new TwirlWorker()
 }

--- a/twirllib/src/mill/twirllib/TwirlWorker.scala
+++ b/twirllib/src/mill/twirllib/TwirlWorker.scala
@@ -1,0 +1,68 @@
+package mill
+package twirllib
+
+import java.io.File
+import java.net.URLClassLoader
+import ammonite.ops.{Path,ls}
+
+
+class TwirlWorker  {
+
+  private var twirlInstanceCache = Option.empty[(Long, TwirlWorkerApi)]
+
+  private def twirl(twirlClasspath: Agg[Path]) = {
+    val classloaderSig =
+      twirlClasspath.map(p => p.toString().hashCode + p.mtime.toMillis).sum
+    twirlInstanceCache match {
+      case Some((sig, instance)) if sig == classloaderSig => instance
+      case _ =>
+        val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
+        val clt = cl.loadClass("play.twirl.compiler.TwirlCompiler")
+        val instance = clt.getDeclaredConstructor().newInstance()
+          .asInstanceOf[TwirlWorkerApi]
+        twirlInstanceCache = Some((classloaderSig, instance))
+        instance
+    }
+  }
+  
+  def compile(twirlClasspath: Agg[Path],
+              sourceDirectories: Seq[Path],
+              dest: Path) : Unit = {
+    val compiler = twirl(twirlClasspath)
+    def compileTwirlDir(inputDir: Path) = {
+      val twirlFiles = ls.rec(inputDir).filter(_.name.matches(".*.scala.(html|xml|js|txt)"))
+      twirlFiles.map { tFile =>
+        val extFormat = twirlExtensionFormat(tFile.name)
+        compiler.compile( tFile.toIO,
+                          inputDir.toIO,
+                          dest.toIO,
+                          s"play.twirl.api.${extFormat}"
+        )
+      }
+    }
+    sourceDirectories.map(compileTwirlDir)
+  }
+ 
+ private def twirlExtensionFormat(name: String) =
+        if (name.endsWith("html"))     "HtmlFormat"
+        else if (name.endsWith("xml")) "XmlFormat"
+        else if (name.endsWith("js"))  "JavaScriptFormat"
+        else "TxtFormat"
+
+}
+
+trait TwirlWorkerApi {
+  def compile(source: File,
+              sourceDirectory: File,
+              generatedDirectory: File,
+              formatterType: String,
+              additionalImports: Seq[String] = Nil,
+              constructorAnnotations: Seq[String] = Nil,
+  //            codec: Codec = TwirlIO.defaultCodec,
+              inclusiveDot: Boolean = false): Unit   
+}
+
+object TwirlWorkerApi extends mill.define.BaseModule(ammonite.ops.pwd) {
+
+  def twirlWorker = T.worker { new TwirlWorker() }
+}

--- a/twirllib/src/mill/twirllib/TwirlWorker.scala
+++ b/twirllib/src/mill/twirllib/TwirlWorker.scala
@@ -3,6 +3,7 @@ package twirllib
 
 import java.io.File
 import java.net.URLClassLoader
+import java.{lang, util}
 
 import ammonite.ops.{Path, ls}
 import mill.eval.PathRef
@@ -14,43 +15,41 @@ import scala.reflect.runtime.universe._
 class TwirlWorker {
 
   private var twirlInstanceCache = Option.empty[(Long, TwirlWorkerApi)]
+  import scala.collection.JavaConverters._
 
   private def twirl(twirlClasspath: Agg[Path]) = {
     val classloaderSig = twirlClasspath.map(p => p.toString().hashCode + p.mtime.toMillis).sum
     twirlInstanceCache match {
       case Some((sig, instance)) if sig == classloaderSig => instance
       case _ =>
+        val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
+        val twirlCompilerClass = cl.loadClass("play.japi.twirl.compiler.TwirlCompiler")
+        // Use the Java API (available in Twirl 1.3+)
+        // Using reflection on a method with "Seq[String] = Nil" parameter type does not seem to work.
+
+        // REMIND: Unable to call the compile method with a primitive boolean
+        // codec and inclusiveDot will not be available
+        val compileMethod = twirlCompilerClass.getMethod("compile",
+          classOf[java.io.File],
+          classOf[java.io.File],
+          classOf[java.io.File],
+          classOf[java.lang.String],
+          classOf[util.Collection[java.lang.String]],
+          classOf[util.List[java.lang.String]])
+
         val instance = new TwirlWorkerApi {
           override def compileTwirl(source: File,
                                     sourceDirectory: File,
                                     generatedDirectory: File,
                                     formatterType: String,
                                     additionalImports: Seq[String] = Nil,
-                                    constructorAnnotations: Seq[String] = Nil,
-                                    codec: Codec = Codec(scala.util.Properties.sourceEncoding),
-                                    inclusiveDot: Boolean = false) {
-            val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
-            val runtime = runtimeMirror(cl)
-            val moduleMirror = runtime.reflectModule(runtime.staticModule("play.twirl.compiler.TwirlCompiler"))
-            val moduleInstance = moduleMirror.instance
-            val instanceMirror = runtime.reflect(moduleInstance)
-            val compileSymbol = instanceMirror.symbol.typeSignature.member(TermName("compile")).asMethod
-            // FIXME: type erasure, unable to call "play.twirl.compiler.TwirlCompiler.compile" function
-            // https://github.com/playframework/twirl/blob/dd56444cf9ea2f95ef3961d3af911561f846df50/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L167
-
-            // scala.MatchError: List() (of class scala.collection.immutable.Nil$)
-            // at scala.reflect.runtime.JavaMirrors$JavaMirror$DerivedValueClassMetadata.unboxer$lzycompute(JavaMirrors.scala:270)
-            // at scala.reflect.runtime.JavaMirrors$JavaMirror$DerivedValueClassMetadata.unboxer(JavaMirrors.scala:269)
-            // at scala.reflect.runtime.JavaMirrors$JavaMirror$MethodMetadata.paramUnboxers(JavaMirrors.scala:416)
-            // at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaTransformingMethodMirror.apply(JavaMirrors.scala:435)
-            instanceMirror.reflectMethod(compileSymbol)(source,
+                                    constructorAnnotations: Seq[String] = Nil) {
+            val o = compileMethod.invoke(null, source,
               sourceDirectory,
               generatedDirectory,
               formatterType,
-              additionalImports,
-              constructorAnnotations,
-              codec,
-              inclusiveDot)
+              additionalImports.asJava,
+              constructorAnnotations.asJava)
           }
         }
         twirlInstanceCache = Some((classloaderSig, instance))
@@ -95,9 +94,7 @@ trait TwirlWorkerApi {
                    generatedDirectory: File,
                    formatterType: String,
                    additionalImports: Seq[String] = Nil,
-                   constructorAnnotations: Seq[String] = Nil,
-                   codec: Codec = Codec(scala.util.Properties.sourceEncoding),
-                   inclusiveDot: Boolean = false)
+                   constructorAnnotations: Seq[String] = Nil)
 }
 
 object TwirlWorkerApi {

--- a/twirllib/src/mill/twirllib/TwirlWorker.scala
+++ b/twirllib/src/mill/twirllib/TwirlWorker.scala
@@ -9,6 +9,10 @@ import ammonite.ops.{Path, ls}
 import mill.eval.PathRef
 import mill.scalalib.CompilationResult
 
+import scala.io.Codec
+import scala.reflect.runtime.universe._
+import scala.util.Properties
+
 class TwirlWorker {
 
   private var twirlInstanceCache = Option.empty[(Long, TwirlWorkerApi)]
@@ -19,39 +23,84 @@ class TwirlWorker {
     twirlInstanceCache match {
       case Some((sig, instance)) if sig == classloaderSig => instance
       case _ =>
-        val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
-        val twirlCompilerClass = cl.loadClass("play.japi.twirl.compiler.TwirlCompiler")
-        // Use the Java API (available in Twirl 1.3+)
-        // Using reflection on a method with "Seq[String] = Nil" parameter type does not seem to work.
-
-        // REMIND: Unable to call the compile method with a primitive boolean
-        // codec and inclusiveDot will not be available
-        val compileMethod = twirlCompilerClass.getMethod("compile",
-          classOf[java.io.File],
-          classOf[java.io.File],
-          classOf[java.io.File],
-          classOf[java.lang.String],
-          classOf[util.Collection[java.lang.String]],
-          classOf[util.List[java.lang.String]])
-
-        val instance = new TwirlWorkerApi {
-          override def compileTwirl(source: File,
-                                    sourceDirectory: File,
-                                    generatedDirectory: File,
-                                    formatterType: String,
-                                    additionalImports: Seq[String] = Nil,
-                                    constructorAnnotations: Seq[String] = Nil) {
-            val o = compileMethod.invoke(null, source,
-              sourceDirectory,
-              generatedDirectory,
-              formatterType,
-              additionalImports.asJava,
-              constructorAnnotations.asJava)
-          }
-        }
-        twirlInstanceCache = Some((classloaderSig, instance))
-        instance
+        //callScalaAPI(twirlClasspath, classloaderSig)
+        callJavaAPI(twirlClasspath, classloaderSig)
     }
+  }
+
+  private def callJavaAPI(twirlClasspath: Agg[Path], classloaderSig: Long) = {
+    val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
+    val twirlCompilerClass = cl.loadClass("play.japi.twirl.compiler.TwirlCompiler")
+    // Use the Java API (available in Twirl 1.3+)
+    // Using reflection on a method with "Seq[String] = Nil" parameter type does not seem to work.
+
+    // REMIND: Unable to call the compile method with a primitive boolean
+    // codec and inclusiveDot will not be available
+    val compileMethod = twirlCompilerClass.getMethod("compile",
+      classOf[File],
+      classOf[File],
+      classOf[File],
+      classOf[String],
+      classOf[util.Collection[String]],
+      classOf[util.List[String]])
+
+    val instance = new TwirlWorkerApi {
+      override def compileTwirl(source: File,
+                                sourceDirectory: File,
+                                generatedDirectory: File,
+                                formatterType: String,
+                                additionalImports: Seq[String] = Nil,
+                                constructorAnnotations: Seq[String] = Nil,
+                                codec: Codec = Codec(Properties.sourceEncoding),
+                                inclusiveDot: Boolean = false) {
+        val o = compileMethod.invoke(null, source,
+          sourceDirectory,
+          generatedDirectory,
+          formatterType,
+          additionalImports.asJava,
+          constructorAnnotations.asJava)
+      }
+    }
+    twirlInstanceCache = Some((classloaderSig, instance))
+    instance
+  }
+
+  private def callScalaAPI(twirlClasspath: Agg[Path], classloaderSig: Long) = {
+    val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
+    val runtime = runtimeMirror(cl)
+    val moduleMirror = runtime.reflectModule(runtime.staticModule("play.twirl.compiler.TwirlCompiler"))
+    val moduleInstance = moduleMirror.instance
+    val instanceMirror = runtime.reflect(moduleInstance)
+    val compileSymbol = instanceMirror.symbol.typeSignature.member(TermName("compile")).asMethod
+    // FIXME: type erasure, unable to call "play.twirl.compiler.TwirlCompiler.compile" function
+    // https://github.com/playframework/twirl/blob/dd56444cf9ea2f95ef3961d3af911561f846df50/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L167
+    val instance = new TwirlWorkerApi {
+      override def compileTwirl(source: File,
+                                sourceDirectory: File,
+                                generatedDirectory: File,
+                                formatterType: String,
+                                additionalImports: Seq[String] = Nil,
+                                constructorAnnotations: Seq[String] = Nil,
+                                codec: Codec = Codec(Properties.sourceEncoding),
+                                inclusiveDot: Boolean = false) {
+
+        // scala.MatchError: List() (of class scala.collection.immutable.Nil$)
+        // at scala.reflect.runtime.JavaMirrors$JavaMirror$DerivedValueClassMetadata.unboxer$lzycompute(JavaMirrors.scala:270)
+        // at scala.reflect.runtime.JavaMirrors$JavaMirror$DerivedValueClassMetadata.unboxer(JavaMirrors.scala:269)
+        // at scala.reflect.runtime.JavaMirrors$JavaMirror$MethodMetadata.paramUnboxers(JavaMirrors.scala:416)
+        // at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaTransformingMethodMirror.apply(JavaMirrors.scala:435)
+        instanceMirror.reflectMethod(compileSymbol)(source,
+          sourceDirectory,
+          generatedDirectory,
+          formatterType,
+          additionalImports,
+          constructorAnnotations,
+          codec,
+          inclusiveDot)
+      }
+    }
+    twirlInstanceCache = Some((classloaderSig, instance))
+    instance
   }
 
   def compile(twirlClasspath: Agg[Path], sourceDirectories: Seq[Path], dest: Path)
@@ -91,7 +140,9 @@ trait TwirlWorkerApi {
                    generatedDirectory: File,
                    formatterType: String,
                    additionalImports: Seq[String] = Nil,
-                   constructorAnnotations: Seq[String] = Nil)
+                   constructorAnnotations: Seq[String] = Nil,
+                   codec: Codec = Codec(Properties.sourceEncoding),
+                   inclusiveDot: Boolean = false)
 }
 
 object TwirlWorkerApi {

--- a/twirllib/src/mill/twirllib/TwirlWorker.scala
+++ b/twirllib/src/mill/twirllib/TwirlWorker.scala
@@ -3,14 +3,11 @@ package twirllib
 
 import java.io.File
 import java.net.URLClassLoader
-import java.{lang, util}
+import java.util
 
 import ammonite.ops.{Path, ls}
 import mill.eval.PathRef
 import mill.scalalib.CompilationResult
-
-import scala.io.Codec
-import scala.reflect.runtime.universe._
 
 class TwirlWorker {
 

--- a/twirllib/src/mill/twirllib/TwirlWorker.scala
+++ b/twirllib/src/mill/twirllib/TwirlWorker.scala
@@ -3,104 +3,62 @@ package twirllib
 
 import java.io.File
 import java.net.URLClassLoader
-import java.util
 
 import ammonite.ops.{Path, ls}
 import mill.eval.PathRef
 import mill.scalalib.CompilationResult
 
 import scala.io.Codec
-import scala.reflect.runtime.universe._
 import scala.util.Properties
 
 class TwirlWorker {
 
   private var twirlInstanceCache = Option.empty[(Long, TwirlWorkerApi)]
-  import scala.collection.JavaConverters._
 
   private def twirl(twirlClasspath: Agg[Path]) = {
     val classloaderSig = twirlClasspath.map(p => p.toString().hashCode + p.mtime.toMillis).sum
     twirlInstanceCache match {
       case Some((sig, instance)) if sig == classloaderSig => instance
       case _ =>
-        //callScalaAPI(twirlClasspath, classloaderSig)
-        callJavaAPI(twirlClasspath, classloaderSig)
+        val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
+        val twirlCompilerClass = cl.loadClass("play.twirl.compiler.TwirlCompiler")
+        val compileMethod = twirlCompilerClass.getMethod("compile",
+          classOf[java.io.File],
+          classOf[java.io.File],
+          classOf[java.io.File],
+          classOf[java.lang.String],
+          cl.loadClass("scala.collection.Seq"),
+          cl.loadClass("scala.collection.Seq"),
+          cl.loadClass("scala.io.Codec"),
+          classOf[Boolean])
+
+        val defaultAdditionalImportsMethod = twirlCompilerClass.getMethod("compile$default$5")
+        val defaultConstructorAnnotationsMethod = twirlCompilerClass.getMethod("compile$default$6")
+        val defaultCodecMethod = twirlCompilerClass.getMethod("compile$default$7")
+        val defaultFlagMethod = twirlCompilerClass.getMethod("compile$default$8")
+
+        val instance = new TwirlWorkerApi {
+          override def compileTwirl(source: File,
+                                    sourceDirectory: File,
+                                    generatedDirectory: File,
+                                    formatterType: String,
+                                    additionalImports: Seq[String] = Nil,
+                                    constructorAnnotations: Seq[String] = Nil,
+                                    codec: Codec = Codec(Properties.sourceEncoding),
+                                    inclusiveDot: Boolean = false) {
+            val o = compileMethod.invoke(null, source,
+              sourceDirectory,
+              generatedDirectory,
+              formatterType,
+              defaultAdditionalImportsMethod.invoke(additionalImports),
+              defaultConstructorAnnotationsMethod.invoke(constructorAnnotations),
+              defaultCodecMethod.invoke(codec),
+              defaultFlagMethod.invoke(inclusiveDot))
+          }
+        }
+        twirlInstanceCache = Some((classloaderSig, instance))
+        instance
     }
-  }
-
-  private def callJavaAPI(twirlClasspath: Agg[Path], classloaderSig: Long) = {
-    val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
-    val twirlCompilerClass = cl.loadClass("play.japi.twirl.compiler.TwirlCompiler")
-    // Use the Java API (available in Twirl 1.3+)
-    // Using reflection on a method with "Seq[String] = Nil" parameter type does not seem to work.
-
-    // REMIND: Unable to call the compile method with a primitive boolean
-    // codec and inclusiveDot will not be available
-    val compileMethod = twirlCompilerClass.getMethod("compile",
-      classOf[File],
-      classOf[File],
-      classOf[File],
-      classOf[String],
-      classOf[util.Collection[String]],
-      classOf[util.List[String]])
-
-    val instance = new TwirlWorkerApi {
-      override def compileTwirl(source: File,
-                                sourceDirectory: File,
-                                generatedDirectory: File,
-                                formatterType: String,
-                                additionalImports: Seq[String] = Nil,
-                                constructorAnnotations: Seq[String] = Nil,
-                                codec: Codec = Codec(Properties.sourceEncoding),
-                                inclusiveDot: Boolean = false) {
-        val o = compileMethod.invoke(null, source,
-          sourceDirectory,
-          generatedDirectory,
-          formatterType,
-          additionalImports.asJava,
-          constructorAnnotations.asJava)
-      }
-    }
-    twirlInstanceCache = Some((classloaderSig, instance))
-    instance
-  }
-
-  private def callScalaAPI(twirlClasspath: Agg[Path], classloaderSig: Long) = {
-    val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
-    val runtime = runtimeMirror(cl)
-    val moduleMirror = runtime.reflectModule(runtime.staticModule("play.twirl.compiler.TwirlCompiler"))
-    val moduleInstance = moduleMirror.instance
-    val instanceMirror = runtime.reflect(moduleInstance)
-    val compileSymbol = instanceMirror.symbol.typeSignature.member(TermName("compile")).asMethod
-    // FIXME: type erasure, unable to call "play.twirl.compiler.TwirlCompiler.compile" function
-    // https://github.com/playframework/twirl/blob/dd56444cf9ea2f95ef3961d3af911561f846df50/compiler/src/main/scala/play/twirl/compiler/TwirlCompiler.scala#L167
-    val instance = new TwirlWorkerApi {
-      override def compileTwirl(source: File,
-                                sourceDirectory: File,
-                                generatedDirectory: File,
-                                formatterType: String,
-                                additionalImports: Seq[String] = Nil,
-                                constructorAnnotations: Seq[String] = Nil,
-                                codec: Codec = Codec(Properties.sourceEncoding),
-                                inclusiveDot: Boolean = false) {
-
-        // scala.MatchError: List() (of class scala.collection.immutable.Nil$)
-        // at scala.reflect.runtime.JavaMirrors$JavaMirror$DerivedValueClassMetadata.unboxer$lzycompute(JavaMirrors.scala:270)
-        // at scala.reflect.runtime.JavaMirrors$JavaMirror$DerivedValueClassMetadata.unboxer(JavaMirrors.scala:269)
-        // at scala.reflect.runtime.JavaMirrors$JavaMirror$MethodMetadata.paramUnboxers(JavaMirrors.scala:416)
-        // at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaTransformingMethodMirror.apply(JavaMirrors.scala:435)
-        instanceMirror.reflectMethod(compileSymbol)(source,
-          sourceDirectory,
-          generatedDirectory,
-          formatterType,
-          additionalImports,
-          constructorAnnotations,
-          codec,
-          inclusiveDot)
-      }
-    }
-    twirlInstanceCache = Some((classloaderSig, instance))
-    instance
   }
 
   def compile(twirlClasspath: Agg[Path], sourceDirectories: Seq[Path], dest: Path)

--- a/twirllib/src/mill/twirllib/TwirlWorker.scala
+++ b/twirllib/src/mill/twirllib/TwirlWorker.scala
@@ -2,6 +2,7 @@ package mill
 package twirllib
 
 import java.io.File
+import java.lang.reflect.Method
 import java.net.URLClassLoader
 
 import ammonite.ops.{Path, ls}
@@ -9,7 +10,6 @@ import mill.eval.PathRef
 import mill.scalalib.CompilationResult
 
 import scala.io.Codec
-import scala.util.Properties
 
 class TwirlWorker {
 
@@ -42,18 +42,18 @@ class TwirlWorker {
                                     sourceDirectory: File,
                                     generatedDirectory: File,
                                     formatterType: String,
-                                    additionalImports: Seq[String] = Nil,
-                                    constructorAnnotations: Seq[String] = Nil,
-                                    codec: Codec = Codec(Properties.sourceEncoding),
-                                    inclusiveDot: Boolean = false) {
+                                    additionalImports: Seq[String],
+                                    constructorAnnotations: Seq[String],
+                                    codec: Codec,
+                                    inclusiveDot: Boolean) {
             val o = compileMethod.invoke(null, source,
               sourceDirectory,
               generatedDirectory,
               formatterType,
-              defaultAdditionalImportsMethod.invoke(additionalImports),
-              defaultConstructorAnnotationsMethod.invoke(constructorAnnotations),
-              defaultCodecMethod.invoke(codec),
-              defaultFlagMethod.invoke(inclusiveDot))
+              defaultAdditionalImportsMethod.invoke(null),
+              defaultConstructorAnnotationsMethod.invoke(null),
+              defaultCodecMethod.invoke(null),
+              defaultFlagMethod.invoke(null))
           }
         }
         twirlInstanceCache = Some((classloaderSig, instance))
@@ -61,7 +61,13 @@ class TwirlWorker {
     }
   }
 
-  def compile(twirlClasspath: Agg[Path], sourceDirectories: Seq[Path], dest: Path)
+  def compile(twirlClasspath: Agg[Path],
+              sourceDirectories: Seq[Path],
+              dest: Path,
+              additionalImports: Seq[String],
+              constructorAnnotations: Seq[String],
+              codec: Codec,
+              inclusiveDot: Boolean)
              (implicit ctx: mill.util.Ctx): mill.eval.Result[CompilationResult] = {
     val compiler = twirl(twirlClasspath)
 
@@ -72,7 +78,11 @@ class TwirlWorker {
           compiler.compileTwirl(template.toIO,
             inputDir.toIO,
             dest.toIO,
-            s"play.twirl.api.$extFormat"
+            s"play.twirl.api.$extFormat",
+            additionalImports,
+            constructorAnnotations,
+            codec,
+            inclusiveDot
           )
         }
     }
@@ -97,10 +107,10 @@ trait TwirlWorkerApi {
                    sourceDirectory: File,
                    generatedDirectory: File,
                    formatterType: String,
-                   additionalImports: Seq[String] = Nil,
-                   constructorAnnotations: Seq[String] = Nil,
-                   codec: Codec = Codec(Properties.sourceEncoding),
-                   inclusiveDot: Boolean = false)
+                   additionalImports: Seq[String],
+                   constructorAnnotations: Seq[String],
+                   codec: Codec,
+                   inclusiveDot: Boolean)
 }
 
 object TwirlWorkerApi {

--- a/twirllib/test/resources/hello-world/core/views/hello.scala.html
+++ b/twirllib/test/resources/hello-world/core/views/hello.scala.html
@@ -1,0 +1,6 @@
+@(title: String)
+<html>
+    <body>
+        <h1>@title</h1>
+    </body>
+</html>

--- a/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -1,0 +1,80 @@
+package mill.twirllib
+
+import ammonite.ops.{Path, cp, exists, ls, mkdir, pwd, read, rm, write}
+import mill.eval.{Evaluator, Result}
+import mill.util.{TestEvaluator, TestUtil}
+import utest.{TestSuite, Tests, assert}
+import ammonite.ops._
+import mill.T
+import utest._
+
+import utest.framework.TestPath
+
+object HelloWorldTests extends TestSuite {
+
+  trait HelloBase extends TestUtil.BaseModule {
+    override def millSourcePath: Path = TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+  }
+
+  trait HelloWorldModule extends mill.twirllib.TwirlModule {
+    def twirlVersion = "1.0.0"
+  }
+
+  object HelloWorld extends HelloBase {
+    object core extends HelloWorldModule {
+      override def twirlVersion = "1.2.1"
+    }
+  }
+
+  val resourcePath: Path = pwd / 'twirllib / 'test / 'resources / "hello-world"
+
+  def workspaceTest[T, M <: TestUtil.BaseModule](m: M, resourcePath: Path = resourcePath)
+                                                (t: TestEvaluator[M] => T)
+                                                (implicit tp: TestPath): T = {
+    val eval = new TestEvaluator(m)
+    rm(m.millSourcePath)
+    rm(eval.outPath)
+    mkdir(m.millSourcePath / up)
+    cp(resourcePath, m.millSourcePath)
+    t(eval)
+  }
+
+  def compileClassfiles: Seq[RelPath] = Seq[RelPath](
+    "hello.template.scala"
+  )
+
+  def tests: Tests = Tests {
+    'twirlVersion - {
+
+      'fromBuild - workspaceTest(HelloWorld) { eval =>
+        val Right((result, evalCount)) = eval.apply(HelloWorld.core.twirlVersion)
+
+        assert(
+          result == "1.2.1",
+          evalCount > 0
+        )
+      }
+    }
+    'compileTwirl - {
+      'fromScratch - workspaceTest(HelloWorld) { eval =>
+        val Right((result, evalCount)) = eval.apply(HelloWorld.core.compileTwirl)
+
+        val outputFiles = ls.rec(result.classes.path)
+        val expectedClassfiles = compileClassfiles.map(
+          eval.outPath / 'core / 'compileTwirl / 'dest / 'html / _
+        )
+        assert(
+          result.classes.path == eval.outPath / 'core / 'compileTwirl / 'dest / 'html,
+          outputFiles.nonEmpty,
+          outputFiles.forall(expectedClassfiles.contains),
+          evalCount > 0
+        )
+
+        // don't recompile if nothing changed
+        val Right((_, unchangedEvalCount)) = eval.apply(HelloWorld.core.compileTwirl)
+
+        assert(unchangedEvalCount == 0)
+      }
+    }
+  }
+}

--- a/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -22,7 +22,7 @@ object HelloWorldTests extends TestSuite {
 
   object HelloWorld extends HelloBase {
     object core extends HelloWorldModule {
-      override def twirlVersion = "1.2.1"
+      override def twirlVersion = "1.3.15"
     }
   }
 
@@ -50,7 +50,7 @@ object HelloWorldTests extends TestSuite {
         val Right((result, evalCount)) = eval.apply(HelloWorld.core.twirlVersion)
 
         assert(
-          result == "1.2.1",
+          result == "1.3.15",
           evalCount > 0
         )
       }

--- a/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -1,14 +1,9 @@
 package mill.twirllib
 
-import ammonite.ops.{Path, cp, exists, ls, mkdir, pwd, read, rm, write}
-import mill.eval.{Evaluator, Result}
+import ammonite.ops.{Path, cp, ls, mkdir, pwd, rm, _}
 import mill.util.{TestEvaluator, TestUtil}
-import utest.{TestSuite, Tests, assert}
-import ammonite.ops._
-import mill.T
-import utest._
-
 import utest.framework.TestPath
+import utest.{TestSuite, Tests, assert, _}
 
 object HelloWorldTests extends TestSuite {
 
@@ -21,9 +16,11 @@ object HelloWorldTests extends TestSuite {
   }
 
   object HelloWorld extends HelloBase {
+
     object core extends HelloWorldModule {
       override def twirlVersion = "1.3.15"
     }
+
   }
 
   val resourcePath: Path = pwd / 'twirllib / 'test / 'resources / "hello-world"
@@ -55,26 +52,25 @@ object HelloWorldTests extends TestSuite {
         )
       }
     }
-    'compileTwirl - {
-      'fromScratch - workspaceTest(HelloWorld) { eval =>
-        val Right((result, evalCount)) = eval.apply(HelloWorld.core.compileTwirl)
+    'compileTwirl - workspaceTest(HelloWorld) { eval =>
+      val Right((result, evalCount)) = eval.apply(HelloWorld.core.compileTwirl)
 
-        val outputFiles = ls.rec(result.classes.path)
-        val expectedClassfiles = compileClassfiles.map(
-          eval.outPath / 'core / 'compileTwirl / 'dest / 'html / _
-        )
-        assert(
-          result.classes.path == eval.outPath / 'core / 'compileTwirl / 'dest / 'html,
-          outputFiles.nonEmpty,
-          outputFiles.forall(expectedClassfiles.contains),
-          evalCount > 0
-        )
+      val outputFiles = ls.rec(result.classes.path)
+      val expectedClassfiles = compileClassfiles.map(
+        eval.outPath / 'core / 'compileTwirl / 'dest / 'html / _
+      )
+      assert(
+        result.classes.path == eval.outPath / 'core / 'compileTwirl / 'dest / 'html,
+        outputFiles.nonEmpty,
+        outputFiles.forall(expectedClassfiles.contains),
+        outputFiles.size == 1,
+        evalCount > 0
+      )
 
-        // don't recompile if nothing changed
-        val Right((_, unchangedEvalCount)) = eval.apply(HelloWorld.core.compileTwirl)
+      // don't recompile if nothing changed
+      val Right((_, unchangedEvalCount)) = eval.apply(HelloWorld.core.compileTwirl)
 
-        assert(unchangedEvalCount == 0)
-      }
+      assert(unchangedEvalCount == 0)
     }
   }
 }

--- a/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -20,7 +20,6 @@ object HelloWorldTests extends TestSuite {
     object core extends HelloWorldModule {
       override def twirlVersion = "1.3.15"
     }
-
   }
 
   val resourcePath: Path = pwd / 'twirllib / 'test / 'resources / "hello-world"


### PR DESCRIPTION
Based on @pleira implementation

This is a work in progress:

 * [x] Find a better solution to solve the `java.lang.ClassNotFoundException: scala.util.parsing.input.Positional`
 * [x] An exception is thrown when `TwirlCompiler.compile` function is invoked using Reflection
 * [x] Unable to call the `compile` method with a primitive boolean using reflection: https://github.com/playframework/twirl/blob/f4ed321dee30c977b7f303ef1229169180beab45/compiler/src/main/java/play/japi/twirl/compiler/TwirlCompiler.java#L38
 * [x] Find a way to use the Scala API because the Java API is only available in Twirl 1.3+


For now the main issue is that an exception is thrown when `TwirlCompiler.compile` is invoked.
Oddly tests are running fine in Intellij IDEA. In this case the reflection is calling `JavaMirrors.JavaVanillaMethodMirror.apply(args: Any*)`. But when I run the tests using `mill twirllib.test`, the reflection is calling `JavaMirrors.JavaTransformingMethodMirror.apply(args: Any*)`.

I've also tried to use Java reflection but without success:

```scala
val clt = cl.loadClass("play.twirl.compiler.TwirlCompiler")
val module = cl.loadClass("play.twirl.compiler.TwirlCompiler$").getField("MODULE$")
val compileMethod = clt.getMethods.find(_.getName == "compile").get
compileMethod.invoke(module, 
    source,
    sourceDirectory,
    generatedDirectory,
    formatterType,
    additionalImports,
    constructorAnnotations,
    codec,
    inclusiveDot) // error: the result type of an implicit conversion must be more specific than AnyRef
```

Help, feedback or review will be greatly appreciated :smile: 
