### PR TITLE
Initial support for jsDependencies

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -238,6 +238,11 @@ object contrib extends MillModule {
     def moduleDeps = Seq(scalalib)
   }
 
+  object scalajsdependencies extends MillModule {
+    def moduleDeps = Seq(scalajslib)
+    def ivyDeps = Agg(ivy"org.scala-js::jsdependencies-core:1.0.0-M3")
+  }
+
 }
 
 

--- a/build.sc
+++ b/build.sc
@@ -241,6 +241,11 @@ object contrib extends MillModule {
   object scalajsdependencies extends MillModule {
     def moduleDeps = Seq(scalajslib)
     def ivyDeps = Agg(ivy"org.scala-js::jsdependencies-core:1.0.0-M3")
+    def testArgs = T{
+      Seq("-Djna.nosys=true") ++
+      scalalib.worker.testArgs() ++
+      scalalib.backgroundwrapper.testArgs()
+    }
   }
 
 }

--- a/contrib/scalajsdependencies/src/ScalaJSDependencies.scala
+++ b/contrib/scalajsdependencies/src/ScalaJSDependencies.scala
@@ -1,0 +1,150 @@
+package mill.contrib
+
+import scala.collection.mutable
+import scala.collection.JavaConverters.enumerationAsScalaIteratorConverter
+import scala.util.matching.Regex
+import java.io.InputStreamReader
+import java.io.File
+import java.util.jar.JarFile
+
+import mill._
+import mill.scalajslib.ScalaJSModule
+import ammonite.ops._
+import mill.define.Target
+import org.scalajs.jsdependencies.core._
+import org.scalajs.io._
+
+
+trait ScalaJSDependencies extends ScalaJSModule {
+
+  def jsdependenciesOutputFileName = T {
+    val infix = if(useMinifiedJSDependencies()) "-min" else ""
+    s"out-deps${infix}.js"
+  }
+
+  def useMinifiedJSDependencies = T {
+    false
+  }
+
+  override def fastOpt = T {
+    packageJSDependencies()
+    super.fastOpt()
+  }
+
+  override def fullOpt = T {
+    packageJSDependencies()
+    super.fullOpt()
+  }
+
+
+  def packageJSDependencies = T {
+    //    val directDeps = ??? // Todo: ProvidedJS equivalent for build file
+    val cpdeps = resolvedJSDependencies(compileClasspath().filter(p => exists(p.path)))
+    val output = T.ctx().dest / jsdependenciesOutputFileName()
+    val selectLib = if (useMinifiedJSDependencies())
+      (dep: ResolvedJSDependency) => dep.minifiedLib.getOrElse(dep.lib)
+    else
+      (dep: ResolvedJSDependency) => dep.lib
+
+    for (dep <- cpdeps) {
+      write.append(output, selectLib(dep).readLines().map(_ + ammonite.util.Util.newLine))
+    }
+    PathRef(output)
+  }
+
+
+  // code mainly copied & adapted from https://github.com/scala-js/jsdependencies
+  private def collectFromClasspath[T](cp: Agg[PathRef],
+                                      filter: Regex,
+                                      collectJar: Path => Seq[T],
+                                      collectFile: (File, String) => T): Seq[T] = {
+    val results = Seq.newBuilder[T]
+    for {
+      pathRef <- cp
+      cpEntry = pathRef.path
+    } {
+      if (cpEntry.isFile && cpEntry.name.endsWith(".jar")) {
+        results ++= collectJar(cpEntry)
+      } else if (cpEntry.isDir) {
+        for (
+          (file, relPath) <-
+            ls.rec !
+              cpEntry |? { p => filter.findFirstMatchIn(p.name).isDefined } | { p => (p.toIO, p.relativeTo(cpEntry).toString()) }
+        ) {
+          results += collectFile(file, relPath)
+        }
+      } else {
+        throw new IllegalArgumentException("Illegal classpath entry: " + cpEntry.toNIO.toString)
+      }
+    }
+    results.result()
+  }
+
+  private def jsDependencyManifestsInJar(container: Path): List[JSDependencyManifest] = {
+    val jar = new JarFile(container.toIO)
+    jar
+      .entries()
+      .asScala
+      .filter(_.getName == JSDependencyManifest.ManifestFileName)
+      .map(m => JSDependencyManifest.read(new InputStreamReader(jar.getInputStream(m), "UTF-8")))
+      .toList
+  }
+
+  private def jsDependencyManifests(ccp: Agg[PathRef]) = {
+    collectFromClasspath(
+      ccp,
+      JSDependencyManifest.ManifestFileName.r,
+      collectJar = jsDependencyManifestsInJar,
+      collectFile = { (file, _) => JSDependencyManifest.read(FileVirtualTextFile(file)) })
+  }
+
+  private def jsFilesInJar(container: Path): List[VirtualJSFile with RelativeVirtualFile] = {
+    val jar = new JarFile(container.toIO)
+    jar
+      .entries()
+      .asScala
+      .filter(_.getName.endsWith(".js"))
+      .map(m => {
+        val file = new EntryJSFile(container.name, m.getName)
+        file.content = org.scalajs.io.IO.readInputStreamToString(jar.getInputStream(m))
+        file.version = None
+        file
+      })
+      .toList
+  }
+
+  private class EntryJSFile(outerPath: String, val relativePath: String)
+    extends MemVirtualJSFile(s"$outerPath:$relativePath")
+      with RelativeVirtualFile
+
+  private def scalaJSNativeLibraries(ccp: Agg[PathRef]) = {
+    collectFromClasspath(
+      ccp,
+      ".*\\.js$".r,
+      collectJar = jsFilesInJar,
+      collectFile = FileVirtualJSFile.relative)
+  }
+
+  private def resolvedJSDependencies(ccp: Agg[PathRef]) = {
+    val attLibs = scalaJSNativeLibraries(ccp)
+    val attManifests = jsDependencyManifests(ccp)
+
+    // Collect available JS libraries
+    val availableLibs: Map[String, VirtualJSFile] = {
+      val libs = mutable.Map.empty[String, VirtualJSFile]
+      for (lib <- attLibs)
+        libs.getOrElseUpdate(lib.relativePath, lib)
+      libs.toMap
+    }
+
+    // Actually resolve the dependencies
+    DependencyResolver
+      .resolveDependencies(
+        attManifests,
+        availableLibs,
+        identity(_)) // filter for js files -> not sure if this is needed
+  }
+
+
+}
+

