### PR TITLE
Add some documentation regarding bootstrapping.

### DIFF
--- a/docs/pages/1 - Intro to Mill.md
+++ b/docs/pages/1 - Intro to Mill.md
@@ -48,6 +48,7 @@ In case you want to try out the latest features and improvements that are
 currently in master, unstable versions of Mill are
 [available](https://github.com/lihaoyi/mill/releases) as binaries named 
 `#.#.#-n-hash` linked to the latest tag.
+Installing the latest unstable release is recommended for bootstrapping mill.
 
 Come by our [Gitter Channel](https://gitter.im/lihaoyi/mill) if you want to ask
 questions or say hi!

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,9 @@ own codebase.
 
 Mill is built using Mill. To begin, first download & install Mill as described
 in the documentation above.
+As Mill is under active development, stable releases may not be able to build 
+the current development branch of Mill.
+It is recommended to install the latest unstable release manually.
 
 To run unit test suite:
 


### PR DESCRIPTION
Mill unstable releases should be used for bootstrapping.

This is from discussion in #293.