### PR TITLE
fixes #226; use transitiveIvyDeps to print dependency tree

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -232,7 +232,7 @@ trait JavaModule extends mill.Module with TaskModule { outer =>
 
   def ivyDepsTree(inverse: Boolean = false) = T.command {
     val (flattened, resolution) = Lib.resolveDependenciesMetadata(
-      repositories, resolveCoursierDependency().apply(_), ivyDeps(), Some(mapDependencies)
+      repositories, resolveCoursierDependency().apply(_), transitiveIvyDeps(), Some(mapDependencies)
     )
 
     println(coursier.util.Print.dependencyTree(flattened, resolution,


### PR DESCRIPTION
Duplicate of https://github.com/lihaoyi/mill/pull/289 to bypass CI errors