--- a/contrib/scalajsdependencies/test/resources/scalajsdependencies/src/Main.scala
+++ b/contrib/scalajsdependencies/test/resources/scalajsdependencies/src/Main.scala
@@ -1,0 +1,5 @@
+object Main extends App {
+
+  println("Hello, World!")
+
+}

--- a/contrib/scalajsdependencies/test/src/mill/contrib/ScalaJSDependenciesTests.scala
+++ b/contrib/scalajsdependencies/test/src/mill/contrib/ScalaJSDependenciesTests.scala
@@ -1,0 +1,79 @@
+package mill.contrib
+
+import ammonite.ops._
+import java.util.jar.JarFile
+import mill._
+import mill.scalalib._
+import mill.define.Target
+import mill.eval.Result._
+import mill.eval.{Evaluator, Result}
+import mill.modules.Assembly
+import mill.scalalib.publish.VersionControl
+import mill.scalalib.publish._
+import mill.util.{TestEvaluator, TestUtil}
+import scala.collection.JavaConverters._
+import utest._
+import utest.framework.TestPath
+
+object ScalaJSDependenciesTests extends TestSuite {
+
+  val scalaVersionString = "2.12.4"
+  val scalaJSVersionString = "0.6.22"
+  trait ScalaJSDependenciesModule extends TestUtil.BaseModule with scalajslib.ScalaJSModule with ScalaJSDependencies {
+    def millSourcePath =  TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+    def scalaVersion = scalaVersionString
+    def scalaJSVersion = scalaJSVersionString
+    def ivyDeps = Agg(ivy"org.singlespaced::scalajs-d3::0.3.4")
+  }
+
+
+  object ScalaJSDependencies extends ScalaJSDependenciesModule
+
+  object ScalaJSDependenciesSettings extends ScalaJSDependenciesModule {
+    def jsdependenciesOutputFileName = T{ "foo.js" }
+  }
+
+  val resourcePath = pwd / 'contrib / 'scalajsdependencies / 'test / 'resources / 'scalajsdependencies
+
+  def workspaceTest[T, M <: TestUtil.BaseModule](m: M, resourcePath: Path = resourcePath)
+                                                (t: TestEvaluator[M] => T)
+                                                (implicit tp: TestPath): T = {
+    val eval = new TestEvaluator(m)
+    rm(m.millSourcePath)
+    rm(eval.outPath)
+    mkdir(m.millSourcePath / up)
+    cp(resourcePath, m.millSourcePath)
+    t(eval)
+  }
+
+  def tests: Tests = Tests {
+
+    val expected = "!function("
+    'scalajsdependencies - {
+      'packageJSDependencies - workspaceTest(ScalaJSDependencies){ eval =>
+        val Right((result, evalCount)) = eval.apply(ScalaJSDependencies.packageJSDependencies)
+        println(result.path)
+        assert(
+          result.path == eval.outPath / 'packageJSDependencies / 'dest / "out-deps.js" &&
+            exists(result.path) &&
+            (read! result.path).take(10) == expected
+        )
+      }
+      'triggeredByFastOptJS - workspaceTest(ScalaJSDependencies){ eval =>
+        // val Right((result, evalCount)) = eval.apply(ScalaJSDependencies.fastOpt)
+        val Left(Result.Exception(result, evalCount)) = eval.apply(ScalaJSDependencies.fastOpt)
+        result.printStackTrace
+        assert(
+            (read! eval.outPath / 'packageJSDependencies / 'dest / "out-deps.js").take(10) == expected
+        )
+        assert(false)
+      }
+      'triggeredByfullOptJS - workspaceTest(ScalaJSDependencies){ eval =>
+        val Right((result, evalCount)) = eval.apply(ScalaJSDependencies.fullOpt)
+        assert(
+            (read! eval.outPath / 'packageJSDependencies / 'dest / "out-deps.js").take(10) == expected
+        )
+      }
+    }
+  }
+}

