### PR TITLE
Fixes #336: pass scalac options to ScalaDoc during docJar stage

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -130,7 +130,7 @@ trait ScalaModule extends JavaModule { outer =>
     } yield p.toNIO.toString
 
     val pluginOptions = scalacPluginClasspath().map(pluginPathRef => s"-Xplugin:${pluginPathRef.path}")
-    val options = Seq("-d", javadocDir.toNIO.toString, "-usejavacp") ++ pluginOptions
+    val options = Seq("-d", javadocDir.toNIO.toString, "-usejavacp") ++ pluginOptions ++ scalacOptions()
 
     if (files.nonEmpty) subprocess(
       "scala.tools.nsc.ScalaDoc",
@@ -193,5 +193,3 @@ trait ScalaModule extends JavaModule { outer =>
   override def artifactId: T[String] = artifactName() + artifactSuffix()
 
 }
-
-

--- a/scalalib/test/resources/hello-world-flags/core/src/Main.scala
+++ b/scalalib/test/resources/hello-world-flags/core/src/Main.scala
@@ -1,0 +1,6 @@
+import scala.collection.immutable.SortedMap
+
+object Main extends App {
+  def foo[F[_], A](fa: F[A]): String = fa.toString
+  foo { x: Int => x * 2 }
+}

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -130,6 +130,16 @@ object HelloWorldTests extends TestSuite {
     }
   }
 
+  object HelloWorldFlags extends HelloBase{
+    object core extends ScalaModule {
+      def scalaVersion = "2.12.4"
+      
+      def scalacOptions = super.scalacOptions() ++ Seq(
+        "-Ypartial-unification"
+      )
+    }
+  }
+
   object HelloScalacheck extends HelloBase{
     object foo extends ScalaModule {
       def scalaVersion = "2.12.4"
@@ -519,6 +529,25 @@ object HelloWorldTests extends TestSuite {
         resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-world-macros"
       ){ eval =>
         val Right((_, evalCount)) = eval.apply(HelloWorldMacros.core.docJar)
+        assert(evalCount > 0)
+      }
+    }
+
+    'flags - {
+      // make sure flags are passed when compiling/running
+      'runMain - workspaceTest(
+        HelloWorldFlags,
+        resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-world-flags"
+      ){ eval =>
+        val Right((_, evalCount)) = eval.apply(HelloWorldFlags.core.runMain("Main"))
+        assert(evalCount > 0)
+      }
+      // make sure flags are passed during ScalaDoc generation
+      'docJar - workspaceTest(
+        HelloWorldFlags,
+        resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-world-flags"
+      ){ eval =>
+        val Right((_, evalCount)) = eval.apply(HelloWorldFlags.core.docJar)
         assert(evalCount > 0)
       }
     }


### PR DESCRIPTION
Added a test (akin to #287 which was insuffcient for my particular case - publishing locally a module with cats in it, that required partial unification)