### PR TITLE
Resolves #305, use an English locale when excuting java command line

### DIFF
--- a/main/test/src/mill/eval/JavaCompileJarTests.scala
+++ b/main/test/src/mill/eval/JavaCompileJarTests.scala
@@ -41,7 +41,7 @@ object JavaCompileJarTests extends TestSuite{
         def jar = T{ Jvm.createJar(Loose.Agg(classFiles().path) ++ resourceRoot().map(_.path)) }
 
         def run(mainClsName: String) = T.command{
-          %%('java, "-cp", classFiles().path, mainClsName)
+          %%('java, "-Duser.language=en", "-cp", classFiles().path, mainClsName)
         }
       }
 


### PR DESCRIPTION
Otherwise we cannot rely on the exception message because the error returned by the java command line will be localized.