--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -49,3 +49,24 @@ object example extends ScalaPBModule {
   override def scalaPBOptions = "flat_package,java_conversions"
 }
 ```
+
+### ScalaJS - JsDependencies
+
+This modules allows a ScalaJS build to *use* dependencies that declare dependencies on JavaScript libraries via `jsDependencies` in their (sbt) buildfile. 
+
+It is usually only needed for older scalajs libraries and is mainly a re-write of the [jsdependencies](https://github.com/scala-js/jsdependencies "jsdependencies") sbt-plugin for mill.
+
+It does not allow a mill build to declare dependencies on JavaScript libraries.
+
+To declare a module that uses JsDependencies you can extend the `mill.contrib.ScalaJSDependencies` trait when defining your module.
+
+#### Configuration options
+
+* `def useMinifiedJSDependencies: T[Boolean]`
+  If set to `true` the plugin will try to use the minified version of the JavaScript library.
+  
+* `def jsdependenciesOutputFileName: T[String]`
+  Name of the generated file that contains all the dependent JavaScript libraries.
+  Defaults to `out-deps.js` (or `out-deps-min.js` when `useMinifiedJSDependencies` is set to `true`) 
+
+


### PR DESCRIPTION
ScalaJS artifacts can bundle .js files (using `jsDependencies += ProvidedJS / "file.js"` in sbt).
Any application that has such a dependency will not be able run unless all those .js files are present when the application loads. For this the scalajs sbt plugin creates a `*-deps.js` file containing all .js files as part of the `fastOpt`/`fullOpt` phases.

While this mechanism is already superseded by scala-js-bundler some (older) artifacts still require this method of bundling .js files.

I'd like to get some early feedback on this especially as this is a separate module. As this way of bundling .js files is no longer recommended (see https://www.scala-js.org/doc/project/dependencies.html Also the sbt-plugin is on life-support only) and it pulls in quite a few external dependencies I think it should be an explicit opt-in for scalajs applications that really require this mechanism. This is also the reason why this plugin does not support the addition of js dependencies for a build but only the assembly of the `-deps.js` for the (transitive) dependencies. I am also a bit unhappy about the overloading of `fastOpt`/`fullOpt` as it somewhat hides the second generated js file.

Most of the code was simply adjusted from the sbt-plugin (https://github.com/scala-js/jsdependencies) with a lot of help from @sjrd