### PR TITLE
Fix MILL_CLASSPATH for Windows

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -317,8 +317,8 @@ object dev extends MillModule{
     val args = forkArgs().distinct
     val (shellArgs, cmdArgs) =
       if (!scala.util.Properties.isWin) (
-        Seq("-DMILL_CLASSPATH=" + classpath.mkString(":")) ++ args,
-        Seq("-DMILL_CLASSPATH=" + classpath.mkString(";")) ++ args
+        Seq("-DMILL_CLASSPATH=" + classpath.mkstring(",")) ++ args,
+        Seq("-DMILL_CLASSPATH=" + classpath.mkstring(",")) ++ args
       )
       else (
         Seq("""-XX:VMOptionsFile="$( dirname "$0" )"/mill.vmoptions"""),

--- a/build.sc
+++ b/build.sc
@@ -269,12 +269,17 @@ def launcherScript(shellJvmArgs: Seq[String],
 object dev extends MillModule{
   def moduleDeps = Seq(scalalib, scalajslib)
   def forkArgs =
-    (scalalib.testArgs() ++
-     scalajslib.testArgs() ++
-     scalalib.worker.testArgs() ++
-     // Workaround for Zinc/JNA bug
-     // https://github.com/sbt/sbt/blame/6718803ee6023ab041b045a6988fafcfae9d15b5/main/src/main/scala/sbt/Main.scala#L130
-     Seq("-Djna.nosys=true", "-DMILL_VERSION=" + build.publishVersion()._2)).distinct
+    (
+      scalalib.testArgs() ++
+      scalajslib.testArgs() ++
+      scalalib.worker.testArgs() ++
+      // Workaround for Zinc/JNA bug
+      // https://github.com/sbt/sbt/blame/6718803ee6023ab041b045a6988fafcfae9d15b5/main/src/main/scala/sbt/Main.scala#L130
+      Seq(
+        "-Djna.nosys=true",
+        "-DMILL_VERSION=" + build.publishVersion()._2
+      )
+    ).distinct
 
   // Pass dev.assembly VM options via file in Window due to small max args limit
   def windowsVmOptions(taskName: String, batch: Path, args: Seq[String])(implicit ctx: mill.util.Ctx) = {

--- a/build.sc
+++ b/build.sc
@@ -320,7 +320,7 @@ object dev extends MillModule{
 
   def prependShellScript = T{
     val classpath = runClasspath().map(_.path.toString)
-    val args = forkArgs().distinct
+    val args = forkArgs()
     val (shellArgs, cmdArgs) =
       if (!scala.util.Properties.isWin) (
         args,

--- a/build.sc
+++ b/build.sc
@@ -277,7 +277,8 @@ object dev extends MillModule{
       // https://github.com/sbt/sbt/blame/6718803ee6023ab041b045a6988fafcfae9d15b5/main/src/main/scala/sbt/Main.scala#L130
       Seq(
         "-Djna.nosys=true",
-        "-DMILL_VERSION=" + build.publishVersion()._2
+        "-DMILL_VERSION=" + build.publishVersion()._2,
+        "-DMILL_CLASSPATH=" + runClasspath().map(_.path.toString).mkString(",")
       )
     ).distinct
 
@@ -322,8 +323,8 @@ object dev extends MillModule{
     val args = forkArgs().distinct
     val (shellArgs, cmdArgs) =
       if (!scala.util.Properties.isWin) (
-        Seq("-DMILL_CLASSPATH=" + classpath.mkstring(",")) ++ args,
-        Seq("-DMILL_CLASSPATH=" + classpath.mkstring(",")) ++ args
+        args,
+        args
       )
       else (
         Seq("""-XX:VMOptionsFile="$( dirname "$0" )"/mill.vmoptions"""),

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -13,13 +13,11 @@ public class MillClientMain {
     static void initServer(String lockBase, boolean setJnaNoSys) throws IOException,URISyntaxException{
         String[] selfJars = System.getProperty("MILL_CLASSPATH").split(",");
 
-        ArrayList<String> l = new java.util.ArrayList<String>();
+        List<String> l = new ArrayList<>();
         List<String> vmOptions = new ArrayList<>();
         l.add("java");
-        Properties props = System.getProperties();
-        Iterator<String> keys = props.stringPropertyNames().iterator();
-        while(keys.hasNext()){
-            String k = keys.next();
+        final Properties props = System.getProperties();
+        for(final String k: props.stringPropertyNames()){
             if (k.startsWith("MILL_") && !"MILL_CLASSPATH".equals(k)) {
                 vmOptions.add("-D" + k + "=" + props.getProperty(k));
             }
@@ -42,7 +40,7 @@ public class MillClientMain {
         l.add("mill.main.MillServerMain");
         l.add(lockBase);
 
-        new java.lang.ProcessBuilder()
+        new ProcessBuilder()
                 .command(l)
                 .redirectOutput(new java.io.File(lockBase + "/logs"))
                 .redirectError(new java.io.File(lockBase + "/logs"))

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -11,7 +11,7 @@ import java.util.*;
 
 public class MillClientMain {
     static void initServer(String lockBase, boolean setJnaNoSys) throws IOException,URISyntaxException{
-        String[] selfJars = System.getProperty("MILL_CLASSPATH").split(File.pathSeparator);
+        String[] selfJars = System.getProperty("MILL_CLASSPATH").split(",");
 
         ArrayList<String> l = new java.util.ArrayList<String>();
         l.add("java");


### PR DESCRIPTION
Use MILL_CLASSPATH system property for Windows. It looks like it was an oversight when it was originally introduced. Also, since this make the command line arguments exceed the limit for Windows, use a vm options file for starting the server.