### PR TITLE
Fixed dev.{assembly, launcher} reaching max CLI arguments in Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ clone_folder: c:\mill
 environment:
   matrix:
   - COMPILER: default
-    JAVA_HOME: C:\Program Files\Java\jdk9
+    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
   - COMPILER: cygwin
     CYGWIN_DIR: cygwin64
     JAVA_HOME: C:\Program Files\Java\jdk9
@@ -18,10 +18,7 @@ environment:
     MSYS2_ARCH: x86_64
     MSYS2_DIR: msys64
     MSYSTEM: MINGW64
-    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-
-cache:
-  - '%LOCALAPPDATA%\Coursier\cache -> build.sc'
+    JAVA_HOME: C:\Program Files\Java\jdk9
 
 install:
   - SET MILL_URL=https://github.com/lihaoyi/mill/releases/download/0.1.7/0.1.7-97-00b10e
@@ -32,14 +29,16 @@ build_script:
       MD C:\bin &&
       curl -Lo C:\bin\mill.bat %MILL_URL% &&
       cmd /C C:\bin\mill.bat -i all __.publishLocal release &&
+      RD /S /Q %USERPROFILE%\.mill &&
       cmd /C C:\mill\out\release\dest\mill.bat -i all main.test scalajslib.test)
   - if [%COMPILER%]==[msys2] (
       SET "PATH=%JAVA_HOME%\bin;C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%" &&
       C:\%MSYS2_DIR%\usr\bin\bash -lc 'mkdir -p /usr/local/bin' &&
       C:\%MSYS2_DIR%\usr\bin\bash -lc "curl -Lo /usr/local/bin/mill %MILL_URL%" &&
       C:\%MSYS2_DIR%\usr\bin\bash -lc 'chmod +x /usr/local/bin/mill' &&
-      C:\%MSYS2_DIR%\usr\bin\bash -lc "cd /c/mill && mill -i all __.publishLocal release" &&
-      C:\%MSYS2_DIR%\usr\bin\bash -lc "cd /c/mill && out/release/dest/mill -i all main.test scalajslib.test")
+      C:\%MSYS2_DIR%\usr\bin\bash -lc "cd /c/mill && mill -i dev.assembly" &&
+      RD /S /Q %USERPROFILE%\.mill &&
+      C:\%MSYS2_DIR%\usr\bin\bash -lc "cd /c/mill && out/dev/assembly/dest/mill.bat -i all main.test scalajslib.test")
   - if [%COMPILER%]==[cygwin] (
       SET "PATH=%JAVA_HOME%\bin;C:\%CYGWIN_DIR%\bin;C:\%CYGWIN_DIR%\usr\bin;%PATH%" &&
       C:\%CYGWIN_DIR%\bin\bash -lc 'mkdir -p /usr/local/bin' &&

--- a/build.sc
+++ b/build.sc
@@ -250,12 +250,13 @@ private def universalScript(shellCommands: String,
   ).filterNot(_.isEmpty).mkString("\n")
 }
 
