### PR TITLE
Check for availability of Java compiler

### DIFF
--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -32,6 +32,11 @@ object Lib{
                   upstreamCompileOutput: Seq[CompilationResult])
                  (implicit ctx: mill.util.Ctx) = {
     val javac = ToolProvider.getSystemJavaCompiler()
+    if (javac == null) {
+      throw new Exception(
+        "Your Java installation is not a JDK, so it can't compile Java code;" +
+        " Please install the JDK version of Java")
+    }
 
     rm(ctx.dest / 'classes)
     mkdir(ctx.dest / 'classes)


### PR DESCRIPTION
Throws an exception with a sensible error message when the Java compiler
is not available.

I spent some time trying to figure out where that NullPointerException was coming from, so I added a check for that case.