### PR TITLE
Pass scalac plugins to scaladoc

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -127,7 +127,8 @@ trait ScalaModule extends JavaModule { outer =>
       if p.isFile
     } yield p.toNIO.toString
 
-    val options = Seq("-d", javadocDir.toNIO.toString, "-usejavacp")
+    val pluginOptions = scalacPluginClasspath().map(pluginPathRef => s"-Xplugin:${pluginPathRef.path}")
+    val options = Seq("-d", javadocDir.toNIO.toString, "-usejavacp") ++ pluginOptions
 
     if (files.nonEmpty) subprocess(
       "scala.tools.nsc.ScalaDoc",

--- a/scalalib/test/resources/hello-world-macros/core/src/Main.scala
+++ b/scalalib/test/resources/hello-world-macros/core/src/Main.scala
@@ -1,0 +1,5 @@
+import monocle.macros._
+@Lenses case class Foo(bar: String)
+object Main extends App {
+  println(Foo.bar.get(Foo("bar")))
+}

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -101,7 +101,7 @@ object HelloWorldTests extends TestSuite {
 
   object HelloWorldTypeLevel extends HelloBase{
     object foo extends ScalaModule {
-      def scalaVersion = "2.11.8"
+      def scalaVersion = "2.12.4"
       override def mapDependencies(d: coursier.Dependency) = {
         val artifacts = Set("scala-library", "scala-compiler", "scala-reflect")
         if (d.module.organization != "org.scala-lang" || !artifacts(d.module.name)) d
@@ -119,7 +119,7 @@ object HelloWorldTests extends TestSuite {
 
   object HelloWorldMacros extends HelloBase{
     object core extends ScalaModule {
-      def scalaVersion = "2.11.8"
+      def scalaVersion = "2.12.4"
 
       def ivyDeps = Agg(
         ivy"com.github.julien-truffaut::monocle-macro::1.4.0"

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -116,6 +116,20 @@ object HelloWorldTests extends TestSuite {
       )
     }
   }
+
+  object HelloWorldMacros extends HelloBase{
+    object core extends ScalaModule {
+      def scalaVersion = "2.11.8"
+
+      def ivyDeps = Agg(
+        ivy"com.github.julien-truffaut::monocle-macro::1.4.0"
+      )
+      def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Agg(
+        ivy"org.scalamacros:::paradise:2.1.0"
+      )
+    }
+  }
+
   val resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-world"
 
   def jarMainClass(jar: JarFile): Option[String] = {
@@ -473,6 +487,24 @@ object HelloWorldTests extends TestSuite {
           result.map(_.toString).exists(x => x.contains("typelevel") && x.contains("scala-library"))
 
         )
+      }
+    }
+    'macros - {
+      // make sure macros are applied when compiling/running
+      'runMain - workspaceTest(
+        HelloWorldMacros,
+        resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-world-macros"
+      ){ eval =>
+        val Right((_, evalCount)) = eval.apply(HelloWorldMacros.core.runMain("Main"))
+        assert(evalCount > 0)
+      }
+      // make sure macros are applied when compiling during scaladoc generation
+      'docJar - workspaceTest(
+        HelloWorldMacros,
+        resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-world-macros"
+      ){ eval =>
+        val Right((_, evalCount)) = eval.apply(HelloWorldMacros.core.docJar)
+        assert(evalCount > 0)
       }
     }
   }


### PR DESCRIPTION
Fixes #282. Passing the flags as @lihaoyi suggested seemed to do the trick (thanks!), and docJar and publishing now seem to be working. I added a small test case with the example from the issue, which fails before the change and succeeds after.