-def launcherScript(jvmArgs: Seq[String],
+def launcherScript(shellJvmArgs: Seq[String],
+                   cmdJvmArgs: Seq[String],
                    shellClassPath: Agg[String],
                    cmdClassPath: Agg[String]) = {
-  val jvmArgsStr = jvmArgs.mkString(" ")
   universalScript(
     shellCommands = {
+      val jvmArgsStr = shellJvmArgs.mkString(" ")
       def java(mainClass: String) =
         s"""exec java $jvmArgsStr $$JAVA_OPTS -cp "${shellClassPath.mkString(":")}" $mainClass "$$@""""
 
@@ -269,6 +270,7 @@ def launcherScript(jvmArgs: Seq[String],
          |esac""".stripMargin
     },
     cmdCommands = {
+      val jvmArgsStr = cmdJvmArgs.mkString(" ")
       def java(mainClass: String) =
         s"""java $jvmArgsStr %JAVA_OPTS% -cp "${cmdClassPath.mkString(";")}" $mainClass %*"""
 
@@ -283,30 +285,35 @@ def launcherScript(jvmArgs: Seq[String],
   )
 }
 
-val isBatch =
-  scala.util.Properties.isWin &&
-    !(org.jline.utils.OSUtils.IS_CYGWIN
-      || org.jline.utils.OSUtils.IS_MINGW
-      || "MSYS" == System.getProperty("MSYSTEM"))
-
-
 object dev extends MillModule{
   def moduleDeps = Seq(scalalib, scalajslib)
   def forkArgs =
-    scalalib.testArgs() ++
-    scalajslib.testArgs() ++
-    scalalib.worker.testArgs() ++
-    // Workaround for Zinc/JNA bug
-    // https://github.com/sbt/sbt/blame/6718803ee6023ab041b045a6988fafcfae9d15b5/main/src/main/scala/sbt/Main.scala#L130
-    Seq("-Djna.nosys=true", "-DMILL_VERSION=" + build.publishVersion()._2)
+    (scalalib.testArgs() ++
+     scalajslib.testArgs() ++
+     scalalib.worker.testArgs() ++
+     // Workaround for Zinc/JNA bug
+     // https://github.com/sbt/sbt/blame/6718803ee6023ab041b045a6988fafcfae9d15b5/main/src/main/scala/sbt/Main.scala#L130
+     Seq("-Djna.nosys=true", "-DMILL_VERSION=" + build.publishVersion()._2)).distinct
+
+  // Pass dev.assembly VM options via file in Window due to small max args limit
+  def windowsVmOptions(taskName: String, batch: Path, args: Seq[String])(implicit ctx: mill.util.Ctx) = {
+    if (System.getProperty("java.specification.version").startsWith("1.")) {
+      throw new Error(s"$taskName in Windows is only supported using Java 9 or above")
+    }
+    val vmOptionsFile = T.ctx().dest / "mill.vmoptions"
+    T.ctx().log.info(s"Generated $vmOptionsFile; it should be kept in the same directory as $taskName's ${batch.last}")
+    write(vmOptionsFile, args.mkString("\r\n"))
+  }
 
   def launcher = T{
     val isWin = scala.util.Properties.isWin
-    val outputPath = T.ctx().dest / (if (isBatch) "run.bat" else "run")
+    val outputPath = T.ctx().dest / (if (isWin) "run.bat" else "run")
 
     write(outputPath, prependShellScript())
 
-    if (!isWin) {
+    if (isWin) {
+      windowsVmOptions("dev.launcher", outputPath, forkArgs())
+    } else {
       val perms = java.nio.file.Files.getPosixFilePermissions(outputPath.toNIO)
       perms.add(PosixFilePermission.GROUP_EXECUTE)
       perms.add(PosixFilePermission.OWNER_EXECUTE)
@@ -317,14 +324,23 @@ object dev extends MillModule{
   }
 
   def assembly = T{
-    val filename = if (isBatch) "mill.bat" else "mill"
-    mv(super.assembly().path, T.ctx().dest / filename)
-    PathRef(T.ctx().dest / filename)
+    val isWin = scala.util.Properties.isWin
+    val millPath = T.ctx().dest / (if (isWin) "mill.bat" else "mill")
+    mv(super.assembly().path, millPath)
+    if (isWin) windowsVmOptions("dev.launcher", millPath, forkArgs())
+    PathRef(millPath)
   }
 
   def prependShellScript = T{
     val classpath = runClasspath().map(_.path.toString)
-    launcherScript(forkArgs(), classpath, classpath)
+    val args = forkArgs().distinct
+    val (shellArgs, cmdArgs) =
+      if (!scala.util.Properties.isWin) (args, args)
+      else (
+        Seq("""-XX:VMOptionsFile="$( dirname "$0" )"/mill.vmoptions"""),
+        Seq("""-XX:VMOptionsFile=%~dp0\mill.vmoptions""")
+      )
+    launcherScript(shellArgs, cmdArgs, classpath, classpath)
   }
 
   def run(args: String*) = T.command{
@@ -346,17 +362,19 @@ object dev extends MillModule{
 
 def release = T{
   val dest = T.ctx().dest
-  val filename = if (isBatch) "mill.bat" else "mill"
+  val filename = if (scala.util.Properties.isWin) "mill.bat" else "mill"
+  val args = Seq(
+    "-DMILL_VERSION=" + publishVersion()._2,
+    // Workaround for Zinc/JNA bug
+    // https://github.com/sbt/sbt/blame/6718803ee6023ab041b045a6988fafcfae9d15b5/main/src/main/scala/sbt/Main.scala#L130
+    "-Djna.nosys=true"
+  )
   mv(
     createAssembly(
       dev.runClasspath().map(_.path),
       prependShellScript = launcherScript(
-        Seq(
-          "-DMILL_VERSION=" + publishVersion()._2,
-          // Workaround for Zinc/JNA bug
-          // https://github.com/sbt/sbt/blame/6718803ee6023ab041b045a6988fafcfae9d15b5/main/src/main/scala/sbt/Main.scala#L130
-          "-Djna.nosys=true"
-        ),
+        args,
+        args,
         Agg("$0"),
         Agg("%~dpnx0")
       )


### PR DESCRIPTION
This PR fixes mill dev.assembly (and .launcher) in Windows where the max num of CLI arg char limit is not as generous as in macOS or Linux, thus causing `Argument list too long` error when running the generated batch file.

The fix generates `mill.vmoptions` file along the corresponding batch file; when invoked, the script looks for the VM options file in the same directory as the batch file.

Notes:

* This only works for Java 9 or above; an error is thrown otherwise. (There does not seem to be a way to pass options file to `java` before Java 9.)

* The generated `mill.vmoptions` is not returned as the Task result of dev.{assembly, launcher} because the tasks only return a single pathref. Returning the .vmoptions file requires changing JavaModule (thus, requiring bootstrapping); it does not seem necessary because they, in general, do not produce long args like dev.
