### PR TITLE
Fix docs re: GenIdea/idea command

### DIFF
--- a/docs/pages/1 - Intro to Mill.md
+++ b/docs/pages/1 - Intro to Mill.md
@@ -458,7 +458,7 @@ JSON it outputs is structured and easily parsed & manipulated.
 
 ## IntelliJ Support
 
-Mill supports IntelliJ by default. Use `mill mill.scalalib.GenIdeaModule/idea` to
+Mill supports IntelliJ by default. Use `mill mill.scalalib.GenIdea/idea` to
 generate an IntelliJ project config for your build.
 
 This also configures IntelliJ to allow easy navigate & code-completion within

--- a/docs/pages/5 - Modules.md
+++ b/docs/pages/5 - Modules.md
@@ -154,5 +154,5 @@ mill foo.Bar/qux
 that is shared by the entire build: for example,
 `mill.scalalib.ScalaWorkerApi/scalaWorker` provides a shared Scala compilation
 service & cache that is shared between all `ScalaModule`s, and
-`mill.scalalib.GenIdeaModule/idea` lets you generate IntelliJ projects without
+`mill.scalalib.GenIdea/idea` lets you generate IntelliJ projects without
 needing to define your own `T.command` in your `build.sc` file

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ mill dev.run docs/example-1 foo.run
 Lastly, you can generate IntelliJ Scala project files using Mill via
 
 ```bash
-./out/dev/assembly/dest/mill mill.scalalib.GenIdeaModule/idea
+./out/dev/assembly/dest/mill mill.scalalib.GenIdea/idea
 ```
 
 Allowing you to import a Mill project into Intellij without using SBT


### PR DESCRIPTION
I found that the module name has changed, but the docs still refer to `GenIdeaModule`