### PR TITLE
Optimize calculation of commit count

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -396,8 +396,7 @@ def publishVersion = T.input{
       val latestTaggedVersion = %%('git, 'describe, "--abbrev=0", "--tags")(pwd).out.trim
 
       val commitsSinceLastTag =
-        %%('git, "rev-list", gitHead(), "--count")(pwd).out.trim.toInt -
-        %%('git, "rev-list", latestTaggedVersion, "--count")(pwd).out.trim.toInt
+        %%('git, "rev-list", gitHead(), "--not", latestTaggedVersion, "--count")(pwd).out.trim.toInt
 
       (latestTaggedVersion, s"$latestTaggedVersion-$commitsSinceLastTag-${gitHead().take(6)}$dirtySuffix")
   }


### PR DESCRIPTION
Instead of count all commits back to the beginning of time twice, and
then subtracting, just make one call to let git figure it out.

This is my first time trying to contribute, so any comments are very welcome.