### PR TITLE
Mark test module as test sources; change sbt module root

### DIFF
--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -217,7 +217,7 @@ object GenIdeaImpl {
       val isTest = mod.isInstanceOf[TestModule]
 
       val elem = moduleXmlTemplate(
-        mod.millModuleBasePath.value,
+        mod.intellijModulePath,
         scalaVersionOpt,
         Strict.Agg.from(resourcesPathRefs.map(_.path)),
         Strict.Agg.from(normalSourcePaths),

--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -214,6 +214,8 @@ object GenIdeaImpl {
         mod.generatedSources.ctx.segments
       )
 
+      val isTest = mod.isInstanceOf[TestModule]
+
       val elem = moduleXmlTemplate(
         mod.millModuleBasePath.value,
         scalaVersionOpt,
@@ -223,7 +225,8 @@ object GenIdeaImpl {
         paths.out,
         generatedSourceOutPath.dest,
         Strict.Agg.from(resolvedDeps.map(pathToLibName)),
-        Strict.Agg.from(mod.moduleDeps.map{ m => moduleName(moduleLabels(m))}.distinct)
+        Strict.Agg.from(mod.moduleDeps.map{ m => moduleName(moduleLabels(m))}.distinct),
+        isTest
       )
       Tuple2(".idea_modules"/s"${moduleName(path)}.iml", elem)
     }
@@ -321,7 +324,9 @@ object GenIdeaImpl {
                         compileOutputPath: Path,
                         generatedSourceOutputPath: Path,
                         libNames: Strict.Agg[String],
-                        depNames: Strict.Agg[String]) = {
+                        depNames: Strict.Agg[String],
+                        isTest: Boolean
+                       ) = {
     <module type="JAVA_MODULE" version="4">
       <component name="NewModuleRootManager">
         <output url={"file://$MODULE_DIR$/" + relify(compileOutputPath) + "/dest/classes"} />
@@ -331,17 +336,17 @@ object GenIdeaImpl {
           {
           for (normalSourcePath <- normalSourcePaths.toSeq.sorted)
             yield
-              <sourceFolder url={"file://$MODULE_DIR$/" + relify(normalSourcePath)} isTestSource="false" />
+              <sourceFolder url={"file://$MODULE_DIR$/" + relify(normalSourcePath)} isTestSource={isTest.toString} />
           }
           {
           for (generatedSourcePath <- generatedSourcePaths.toSeq.sorted)
             yield
-              <sourceFolder url={"file://$MODULE_DIR$/" + relify(generatedSourcePath)} isTestSource="false" generated="true" />
+              <sourceFolder url={"file://$MODULE_DIR$/" + relify(generatedSourcePath)} isTestSource={isTest.toString} generated="true" />
           }
           {
           for (resourcePath <- resourcePaths.toSeq.sorted)
             yield
-              <sourceFolder url={"file://$MODULE_DIR$/" + relify(resourcePath)} isTestSource="false"  type="java-resource" />
+              <sourceFolder url={"file://$MODULE_DIR$/" + relify(resourcePath)} isTestSource={isTest.toString}  type="java-resource" />
           }
           <excludeFolder url={"file://$MODULE_DIR$/" +  relify(basePath) + "/target"} />
         </content>

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -289,6 +289,8 @@ trait JavaModule extends mill.Module with TaskModule { outer =>
   def artifactName: T[String] = millModuleSegments.parts.mkString("-")
 
   def artifactId: T[String] = artifactName()
+
+  def intellijModulePath: Path = millSourcePath
 }
 
 trait TestModule extends JavaModule with TaskModule {

--- a/scalalib/src/mill/scalalib/MiscModule.scala
+++ b/scalalib/src/mill/scalalib/MiscModule.scala
@@ -66,12 +66,14 @@ trait MavenModule extends JavaModule{outer =>
   override def resources = T.sources{ millSourcePath / 'src / 'main / 'resources }
   trait Tests extends super.Tests with MavenTests {
     override def millSourcePath = outer.millSourcePath
+    override def intellijModulePath = outer.millSourcePath / 'src / 'test
   }
 }
 
 trait SbtModule extends MavenModule with ScalaModule{ outer =>
   trait Tests extends super.Tests with MavenTests {
     override def millSourcePath = outer.millSourcePath
+    override def intellijModulePath = outer.millSourcePath / 'src / 'test
   }
 }
 

--- a/scalalib/test/resources/gen-idea/idea/modules.xml
+++ b/scalalib/test/resources/gen-idea/idea/modules.xml
@@ -3,6 +3,7 @@
         <modules>
             <module fileurl="file://$PROJECT_DIR$/.idea_modules/mill-build.iml" filepath="$PROJECT_DIR$/.idea_modules/mill-build.iml"/>
             <module fileurl="file://$PROJECT_DIR$/.idea_modules/.iml" filepath="$PROJECT_DIR$/.idea_modules/.iml"/>
+            <module fileurl="file://$PROJECT_DIR$/.idea_modules/test.iml" filepath="$PROJECT_DIR$/.idea_modules/test.iml"/>
         </modules>
     </component>
 </project>

--- a/scalalib/test/resources/gen-idea/idea_modules/test.iml
+++ b/scalalib/test/resources/gen-idea/idea_modules/test.iml
@@ -1,0 +1,18 @@
+<module type="JAVA_MODULE" version="4">
+    <component name="NewModuleRootManager">
+        <output url="file://$MODULE_DIR$/../target/workspace/mill/scalalib/GenIdeaTests/helloWorldEvaluator/test/compile/dest/classes"/>
+        <exclude-output/>
+        <content url="file://$MODULE_DIR$/../target/workspace/mill/scalalib/GenIdeaTests/helloWorldEvaluator/test/generatedSources/dest"/>
+        <content url="file://$MODULE_DIR$/../target/workspace/gen-idea/test">
+            <sourceFolder url="file://$MODULE_DIR$/../target/workspace/gen-idea/test/src" isTestSource="true"/>
+            <sourceFolder url="file://$MODULE_DIR$/../target/workspace/gen-idea/test/resources" isTestSource="true" type="java-resource"/>
+            <excludeFolder url="file://$MODULE_DIR$/../target/workspace/gen-idea/test/target"/>
+        </content>
+        <orderEntry type="inheritedJdk"/>
+        <orderEntry type="sourceFolder" forTests="false"/>
+        <orderEntry type="library" name="scala-sdk-2.12.4" level="application"/>
+        <orderEntry type="library" name="scala-library-2.12.4-sources.jar" level="project"/>
+        <orderEntry type="library" name="scala-library-2.12.4.jar" level="project"/>
+        <orderEntry type="module" module-name="" exported=""/>
+    </component>
+</module>

--- a/scalalib/test/src/mill/scalalib/GenIdeaTests.scala
+++ b/scalalib/test/src/mill/scalalib/GenIdeaTests.scala
@@ -13,6 +13,9 @@ object GenIdeaTests extends TestSuite {
   trait HelloWorldModule extends scalalib.ScalaModule {
     def scalaVersion = "2.12.4"
     def millSourcePath = GenIdeaTests.millSourcePath
+    object test extends super.Tests {
+      def testFrameworks = Seq("utest.runner.Framework")
+    }
   }
 
   object HelloWorld extends TestUtil.BaseModule with HelloWorldModule
@@ -34,6 +37,8 @@ object GenIdeaTests extends TestSuite {
       Seq(
         "gen-idea/idea_modules/iml" ->
           millSourcePath / "generated" / ".idea_modules" /".iml",
+        "gen-idea/idea_modules/test.iml" ->
+          millSourcePath / "generated" / ".idea_modules" /"test.iml",
         "gen-idea/idea_modules/mill-build.iml" ->
           millSourcePath / "generated" / ".idea_modules" /"mill-build.iml",
         "gen-idea/idea/libraries/scala-library-2.12.4.jar.xml" ->


### PR DESCRIPTION
This PR fixes #201
It's achieved by introducing `intellijModulePath`, which is different from `millSourcePath` for sbt/maven module's tests.
For instance:
module path in Intellij is: `module`
module's test path in Intellij is: `module/src/test`.

Meanwhile `millSourcePath` didn't change 