### PR TITLE
Allow shebang with launcherUniversalScript

### DIFF
--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -342,12 +342,14 @@ object Jvm {
   def launcherUniversalScript(mainClass: String,
                               shellClassPath: Agg[String],
                               cmdClassPath: Agg[String],
-                              jvmArgs: Seq[String]) = {
+                              jvmArgs: Seq[String],
+                              shebang: Boolean = false) = {
     universalScript(
       shellCommands =
         s"""exec java ${jvmArgs.mkString(" ")} $$JAVA_OPTS -cp "${shellClassPath.mkString(":")}" $mainClass "$$@"""",
       cmdCommands =
         s"""java ${jvmArgs.mkString(" ")} %JAVA_OPTS% -cp "${cmdClassPath.mkString(";")}" $mainClass %*""",
+      shebang = shebang
     )
   }
   def createLauncher(mainClass: String,


### PR DESCRIPTION
This is needed to fix https://github.com/lihaoyi/Ammonite/issues/813

Basically it allows us to specify whether to use `shebang` for `launcherUniversalScript`