### PR TITLE
Move interactiveSubprocess to Util

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -303,7 +303,7 @@ object dev extends MillModule{
       case wd0 +: rest =>
         val wd = Path(wd0, pwd)
         mkdir(wd)
-        mill.modules.Jvm.baseInteractiveSubprocess(
+        mill.modules.Util.interactiveSubprocess(
           Seq(launcher().path.toString) ++ rest,
           forkEnv(),
           workingDir = wd

--- a/main/src/mill/modules/Util.scala
+++ b/main/src/mill/modules/Util.scala
@@ -1,8 +1,9 @@
 package mill.modules
 
-
-import ammonite.ops.{Path, RelPath, empty, mkdir, read}
+import java.io.{ByteArrayInputStream}
+import ammonite.ops.{Path, RelPath, InteractiveShelloutException, empty, mkdir, read}
 import mill.eval.PathRef
+import mill.clientserver.InputPumper
 import mill.util.{Ctx, IO}
 
 object Util {
@@ -53,5 +54,44 @@ object Util {
       }
     })()
     PathRef(ctx.dest / dest)
+  }
+
+  def interactiveSubprocess(commandArgs: Seq[String],
+                            envArgs: Map[String, String],
+                            workingDir: Path) = {
+    val builder = new java.lang.ProcessBuilder()
+
+    for ((k, v) <- envArgs){
+      if (v != null) builder.environment().put(k, v)
+      else builder.environment().remove(k)
+    }
+    builder.directory(workingDir.toIO)
+
+    val process = if (System.in.isInstanceOf[ByteArrayInputStream]){
+
+      val process = builder
+        .command(commandArgs:_*)
+        .start()
+
+      val sources = Seq(
+        process.getInputStream -> System.out,
+        process.getErrorStream -> System.err,
+        System.in -> process.getOutputStream
+      )
+
+      for((std, dest) <- sources){
+        new Thread(new InputPumper(std, dest, false)).start()
+      }
+      process
+    } else {
+      builder
+        .command(commandArgs:_*)
+        .inheritIO()
+        .start()
+    }
+
+    val exitCode = process.waitFor()
+    if (exitCode == 0) ()
+    else throw InteractiveShelloutException()
   }
 }


### PR DESCRIPTION
Currently forking an interactive subprocess is not possible because of the way standard IO are captured by mill. I have the feeling that something is missing here because it is probably a common use case.

In the meantime I have found that `JVM.baseInteractiveSubprocess` does the job but it is a bit strange to call something in `JVM` to fork a non JVM process, so I propose to move it to `Util`.

If you think that there are better ways to solve this, especially if you think there is a way to make ammonite ops work for interactive process in mill I could give it a try!