### PR TITLE
Improve Intellij Idea support

### DIFF
--- a/scalalib/test/resources/gen-idea/idea/libraries/scala-library-2.12.4-sources.jar.xml
+++ b/scalalib/test/resources/gen-idea/idea/libraries/scala-library-2.12.4-sources.jar.xml
@@ -1,7 +1,0 @@
-<component name="libraryTable">
-    <library name="scala-library-2.12.4-sources.jar" type="Scala">
-        <CLASSES>
-            <root url="jar://COURSIER_HOME/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.4/scala-library-2.12.4-sources.jar!/"/>
-        </CLASSES>
-    </library>
-</component>

--- a/scalalib/test/resources/gen-idea/idea/libraries/scala-library-2.12.4.jar.xml
+++ b/scalalib/test/resources/gen-idea/idea/libraries/scala-library-2.12.4.jar.xml
@@ -3,5 +3,8 @@
         <CLASSES>
             <root url="jar://COURSIER_HOME/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.4/scala-library-2.12.4.jar!/"/>
         </CLASSES>
+        <SOURCES>
+            <root url="jar://COURSIER_HOME/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.4/scala-library-2.12.4-sources.jar!/"/>
+        </SOURCES>
     </library>
 </component>

--- a/scalalib/test/src/mill/scalalib/GenIdeaTests.scala
+++ b/scalalib/test/src/mill/scalalib/GenIdeaTests.scala
@@ -43,8 +43,6 @@ object GenIdeaTests extends TestSuite {
           millSourcePath / "generated" / ".idea_modules" /"mill-build.iml",
         "gen-idea/idea/libraries/scala-library-2.12.4.jar.xml" ->
           millSourcePath / "generated" / ".idea" / "libraries" / "scala-library-2.12.4.jar.xml",
-        "gen-idea/idea/libraries/scala-library-2.12.4-sources.jar.xml" ->
-          millSourcePath / "generated" / ".idea" / "libraries" / "scala-library-2.12.4-sources.jar.xml",
         "gen-idea/idea/modules.xml" ->
           millSourcePath / "generated" / ".idea" / "modules.xml",
         "gen-idea/idea/misc.xml" ->


### PR DESCRIPTION
Improves the Intellij Idea support in various ways :

* Cherrypicks the idea conf that needs deleting rather than deleting the whole .idea directory. That directory contains elements of configuration like VCS reference that were annoying to set again every time mill regenerated idea config.
* Attempts to retrieve libraries that the build depends on by inspecting the classloader of the top module
* Attempts at grouping jars and sources together in order to have both in the same idea files, which appears to give better jump to definition
* Hacks the library names for the libraries the build depends on, in order to match Intellij's ammonite support and not show red to the user about the library that has successfuly been resolved. Also allows to jump to the library sources from the magic import.