### PR TITLE
Allow hyphens in target names

### DIFF
--- a/core/src/mill/define/Module.scala
+++ b/core/src/mill/define/Module.scala
@@ -3,9 +3,10 @@ package mill.define
 import java.lang.reflect.Modifier
 
 import ammonite.ops.Path
+import mill.util.ParseArgs
 
 import scala.language.experimental.macros
-import scala.reflect.ClassTag
+import scala.reflect.{ClassTag,NameTransformer}
 
 /**
   * `Module` is a class meant to be extended by `trait`s *only*, in order to
@@ -60,7 +61,7 @@ object Module{
       for{
         m <- outer.getClass.getMethods
         if
-          !m.getName.contains('$') &&
+          !NameTransformer.decode(m.getName).contains('$') &&
           m.getParameterCount == 0 &&
           (m.getModifiers & Modifier.STATIC) == 0 &&
           runtimeCls.isAssignableFrom(m.getReturnType)

--- a/main/src/mill/main/Resolve.scala
+++ b/main/src/mill/main/Resolve.scala
@@ -5,9 +5,9 @@ import mill.define.TaskModule
 import ammonite.util.Res
 import mill.main.ResolveMetadata.singleModuleMeta
 import mill.util.Router.EntryPoint
-import mill.util.Scripts
+import mill.util.{ParseArgs, Scripts}
 
-import scala.reflect.ClassTag
+import scala.reflect.{ClassTag,NameTransformer}
 
 object ResolveMetadata extends Resolve[String]{
   def singleModuleMeta(obj: Module, discover: Discover[_], isRootModule: Boolean) = {
@@ -123,7 +123,7 @@ object ResolveTasks extends Resolve[NamedTask[Any]]{
       obj
         .millInternal
         .reflect[Target[_]]
-        .find(_.label == last)
+        .find(t => NameTransformer.decode(t.label) == last)
         .map(Right(_))
 
     val command = Resolve.invokeCommand(obj, last, discover, rest).headOption

--- a/main/test/src/mill/main/MainTests.scala
+++ b/main/test/src/mill/main/MainTests.scala
@@ -34,6 +34,27 @@ object MainTests extends TestSuite{
       'neg6 - check("single.doesntExist", Left("Task single is not a module and has no children."))
       'neg7 - check("", Left("Selector cannot be empty"))
     }
+    'nonJavaLegalIdentifiers - {
+      import mill.util.TestUtil.{test,BaseModule}
+      object hyphenated extends BaseModule {
+        val `two-words` = test()
+        val `three-word-target` = test()
+        object `nested-module` extends BaseModule {
+          val `nested-target` = test()
+        }
+      }
+      val check = MainTests.check(hyphenated) _
+      'pos1 - check("two-words", Right(Seq(_.`two-words`)))
+      'pos2 - check("three-word-target", Right(Seq(_.`three-word-target`)))
+      'neg1 - check("twowords", Left("Cannot resolve twowords. Did you mean two-words?"))
+      'neg2 - check("twow-ords", Left("Cannot resolve twow-ords. Did you mean two-words?"))
+      'neg3 - check("two-words.doesntExist", Left("Task two-words is not a module and has no children."))
+      'neg4 - check("", Left("Selector cannot be empty"))
+      'nested - {
+        'pos - check("nested-module.nested-target", Right(Seq(_.`nested-module`.`nested-target`)))
+        'neg - check("nested-module.doesntExist", Left("Cannot resolve nested-module.doesntExist. Try `mill resolve nested-module._` to see what's available."))
+      }
+    }
     'nested - {
       val check = MainTests.check(nestedModule) _
       'pos1 - check("single", Right(Seq(_.single)))


### PR DESCRIPTION
This resolves #166.

I decided to be conservative, and only allow hyphens.

Hyphens were already legal characters for mill identifiers, but were not matched due to their names being "javafied", e.g., `hyphenated-target` becomes `hyphenated$minustarget`. Therefore, there is not much downside just allowing them.

If any other characters are to be legalized they will need to be added to `identChars` in `mill.util.ParseArgs.parseSelector`.