### PR TITLE
run scalafmt on mill's sources

### DIFF
--- a/core/src/mill/define/Applicative.scala
+++ b/core/src/mill/define/Applicative.scala
@@ -14,14 +14,14 @@ import scala.reflect.macros.blackbox.Context
   * Applier.zipMap(applyable1, applyable2){ (a1, a2, ctx) => ... a1 ... a2 ... }
   */
 object Applicative {
-  trait ApplyHandler[M[+_]]{
+  trait ApplyHandler[M[+ _]] {
     def apply[T](t: M[T]): T
   }
-  object ApplyHandler{
+  object ApplyHandler {
     @compileTimeOnly("Target#apply() can only be used with a T{...} block")
-    implicit def defaultApplyHandler[M[+_]]: ApplyHandler[M] = ???
+    implicit def defaultApplyHandler[M[+ _]]: ApplyHandler[M] = ???
   }
-  trait Applyable[M[+_], +T]{
+  trait Applyable[M[+ _], +T] {
     def self: M[T]
     def apply()(implicit handler: ApplyHandler[M]): T = handler(self)
   }
@@ -32,20 +32,24 @@ object Applicative {
     def ctx()(implicit c: Ctx) = c
     def underlying[A](v: W[A]): T[_]
 
-    def zipMap[R]()(cb: Ctx => Z[R]) = mapCtx(zip()){ (_, ctx) => cb(ctx)}
+    def zipMap[R]()(cb: Ctx => Z[R]) = mapCtx(zip()) { (_, ctx) =>
+      cb(ctx)
+    }
     def zipMap[A, R](a: T[A])(f: (A, Ctx) => Z[R]) = mapCtx(a)(f)
     def zip(): T[Unit]
     def zip[A](a: T[A]): T[Tuple1[A]]
   }
 
-  def impl[M[_], T: c.WeakTypeTag, Ctx: c.WeakTypeTag](c: Context)
-                                                      (t: c.Expr[T]): c.Expr[M[T]] = {
-    impl0(c)(t.tree)(implicitly[c.WeakTypeTag[T]], implicitly[c.WeakTypeTag[Ctx]])
+  def impl[M[_], T: c.WeakTypeTag, Ctx: c.WeakTypeTag](c: Context)(
+      t: c.Expr[T]): c.Expr[M[T]] = {
+    impl0(c)(t.tree)(implicitly[c.WeakTypeTag[T]],
+                     implicitly[c.WeakTypeTag[Ctx]])
   }
-  def impl0[M[_], T: c.WeakTypeTag, Ctx: c.WeakTypeTag](c: Context)
-                                                       (t: c.Tree): c.Expr[M[T]] = {
+  def impl0[M[_], T: c.WeakTypeTag, Ctx: c.WeakTypeTag](c: Context)(
+      t: c.Tree): c.Expr[M[T]] = {
     import c.universe._
-    def rec(t: Tree): Iterator[c.Tree] = Iterator(t) ++ t.children.flatMap(rec(_))
+    def rec(t: Tree): Iterator[c.Tree] =
+      Iterator(t) ++ t.children.flatMap(rec(_))
 
     val bound = collection.mutable.Buffer.empty[(c.Tree, ValDef)]
     val targetApplySym = typeOf[Applyable[Nothing, _]].member(TermName("apply"))
@@ -60,11 +64,10 @@ object Applicative {
 
     val transformed = c.internal.typingTransform(t) {
       case (t @ q"$fun.apply()($handler)", api) if t.symbol == targetApplySym =>
-
         val localDefs = rec(fun).filter(_.isDef).map(_.symbol).toSet
         val banned = rec(t).filter(x => defs(x.symbol) && !localDefs(x.symbol))
 
-        if (banned.hasNext){
+        if (banned.hasNext) {
           val banned0 = banned.next()
           c.abort(
             banned0.pos,
@@ -72,17 +75,19 @@ object Applicative {
           )
         }
         val tempName = c.freshName(TermName("tmp"))
-        val tempSym = c.internal.newTermSymbol(c.internal.enclosingOwner, tempName)
+        val tempSym =
+          c.internal.newTermSymbol(c.internal.enclosingOwner, tempName)
         c.internal.setInfo(tempSym, t.tpe)
         val tempIdent = Ident(tempSym)
         c.internal.setType(tempIdent, t.tpe)
         c.internal.setFlag(tempSym, (1L << 44).asInstanceOf[c.universe.FlagSet])
-        bound.append((q"${c.prefix}.underlying($fun)", c.internal.valDef(tempSym)))
+        bound.append(
+          (q"${c.prefix}.underlying($fun)", c.internal.valDef(tempSym)))
         tempIdent
       case (t, api)
-        if t.symbol != null
-        && t.symbol.annotations.exists(_.tree.tpe =:= typeOf[ImplicitStub]) =>
-
+          if t.symbol != null
+            && t.symbol.annotations.exists(
+              _.tree.tpe =:= typeOf[ImplicitStub]) =>
         val tempIdent = Ident(ctxSym)
         c.internal.setType(tempIdent, t.tpe)
         c.internal.setFlag(ctxSym, (1L << 44).asInstanceOf[c.universe.FlagSet])
@@ -93,14 +98,15 @@ object Applicative {
 
     val (exprs, bindings) = bound.unzip
 
-
     val ctxBinding = c.internal.valDef(ctxSym)
 
     val callback = c.typecheck(q"(..$bindings, $ctxBinding) => $transformed ")
 
     val res = q"${c.prefix}.zipMap(..$exprs){ $callback }"
 
-    c.internal.changeOwner(transformed, c.internal.enclosingOwner, callback.symbol)
+    c.internal.changeOwner(transformed,
+                           c.internal.enclosingOwner,
+                           callback.symbol)
 
     c.Expr[M[T]](res)
   }

--- a/core/src/mill/define/BaseModule.scala
+++ b/core/src/mill/define/BaseModule.scala
@@ -2,45 +2,46 @@ package mill.define
 
 import ammonite.ops.Path
 
-object BaseModule{
+object BaseModule {
   case class Implicit(value: BaseModule)
 }
 
 abstract class BaseModule(millSourcePath0: Path,
                           external0: Boolean = false,
-                          foreign0 : Boolean = false)
-                         (implicit millModuleEnclosing0: sourcecode.Enclosing,
-                          millModuleLine0: sourcecode.Line,
-                          millName0: sourcecode.Name,
-                          millFile0: sourcecode.File)
-  extends Module()(
-    mill.define.Ctx.make(
-      implicitly,
-      implicitly,
-      implicitly,
-      BasePath(millSourcePath0),
-      Segments(),
-      mill.util.Router.Overrides(0),
-      Ctx.External(external0),
-      Ctx.Foreign(foreign0),
-      millFile0
-    )
-  ){
+                          foreign0: Boolean = false)(
+    implicit millModuleEnclosing0: sourcecode.Enclosing,
+    millModuleLine0: sourcecode.Line,
+    millName0: sourcecode.Name,
+    millFile0: sourcecode.File)
+    extends Module()(
+      mill.define.Ctx.make(
+        implicitly,
+        implicitly,
+        implicitly,
+        BasePath(millSourcePath0),
+        Segments(),
+        mill.util.Router.Overrides(0),
+        Ctx.External(external0),
+        Ctx.Foreign(foreign0),
+        millFile0
+      )
+    ) {
   // A BaseModule should provide an empty Segments list to it's children, since
   // it is the root of the module tree, and thus must not include it's own
   // sourcecode.Name as part of the list,
   override implicit def millModuleSegments: Segments = Segments()
   override def millSourcePath = millOuterCtx.millSourcePath
   override implicit def millModuleBasePath: BasePath = BasePath(millSourcePath)
-  implicit def millImplicitBaseModule: BaseModule.Implicit = BaseModule.Implicit(this)
+  implicit def millImplicitBaseModule: BaseModule.Implicit =
+    BaseModule.Implicit(this)
   def millDiscover: Discover[this.type]
 }
 
-
-abstract class ExternalModule(implicit millModuleEnclosing0: sourcecode.Enclosing,
-                              millModuleLine0: sourcecode.Line,
-                              millName0: sourcecode.Name)
-  extends BaseModule(ammonite.ops.pwd, external0 = true, foreign0 = false){
+abstract class ExternalModule(
+    implicit millModuleEnclosing0: sourcecode.Enclosing,
+    millModuleLine0: sourcecode.Line,
+    millName0: sourcecode.Name)
+    extends BaseModule(ammonite.ops.pwd, external0 = true, foreign0 = false) {
 
   implicit def millDiscoverImplicit: Discover[_] = millDiscover
   assert(
@@ -48,6 +49,6 @@ abstract class ExternalModule(implicit millModuleEnclosing0: sourcecode.Enclosin
     "External modules must be at a top-level static path, not " + millModuleEnclosing0.value
   )
   override implicit def millModuleSegments = {
-    Segments(millModuleEnclosing0.value.split('.').map(Segment.Label):_*)
+    Segments(millModuleEnclosing0.value.split('.').map(Segment.Label): _*)
   }
 }

--- a/core/src/mill/define/Cross.scala
+++ b/core/src/mill/define/Cross.scala
@@ -2,11 +2,10 @@ package mill.define
 import language.experimental.macros
 import scala.reflect.macros.blackbox
 
-
-object Cross{
+object Cross {
   case class Factory[T](make: (Product, mill.define.Ctx) => T)
 
-  object Factory{
+  object Factory {
     implicit def make[T]: Factory[T] = macro makeImpl[T]
     def makeImpl[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[Factory[T]] = {
       import c.universe._
@@ -16,8 +15,8 @@ object Cross{
         tpe.typeSymbol.asClass.primaryConstructor.typeSignature.paramLists.head
 
       val argTupleValues =
-        for((a, n) <- primaryConstructorArgs.zipWithIndex)
-        yield q"v.productElement($n).asInstanceOf[${a.info}]"
+        for ((a, n) <- primaryConstructorArgs.zipWithIndex)
+          yield q"v.productElement($n).asInstanceOf[${a.info}]"
 
       val instance = c.Expr[(Product, mill.define.Ctx) => T](
         q"{ (v, ctx0) => new $tpe(..$argTupleValues){  override def millOuterCtx = ctx0 } }"
@@ -27,7 +26,7 @@ object Cross{
     }
   }
 
-  trait Resolver[-T]{
+  trait Resolver[-T] {
     def resolve[V <: T](c: Cross[V]): V
   }
 }
@@ -42,18 +41,17 @@ object Cross{
   *   ...
   * }
   */
-class Cross[T](cases: Any*)
-              (implicit ci: Cross.Factory[T],
-               ctx: mill.define.Ctx) extends mill.define.Module()(ctx) {
+class Cross[T](cases: Any*)(implicit ci: Cross.Factory[T], ctx: mill.define.Ctx)
+    extends mill.define.Module()(ctx) {
 
   override lazy val millModuleDirectChildren =
     this.millInternal.reflectNestedObjects[Module] ++
-    items.collect{case (k, v: mill.define.Module) => v}
+      items.collect { case (k, v: mill.define.Module) => v }
 
-  val items = for(c0 <- cases.toList) yield{
-    val c = c0 match{
+  val items = for (c0 <- cases.toList) yield {
+    val c = c0 match {
       case p: Product => p
-      case v => Tuple1(v)
+      case v          => Tuple1(v)
     }
     val crossValues = c.productIterator.toList
     val relPath = ctx.segment.pathSegments

--- a/core/src/mill/define/Ctx.scala
+++ b/core/src/mill/define/Ctx.scala
@@ -1,25 +1,23 @@
 package mill.define
 
-
 import ammonite.ops.Path
 
 import scala.annotation.implicitNotFound
 
-sealed trait Segment{
-  def pathSegments: Seq[String] = this match{
-    case Segment.Label(s) => List(s)
+sealed trait Segment {
+  def pathSegments: Seq[String] = this match {
+    case Segment.Label(s)  => List(s)
     case Segment.Cross(vs) => vs.map(_.toString)
   }
 }
-object Segment{
-  case class Label(value: String) extends Segment{
+object Segment {
+  case class Label(value: String) extends Segment {
     assert(!value.contains('.'))
   }
   case class Cross(value: Seq[Any]) extends Segment
 }
 
 case class BasePath(value: Path)
-
 
 /**
   * Models a path with the Mill build hierarchy, e.g.
@@ -29,24 +27,24 @@ case class BasePath(value: Path)
   * .-separated segments are [[Segment.Label]]s, while []-delimited
   * segments are [[Segment.Cross]]s
   */
-case class Segments(value: Segment*){
-  def ++(other: Seq[Segment]): Segments = Segments(value ++ other:_*)
-  def ++(other: Segments): Segments = Segments(value ++ other.value:_*)
+case class Segments(value: Segment*) {
+  def ++(other: Seq[Segment]): Segments = Segments(value ++ other: _*)
+  def ++(other: Segments): Segments = Segments(value ++ other.value: _*)
   def parts = value.toList match {
     case Nil => Nil
     case Segment.Label(head) :: rest =>
-      val stringSegments = rest.flatMap{
-        case Segment.Label(s) => Seq(s)
+      val stringSegments = rest.flatMap {
+        case Segment.Label(s)  => Seq(s)
         case Segment.Cross(vs) => vs.map(_.toString)
       }
       head +: stringSegments
   }
-  def last : Segments = Segments(value.last)
+  def last: Segments = Segments(value.last)
   def render = value.toList match {
     case Nil => ""
     case Segment.Label(head) :: rest =>
-      val stringSegments = rest.map{
-        case Segment.Label(s) => "." + s
+      val stringSegments = rest.map {
+        case Segment.Label(s)  => "." + s
         case Segment.Cross(vs) => "[" + vs.mkString(",") + "]"
       }
       head + stringSegments.mkString
@@ -55,12 +53,13 @@ case class Segments(value: Segment*){
 
 object Segments {
 
-  def labels(values : String*) : Segments =
-    Segments(values.map(Segment.Label):_*)
+  def labels(values: String*): Segments =
+    Segments(values.map(Segment.Label): _*)
 
 }
 
-@implicitNotFound("Modules, Targets and Commands can only be defined within a mill Module")
+@implicitNotFound(
+  "Modules, Targets and Commands can only be defined within a mill Module")
 case class Ctx(enclosing: String,
                lineNum: Int,
                segment: Segment,
@@ -69,12 +68,11 @@ case class Ctx(enclosing: String,
                overrides: Int,
                external: Boolean,
                foreign: Boolean,
-               fileName: String){
-}
+               fileName: String) {}
 
-object Ctx{
+object Ctx {
   case class External(value: Boolean)
-  case class Foreign(value : Boolean)
+  case class Foreign(value: Boolean)
   implicit def make(implicit millModuleEnclosing0: sourcecode.Enclosing,
                     millModuleLine0: sourcecode.Line,
                     millName0: sourcecode.Name,

--- a/core/src/mill/define/Graph.scala
+++ b/core/src/mill/define/Graph.scala
@@ -5,12 +5,13 @@ import mill.util.MultiBiMap
 import mill.util.Strict.Agg
 
 object Graph {
-  class TopoSorted private[Graph](val values: Agg[Task[_]])
-  def groupAroundImportantTargets[T](topoSortedTargets: TopoSorted)
-                                    (important: PartialFunction[Task[_], T]): MultiBiMap[T, Task[_]] = {
+  class TopoSorted private[Graph] (val values: Agg[Task[_]])
+  def groupAroundImportantTargets[T](topoSortedTargets: TopoSorted)(
+      important: PartialFunction[Task[_], T]): MultiBiMap[T, Task[_]] = {
 
     val output = new MultiBiMap.Mutable[T, Task[_]]()
-    for ((target, t) <- topoSortedTargets.values.flatMap(t => important.lift(t).map((t, _)))) {
+    for ((target, t) <- topoSortedTargets.values.flatMap(
+           t => important.lift(t).map((t, _)))) {
 
       val transitiveTargets = new Agg.Mutable[Task[_]]
       def rec(t: Task[_]): Unit = {
@@ -40,6 +41,7 @@ object Graph {
     sourceTargets.items.foreach(rec)
     transitiveTargets
   }
+
   /**
     * Takes the given targets, finds all the targets they transitively depend
     * on, and sort them topologically. Fails if there are dependency cycles
@@ -50,7 +52,7 @@ object Graph {
     val targetIndices = indexed.zipWithIndex.toMap
 
     val numberedEdges =
-      for(t <- transitiveTargets.items)
+      for (t <- transitiveTargets.items)
         yield t.inputs.collect(targetIndices)
 
     val sortedClusters = Tarjans(numberedEdges)

--- a/core/src/mill/eval/PathRef.scala
+++ b/core/src/mill/eval/PathRef.scala
@@ -10,17 +10,16 @@ import upickle.default.{ReadWriter => RW}
 import ammonite.ops.Path
 import mill.util.{DummyOutputStream, IO, JsonFormatters}
 
-
 /**
   * A wrapper around `ammonite.ops.Path` that calculates it's hashcode based
   * on the contents of the filesystem underneath it. Used to ensure filesystem
   * changes can bust caches which are keyed off hashcodes.
   */
-case class PathRef(path: ammonite.ops.Path, quick: Boolean, sig: Int){
+case class PathRef(path: ammonite.ops.Path, quick: Boolean, sig: Int) {
   override def hashCode() = sig
 }
 
-object PathRef{
+object PathRef {
   def apply(path: ammonite.ops.Path, quick: Boolean = false) = {
     val sig = {
       val digest = MessageDigest.getInstance("MD5")
@@ -37,13 +36,13 @@ object PathRef{
 
           def visitFile(file: jnio.Path, attrs: BasicFileAttributes) = {
             digest.update(file.toAbsolutePath.toString.getBytes)
-            if (quick){
+            if (quick) {
               val value = (path.mtime.toMillis, path.size).hashCode()
               digest.update((value >>> 24).toByte)
               digest.update((value >>> 16).toByte)
               digest.update((value >>> 8).toByte)
               digest.update(value.toByte)
-            }else {
+            } else {
               val is = jnio.Files.newInputStream(file)
               IO.stream(is, digestOut)
               is.close()
@@ -51,8 +50,10 @@ object PathRef{
             FileVisitResult.CONTINUE
           }
 
-          def visitFileFailed(file: jnio.Path, exc: IOException) = FileVisitResult.CONTINUE
-          def postVisitDirectory(dir: jnio.Path, exc: IOException) = FileVisitResult.CONTINUE
+          def visitFileFailed(file: jnio.Path, exc: IOException) =
+            FileVisitResult.CONTINUE
+          def postVisitDirectory(dir: jnio.Path, exc: IOException) =
+            FileVisitResult.CONTINUE
         }
       )
 
@@ -62,21 +63,27 @@ object PathRef{
     new PathRef(path, quick, sig)
   }
 
-  implicit def jsonFormatter: RW[PathRef] = upickle.default.readwriter[String].bimap[PathRef](
-    p => {
-      (if (p.quick) "qref" else "ref") + ":" +
-      String.format("%08x", p.sig: Integer) + ":" +
-      p.path.toString()
-    },
-    s => {
-      val Array(prefix, hex, path) = s.split(":", 3)
-      PathRef(
-        Path(path),
-        prefix match{ case "qref" => true case "ref" => false},
-        // Parsing to a long and casting to an int is the only way to make
-        // round-trip handling of negative numbers work =(
-        java.lang.Long.parseLong(hex, 16).toInt
+  implicit def jsonFormatter: RW[PathRef] =
+    upickle.default
+      .readwriter[String]
+      .bimap[PathRef](
+        p => {
+          (if (p.quick) "qref" else "ref") + ":" +
+            String.format("%08x", p.sig: Integer) + ":" +
+            p.path.toString()
+        },
+        s => {
+          val Array(prefix, hex, path) = s.split(":", 3)
+          PathRef(
+            Path(path),
+            prefix match {
+              case "qref" => true
+              case "ref"  => false
+            },
+            // Parsing to a long and casting to an int is the only way to make
+            // round-trip handling of negative numbers work =(
+            java.lang.Long.parseLong(hex, 16).toInt
+          )
+        }
       )
-    }
-  )
 }

--- a/core/src/mill/eval/Result.scala
+++ b/core/src/mill/eval/Result.scala
@@ -1,36 +1,41 @@
 package mill.eval
 
-sealed trait Result[+T]{
+sealed trait Result[+T] {
   def map[V](f: T => V): Result[V]
   def asSuccess: Option[Result.Success[T]] = None
 }
-object Result{
+object Result {
   implicit def create[T](t: => T): Result[T] = {
     try Success(t)
-    catch { case e: Throwable => Exception(e, new OuterStack(new java.lang.Exception().getStackTrace)) }
+    catch {
+      case e: Throwable =>
+        Exception(e, new OuterStack(new java.lang.Exception().getStackTrace))
+    }
   }
-  case class Success[+T](value: T) extends Result[T]{
+  case class Success[+T](value: T) extends Result[T] {
     def map[V](f: T => V) = Result.Success(f(value))
     override def asSuccess = Some(this)
   }
-  case object Skipped extends Result[Nothing]{
+  case object Skipped extends Result[Nothing] {
     def map[V](f: Nothing => V) = this
   }
-  sealed trait Failing[+T] extends Result[T]{
+  sealed trait Failing[+T] extends Result[T] {
     def map[V](f: T => V): Failing[V]
   }
-  case class Failure[T](msg: String, value: Option[T] = None) extends Failing[T]{
+  case class Failure[T](msg: String, value: Option[T] = None)
+      extends Failing[T] {
     def map[V](f: T => V) = Result.Failure(msg, value.map(f(_)))
   }
-  case class Exception(throwable: Throwable, outerStack: OuterStack) extends Failing[Nothing]{
+  case class Exception(throwable: Throwable, outerStack: OuterStack)
+      extends Failing[Nothing] {
     def map[V](f: Nothing => V) = this
   }
-  class OuterStack(val value: Seq[StackTraceElement]){
+  class OuterStack(val value: Seq[StackTraceElement]) {
     override def hashCode() = value.hashCode()
 
-    override def equals(obj: scala.Any) = obj match{
+    override def equals(obj: scala.Any) = obj match {
       case o: OuterStack => value.equals(o.value)
-      case _ => false
+      case _             => false
     }
   }
 }

--- a/core/src/mill/eval/Tarjans.scala
+++ b/core/src/mill/eval/Tarjans.scala
@@ -14,7 +14,6 @@ object Tarjans {
     val lowlink = new Array[Int](n)
     val components = mutable.ArrayBuffer.empty[Seq[Int]]
 
-
     for (u <- 0 until n) {
       if (!visited(u)) dfs(u)
     }

--- a/core/src/mill/util/AggWrapper.scala
+++ b/core/src/mill/util/AggWrapper.scala
@@ -1,17 +1,16 @@
 package mill.util
 
-
-
 import scala.collection.mutable
 object Strict extends AggWrapper(true)
 object Loose extends AggWrapper(false)
-sealed class AggWrapper(strictUniqueness: Boolean){
+sealed class AggWrapper(strictUniqueness: Boolean) {
+
   /**
     * A collection with enforced uniqueness, fast contains and deterministic
     * ordering. Raises an exception if a duplicate is found; call
     * `toSeq.distinct` if you explicitly want to make it swallow duplicates
     */
-  trait Agg[V] extends TraversableOnce[V]{
+  trait Agg[V] extends TraversableOnce[V] {
     def contains(v: V): Boolean
     def items: Iterator[V]
     def indexed: IndexedSeq[V]
@@ -27,13 +26,16 @@ sealed class AggWrapper(strictUniqueness: Boolean){
     def length: Int
   }
 
-  object Agg{
+  object Agg {
     def empty[V]: Agg[V] = new Agg.Mutable[V]
-    implicit def jsonFormat[T: upickle.default.ReadWriter]: upickle.default.ReadWriter[Agg[T]] =
-      upickle.default.readwriter[Seq[T]].bimap[Agg[T]](
-        _.toList,
-        Agg.from(_)
-      )
+    implicit def jsonFormat[T: upickle.default.ReadWriter]
+      : upickle.default.ReadWriter[Agg[T]] =
+      upickle.default
+        .readwriter[Seq[T]]
+        .bimap[Agg[T]](
+          _.toList,
+          Agg.from(_)
+        )
 
     def apply[V](items: V*) = from(items)
 
@@ -43,17 +45,17 @@ sealed class AggWrapper(strictUniqueness: Boolean){
       set
     }
 
-
-    class Mutable[V]() extends Agg[V]{
+    class Mutable[V]() extends Agg[V] {
 
       private[this] val set0 = mutable.LinkedHashSet.empty[V]
       def contains(v: V) = set0.contains(v)
-      def append(v: V) = if (!contains(v)){
-        set0.add(v)
+      def append(v: V) =
+        if (!contains(v)) {
+          set0.add(v)
 
-      }else if (strictUniqueness){
-        throw new Exception("Duplicated item inserted into OrderedSet: " + v)
-      }
+        } else if (strictUniqueness) {
+          throw new Exception("Duplicated item inserted into OrderedSet: " + v)
+        }
       def appendAll(vs: Seq[V]) = vs.foreach(append)
       def items = set0.iterator
       def indexed: IndexedSeq[V] = items.toIndexedSeq
@@ -61,28 +63,29 @@ sealed class AggWrapper(strictUniqueness: Boolean){
 
       def map[T](f: V => T): Agg[T] = {
         val output = new Agg.Mutable[T]
-        for(i <- items) output.append(f(i))
+        for (i <- items) output.append(f(i))
         output
       }
       def flatMap[T](f: V => TraversableOnce[T]): Agg[T] = {
         val output = new Agg.Mutable[T]
-        for(i <- items) for(i0 <- f(i)) output.append(i0)
+        for (i <- items) for (i0 <- f(i)) output.append(i0)
         output
       }
       def filter(f: V => Boolean): Agg[V] = {
         val output = new Agg.Mutable[V]
-        for(i <- items) if (f(i)) output.append(i)
+        for (i <- items) if (f(i)) output.append(i)
         output
       }
       def withFilter(f: V => Boolean): Agg[V] = filter(f)
 
-      def collect[T](f: PartialFunction[V, T]) = this.filter(f.isDefinedAt).map(x => f(x))
+      def collect[T](f: PartialFunction[V, T]) =
+        this.filter(f.isDefinedAt).map(x => f(x))
 
       def zipWithIndex = {
         var i = 0
-        this.map{ x =>
+        this.map { x =>
           i += 1
-          (x, i-1)
+          (x, i - 1)
         }
       }
 
@@ -98,7 +101,8 @@ sealed class AggWrapper(strictUniqueness: Boolean){
       def toStream: Stream[V] = items.toStream
 
       // Members declared in scala.collection.TraversableOnce
-      def copyToArray[B >: V](xs: Array[B], start: Int,len: Int): Unit = items.copyToArray(xs, start, len)
+      def copyToArray[B >: V](xs: Array[B], start: Int, len: Int): Unit =
+        items.copyToArray(xs, start, len)
       def exists(p: V => Boolean): Boolean = items.exists(p)
       def find(p: V => Boolean): Option[V] = items.find(p)
       def forall(p: V => Boolean): Boolean = items.forall(p)
@@ -109,9 +113,9 @@ sealed class AggWrapper(strictUniqueness: Boolean){
       def toTraversable: Traversable[V] = items.toTraversable
 
       override def hashCode() = items.map(_.hashCode()).sum
-      override def equals(other: Any) = other match{
+      override def equals(other: Any) = other match {
         case s: Agg[_] => items.sameElements(s.items)
-        case _ => super.equals(other)
+        case _         => super.equals(other)
       }
       override def toString = items.mkString("Agg(", ", ", ")")
     }

--- a/core/src/mill/util/ClassLoader.scala
+++ b/core/src/mill/util/ClassLoader.scala
@@ -14,7 +14,8 @@ object ClassLoader {
       refinePlatformParent(parent)
     ) {
       override def findClass(name: String): Class[_] = {
-        if (name.startsWith("com.sun.jna")) getClass.getClassLoader.loadClass(name)
+        if (name.startsWith("com.sun.jna"))
+          getClass.getClassLoader.loadClass(name)
         else super.findClass(name)
       }
     }
@@ -29,7 +30,8 @@ object ClassLoader {
       refinePlatformParent(parent)
     ) {
       override def findClass(name: String): Class[_] = {
-        if (name.startsWith("com.sun.jna")) getClass.getClassLoader.loadClass(name)
+        if (name.startsWith("com.sun.jna"))
+          getClass.getClassLoader.loadClass(name)
         else customFindClass(name).getOrElse(super.findClass(name))
       }
     }
@@ -43,7 +45,8 @@ object ClassLoader {
     *  `ClassLoader.getPlatformClassLoader` call is implemented via runtime reflection, cause otherwise
     *  mill could be compiled only with jdk 9 or above. We don't want to introduce this restriction now.
     */
-  private def refinePlatformParent(parent: java.lang.ClassLoader): ClassLoader = {
+  private def refinePlatformParent(
+      parent: java.lang.ClassLoader): ClassLoader = {
     if (ammonite.util.Util.java9OrAbove) {
       if (parent == null)
         classOf[ClassLoader]

--- a/core/src/mill/util/Ctx.scala
+++ b/core/src/mill/util/Ctx.scala
@@ -6,7 +6,7 @@ import mill.define.Applicative.ImplicitStub
 import scala.annotation.compileTimeOnly
 import scala.language.implicitConversions
 
-object Ctx{
+object Ctx {
   @compileTimeOnly("Target.ctx() can only be used with a T{...} block")
   @ImplicitStub
   implicit def taskCtx: Ctx = ???
@@ -14,22 +14,22 @@ object Ctx{
   object Dest {
     implicit def pathToCtx(path: Path): Dest = new Dest { def dest = path }
   }
-  trait Dest{
+  trait Dest {
     def dest: Path
   }
-  trait Log{
+  trait Log {
     def log: Logger
   }
-  trait Home{
+  trait Home {
     def home: Path
   }
-  trait Env{
+  trait Env {
     def env: Map[String, String]
   }
-  object Log{
+  object Log {
     implicit def logToCtx(l: Logger): Log = new Log { def log = l }
   }
-  trait Args{
+  trait Args {
     def args: IndexedSeq[_]
   }
 
@@ -40,17 +40,19 @@ class Ctx(val args: IndexedSeq[_],
           dest0: () => Path,
           val log: Logger,
           val home: Path,
-          val env : Map[String, String])
-  extends Ctx.Dest
-  with Ctx.Log
-  with Ctx.Args
-  with Ctx.Home
-  with Ctx.Env {
+          val env: Map[String, String])
+    extends Ctx.Dest
+    with Ctx.Log
+    with Ctx.Args
+    with Ctx.Home
+    with Ctx.Env {
 
   def dest = dest0()
   def length = args.length
   def apply[T](index: Int): T = {
     if (index >= 0 && index < args.length) args(index).asInstanceOf[T]
-    else throw new IndexOutOfBoundsException(s"Index $index outside of range 0 - ${args.length}")
+    else
+      throw new IndexOutOfBoundsException(
+        s"Index $index outside of range 0 - ${args.length}")
   }
 }

--- a/core/src/mill/util/EnclosingClass.scala
+++ b/core/src/mill/util/EnclosingClass.scala
@@ -3,7 +3,7 @@ package mill.util
 import sourcecode.Compat.Context
 import language.experimental.macros
 case class EnclosingClass(value: Class[_])
-object EnclosingClass{
+object EnclosingClass {
   def apply()(implicit c: EnclosingClass) = c.value
   implicit def generate: EnclosingClass = macro impl
   def impl(c: Context): c.Tree = {

--- a/core/src/mill/util/IO.scala
+++ b/core/src/mill/util/IO.scala
@@ -11,7 +11,7 @@ import scala.tools.nsc.interpreter.OutputStream
 object IO {
   def stream(src: InputStream, dest: OutputStream) = {
     val buffer = new Array[Byte](4096)
-    while ( {
+    while ({
       src.read(buffer) match {
         case -1 => false
         case n =>
@@ -25,7 +25,7 @@ object IO {
 import java.io.{ByteArrayInputStream, OutputStream}
 
 object DummyInputStream extends ByteArrayInputStream(Array())
-object DummyOutputStream extends OutputStream{
+object DummyOutputStream extends OutputStream {
   override def write(b: Int) = ()
   override def write(b: Array[Byte]) = ()
   override def write(b: Array[Byte], off: Int, len: Int) = ()

--- a/core/src/mill/util/JsonFormatters.scala
+++ b/core/src/mill/util/JsonFormatters.scala
@@ -5,40 +5,45 @@ import upickle.Js
 import upickle.default.{ReadWriter => RW}
 object JsonFormatters extends JsonFormatters
 trait JsonFormatters {
-  implicit val pathReadWrite: RW[ammonite.ops.Path] = upickle.default.readwriter[String]
+  implicit val pathReadWrite: RW[ammonite.ops.Path] = upickle.default
+    .readwriter[String]
     .bimap[ammonite.ops.Path](
       _.toString,
       Path(_)
     )
 
-  implicit val bytesReadWrite: RW[Bytes] = upickle.default.readwriter[String]
+  implicit val bytesReadWrite: RW[Bytes] = upickle.default
+    .readwriter[String]
     .bimap(
       o => javax.xml.bind.DatatypeConverter.printBase64Binary(o.array),
       str => new Bytes(javax.xml.bind.DatatypeConverter.parseBase64Binary(str))
     )
 
-
-  implicit lazy val crFormat: RW[ammonite.ops.CommandResult] = upickle.default.macroRW
+  implicit lazy val crFormat: RW[ammonite.ops.CommandResult] =
+    upickle.default.macroRW
 
   implicit lazy val modFormat: RW[coursier.Module] = upickle.default.macroRW
-  implicit lazy val depFormat: RW[coursier.Dependency]= upickle.default.macroRW
-  implicit lazy val attrFormat: RW[coursier.Attributes] = upickle.default.macroRW
-  implicit val stackTraceRW = upickle.default.readwriter[Js.Obj].bimap[StackTraceElement](
-    ste => Js.Obj(
-      "declaringClass" -> Js.Str(ste.getClassName),
-      "methodName" -> Js.Str(ste.getMethodName),
-      "fileName" -> Js.Str(ste.getFileName),
-      "lineNumber" -> Js.Num(ste.getLineNumber)
-    ),
-    {case json: Js.Obj =>
-      new StackTraceElement(
-        json("declaringClass").str.toString,
-        json("methodName").str.toString,
-        json("fileName").str.toString,
-        json("lineNumber").num.toInt
-      )
-    }
-  )
-
+  implicit lazy val depFormat: RW[coursier.Dependency] = upickle.default.macroRW
+  implicit lazy val attrFormat: RW[coursier.Attributes] =
+    upickle.default.macroRW
+  implicit val stackTraceRW = upickle.default
+    .readwriter[Js.Obj]
+    .bimap[StackTraceElement](
+      ste =>
+        Js.Obj(
+          "declaringClass" -> Js.Str(ste.getClassName),
+          "methodName" -> Js.Str(ste.getMethodName),
+          "fileName" -> Js.Str(ste.getFileName),
+          "lineNumber" -> Js.Num(ste.getLineNumber)
+      ), {
+        case json: Js.Obj =>
+          new StackTraceElement(
+            json("declaringClass").str.toString,
+            json("methodName").str.toString,
+            json("fileName").str.toString,
+            json("lineNumber").num.toInt
+          )
+      }
+    )
 
 }

--- a/core/src/mill/util/MultiBiMap.scala
+++ b/core/src/mill/util/MultiBiMap.scala
@@ -2,12 +2,13 @@ package mill.util
 
 import scala.collection.mutable
 import Strict.Agg
+
 /**
   * A map from keys to collections of values: you can assign multiple values
   * to any particular key. Also allows lookups in both directions: what values
   * are assigned to a key or what key a value is assigned ti.
   */
-trait MultiBiMap[K, V]{
+trait MultiBiMap[K, V] {
   def containsValue(v: V): Boolean
   def lookupKey(k: K): Agg[V]
   def lookupValue(v: V): K
@@ -21,10 +22,11 @@ trait MultiBiMap[K, V]{
   def keyCount: Int
 }
 
-object MultiBiMap{
-  class Mutable[K, V]() extends MultiBiMap[K, V]{
+object MultiBiMap {
+  class Mutable[K, V]() extends MultiBiMap[K, V] {
     private[this] val valueToKey = mutable.LinkedHashMap.empty[V, K]
-    private[this] val keyToValues = mutable.LinkedHashMap.empty[K, Agg.Mutable[V]]
+    private[this] val keyToValues =
+      mutable.LinkedHashMap.empty[K, Agg.Mutable[V]]
     def containsValue(v: V) = valueToKey.contains(v)
     def lookupKey(k: K) = keyToValues(k)
     def lookupKeyOpt(k: K) = keyToValues.get(k)

--- a/core/src/mill/util/ParseArgs.scala
+++ b/core/src/mill/util/ParseArgs.scala
@@ -5,8 +5,8 @@ import mill.define.{Segment, Segments}
 
 object ParseArgs {
 
-  def apply(scriptArgs: Seq[String],
-            multiSelect: Boolean): Either[String, (List[(Option[Segments], Segments)], Seq[String])] = {
+  def apply(scriptArgs: Seq[String], multiSelect: Boolean)
+    : Either[String, (List[(Option[Segments], Segments)], Seq[String])] = {
     val (selectors, args) = extractSelsAndArgs(scriptArgs, multiSelect)
     for {
       _ <- validateSelectors(selectors)
@@ -31,7 +31,8 @@ object ParseArgs {
     }
   }
 
-  private def validateSelectors(selectors: Seq[String]): Either[String, Unit] = {
+  private def validateSelectors(
+      selectors: Seq[String]): Either[String, Unit] = {
     if (selectors.isEmpty || selectors.exists(_.isEmpty))
       Left("Selector cannot be empty")
     else Right(())
@@ -106,23 +107,26 @@ object ParseArgs {
       .parse(input)
   }
 
-  def extractSegments(selectorString: String): Either[String, (Option[Segments], Segments)] =
+  def extractSegments(
+      selectorString: String): Either[String, (Option[Segments], Segments)] =
     parseSelector(selectorString) match {
       case f: Parsed.Failure           => Left(s"Parsing exception ${f.msg}")
       case Parsed.Success(selector, _) => Right(selector)
     }
 
   private def parseSelector(input: String) = {
-    val identChars = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ Seq('_', '-')
-    val ident = P( CharsWhileIn(identChars) ).!
-    val ident2 = P( CharsWhileIn(identChars ++ ".") ).!
-    val segment = P( ident ).map( Segment.Label)
-    val crossSegment = P("[" ~ ident2.rep(1, sep = ",") ~ "]").map(Segment.Cross)
+    val identChars = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ Seq('_',
+                                                                         '-')
+    val ident = P(CharsWhileIn(identChars)).!
+    val ident2 = P(CharsWhileIn(identChars ++ ".")).!
+    val segment = P(ident).map(Segment.Label)
+    val crossSegment =
+      P("[" ~ ident2.rep(1, sep = ",") ~ "]").map(Segment.Cross)
     val simpleQuery = P(segment ~ ("." ~ segment | crossSegment).rep).map {
-      case (h, rest) => Segments(h :: rest.toList:_*)
+      case (h, rest) => Segments(h :: rest.toList: _*)
     }
-    val query = P( simpleQuery ~ ("/" ~/ simpleQuery).?).map{
-      case (q, None) => (None, q)
+    val query = P(simpleQuery ~ ("/" ~/ simpleQuery).?).map {
+      case (q, None)     => (None, q)
       case (q, Some(q2)) => (Some(q), q2)
     }
     query.parse(input)

--- a/core/src/mill/util/Router.scala
+++ b/core/src/mill/util/Router.scala
@@ -14,12 +14,13 @@ import scala.reflect.macros.blackbox.Context
   * generate/compile code or use Scala reflection. This saves us spinning up
   * the Scala compiler and greatly reduces the startup time of cached scripts.
   */
-object Router{
+object Router {
+
   /**
     * Allows you to query how many things are overriden by the enclosing owner.
     */
   case class Overrides(value: Int)
-  object Overrides{
+  object Overrides {
     def apply()(implicit c: Overrides) = c.value
     implicit def generate: Overrides = macro impl
     def impl(c: Context): c.Tree = {
@@ -31,12 +32,15 @@ object Router{
   class doc(s: String) extends StaticAnnotation
   class main extends StaticAnnotation
   def generateRoutes[T]: Seq[Router.EntryPoint[T]] = macro generateRoutesImpl[T]
-  def generateRoutesImpl[T: c.WeakTypeTag](c: Context): c.Expr[Seq[EntryPoint[T]]] = {
+  def generateRoutesImpl[T: c.WeakTypeTag](
+      c: Context): c.Expr[Seq[EntryPoint[T]]] = {
     import c.universe._
     val r = new Router(c)
-    val allRoutes = r.getAllRoutesForClass(
-      weakTypeOf[T].asInstanceOf[r.c.Type]
-    ).asInstanceOf[Iterable[c.Tree]]
+    val allRoutes = r
+      .getAllRoutesForClass(
+        weakTypeOf[T].asInstanceOf[r.c.Type]
+      )
+      .asInstanceOf[Iterable[c.Tree]]
 
     c.Expr[Seq[EntryPoint[T]]](q"_root_.scala.Seq(..$allRoutes)")
   }
@@ -47,17 +51,18 @@ object Router{
     * (just for logging and reading, not a replacement for a `TypeTag`) and
     * possible a function that can compute its default value
     */
-  case class ArgSig[T, V](name: String,
-                          typeString: String,
-                          doc: Option[String],
-                          default: Option[T => V])
-                         (implicit val reads: scopt.Read[V])
+  case class ArgSig[T, V](
+      name: String,
+      typeString: String,
+      doc: Option[String],
+      default: Option[T => V])(implicit val reads: scopt.Read[V])
 
   def stripDashes(s: String) = {
     if (s.startsWith("--")) s.drop(2)
     else if (s.startsWith("-")) s.drop(1)
     else s
   }
+
   /**
     * What is known about a single endpoint for our routes. It has a [[name]],
     * [[argSignatures]] for each argument, and a macro-generated [[invoke0]]
@@ -67,52 +72,60 @@ object Router{
     * instead, which provides a nicer API to call it that mimmicks the API of
     * calling a Scala method.
     */
-  case class EntryPoint[T](name: String,
-                           argSignatures: Seq[ArgSig[T, _]],
-                           doc: Option[String],
-                           varargs: Boolean,
-                           invoke0: (T, Map[String, String], Seq[String]) => Result[Any],
-                           overrides: Int){
-    def invoke(target: T, groupedArgs: Seq[(String, Option[String])]): Result[Any] = {
-      var remainingArgSignatures = argSignatures.toList.filter(_.reads.arity > 0)
+  case class EntryPoint[T](
+      name: String,
+      argSignatures: Seq[ArgSig[T, _]],
+      doc: Option[String],
+      varargs: Boolean,
+      invoke0: (T, Map[String, String], Seq[String]) => Result[Any],
+      overrides: Int) {
+    def invoke(target: T,
+               groupedArgs: Seq[(String, Option[String])]): Result[Any] = {
+      var remainingArgSignatures =
+        argSignatures.toList.filter(_.reads.arity > 0)
 
-      val accumulatedKeywords = mutable.Map.empty[ArgSig[T, _], mutable.Buffer[String]]
-      val keywordableArgs = if (varargs) argSignatures.dropRight(1) else argSignatures
+      val accumulatedKeywords =
+        mutable.Map.empty[ArgSig[T, _], mutable.Buffer[String]]
+      val keywordableArgs =
+        if (varargs) argSignatures.dropRight(1) else argSignatures
 
-      for(arg <- keywordableArgs) accumulatedKeywords(arg) = mutable.Buffer.empty
+      for (arg <- keywordableArgs)
+        accumulatedKeywords(arg) = mutable.Buffer.empty
 
       val leftoverArgs = mutable.Buffer.empty[String]
 
-      val lookupArgSig = Map(argSignatures.map(x => (x.name, x)):_*)
+      val lookupArgSig = Map(argSignatures.map(x => (x.name, x)): _*)
 
       var incomplete: Option[ArgSig[T, _]] = None
 
-      for(group <- groupedArgs){
+      for (group <- groupedArgs) {
 
-        group match{
+        group match {
           case (value, None) =>
-            if (value(0) == '-' && !varargs){
-              lookupArgSig.get(stripDashes(value)) match{
-                case None => leftoverArgs.append(value)
+            if (value(0) == '-' && !varargs) {
+              lookupArgSig.get(stripDashes(value)) match {
+                case None      => leftoverArgs.append(value)
                 case Some(sig) => incomplete = Some(sig)
               }
 
-            } else remainingArgSignatures match {
-              case Nil => leftoverArgs.append(value)
-              case last :: Nil if varargs => leftoverArgs.append(value)
-              case next :: rest =>
-                accumulatedKeywords(next).append(value)
-                remainingArgSignatures = rest
-            }
+            } else
+              remainingArgSignatures match {
+                case Nil                    => leftoverArgs.append(value)
+                case last :: Nil if varargs => leftoverArgs.append(value)
+                case next :: rest =>
+                  accumulatedKeywords(next).append(value)
+                  remainingArgSignatures = rest
+              }
           case (rawKey, Some(value)) =>
             val key = stripDashes(rawKey)
-            lookupArgSig.get(key) match{
+            lookupArgSig.get(key) match {
               case Some(x) if accumulatedKeywords.contains(x) =>
-                if (accumulatedKeywords(x).nonEmpty && varargs){
+                if (accumulatedKeywords(x).nonEmpty && varargs) {
                   leftoverArgs.append(rawKey, value)
-                }else{
+                } else {
                   accumulatedKeywords(x).append(value)
-                  remainingArgSignatures = remainingArgSignatures.filter(_.name != key)
+                  remainingArgSignatures =
+                    remainingArgSignatures.filter(_.name != key)
                 }
               case _ =>
                 leftoverArgs.append(rawKey, value)
@@ -123,35 +136,32 @@ object Router{
       val missing0 = remainingArgSignatures
         .filter(_.default.isEmpty)
 
-      val missing = if(varargs) {
+      val missing = if (varargs) {
         missing0.filter(_ != argSignatures.last)
       } else {
         missing0.filter(x => incomplete != Some(x))
       }
       val duplicates = accumulatedKeywords.toSeq.filter(_._2.length > 1)
 
-      if (
-        incomplete.nonEmpty ||
+      if (incomplete.nonEmpty ||
           missing.nonEmpty ||
           duplicates.nonEmpty ||
-          (leftoverArgs.nonEmpty && !varargs)
-      ){
+          (leftoverArgs.nonEmpty && !varargs)) {
         Result.Error.MismatchedArguments(
           missing = missing,
           unknown = leftoverArgs,
           duplicate = duplicates,
           incomplete = incomplete
-
         )
       } else {
-        val mapping = accumulatedKeywords
-          .iterator
-          .collect{case (k, Seq(single)) => (k.name, single)}
-          .toMap
+        val mapping = accumulatedKeywords.iterator.collect {
+          case (k, Seq(single)) => (k.name, single)
+        }.toMap
 
         try invoke0(target, mapping, leftoverArgs)
-        catch{case e: Throwable =>
-          Result.Error.Exception(e)
+        catch {
+          case e: Throwable =>
+            Result.Error.Exception(e)
         }
       }
     }
@@ -159,34 +169,36 @@ object Router{
 
   def tryEither[T](t: => T, error: Throwable => Result.ParamError) = {
     try Right(t)
-    catch{ case e: Throwable => Left(error(e))}
+    catch { case e: Throwable => Left(error(e)) }
   }
   def readVarargs(arg: ArgSig[_, _],
                   values: Seq[String],
                   thunk: String => Any) = {
     val attempts =
-      for(item <- values)
+      for (item <- values)
         yield tryEither(thunk(item), Result.ParamError.Invalid(arg, item, _))
 
-
-    val bad = attempts.collect{ case Left(x) => x}
+    val bad = attempts.collect { case Left(x) => x }
     if (bad.nonEmpty) Left(bad)
-    else Right(attempts.collect{case Right(x) => x})
+    else Right(attempts.collect { case Right(x) => x })
   }
   def read(dict: Map[String, String],
            default: => Option[Any],
            arg: ArgSig[_, _],
            thunk: String => Any): FailMaybe = {
-    arg.reads.arity match{
+    arg.reads.arity match {
       case 0 =>
-        tryEither(thunk(null), Result.ParamError.DefaultFailed(arg, _)).left.map(Seq(_))
+        tryEither(thunk(null), Result.ParamError.DefaultFailed(arg, _)).left
+          .map(Seq(_))
       case 1 =>
-        dict.get(arg.name) match{
+        dict.get(arg.name) match {
           case None =>
-            tryEither(default.get, Result.ParamError.DefaultFailed(arg, _)).left.map(Seq(_))
+            tryEither(default.get, Result.ParamError.DefaultFailed(arg, _)).left
+              .map(Seq(_))
 
           case Some(x) =>
-            tryEither(thunk(x), Result.ParamError.Invalid(arg, x, _)).left.map(Seq(_))
+            tryEither(thunk(x), Result.ParamError.Invalid(arg, x, _)).left
+              .map(Seq(_))
         }
     }
 
@@ -197,7 +209,7 @@ object Router{
     * Could succeed with a value, but could fail in many different ways.
     */
   sealed trait Result[+T]
-  object Result{
+  object Result {
 
     /**
       * Invoking the [[EntryPoint]] was totally successful, and returned a
@@ -209,7 +221,7 @@ object Router{
       * Invoking the [[EntryPoint]] was not successful
       */
     sealed trait Error extends Result[Nothing]
-    object Error{
+    object Error {
 
       /**
         * Invoking the [[EntryPoint]] failed with an exception while executing
@@ -221,10 +233,13 @@ object Router{
         * Invoking the [[EntryPoint]] failed because the arguments provided
         * did not line up with the arguments expected
         */
-      case class MismatchedArguments(missing: Seq[ArgSig[_, _]],
-                                     unknown: Seq[String],
-                                     duplicate: Seq[(ArgSig[_, _], Seq[String])],
-                                     incomplete: Option[ArgSig[_, _]]) extends Error
+      case class MismatchedArguments(
+          missing: Seq[ArgSig[_, _]],
+          unknown: Seq[String],
+          duplicate: Seq[(ArgSig[_, _], Seq[String])],
+          incomplete: Option[ArgSig[_, _]])
+          extends Error
+
       /**
         * Invoking the [[EntryPoint]] failed because there were problems
         * deserializing/parsing individual arguments
@@ -233,30 +248,33 @@ object Router{
     }
 
     sealed trait ParamError
-    object ParamError{
+    object ParamError {
+
       /**
         * Something went wrong trying to de-serialize the input parameter;
         * the thrown exception is stored in [[ex]]
         */
-      case class Invalid(arg: ArgSig[_, _], value: String, ex: Throwable) extends ParamError
+      case class Invalid(arg: ArgSig[_, _], value: String, ex: Throwable)
+          extends ParamError
+
       /**
         * Something went wrong trying to evaluate the default value
         * for this input parameter
         */
-      case class DefaultFailed(arg: ArgSig[_, _], ex: Throwable) extends ParamError
+      case class DefaultFailed(arg: ArgSig[_, _], ex: Throwable)
+          extends ParamError
     }
   }
-
 
   type FailMaybe = Either[Seq[Result.ParamError], Any]
   type FailAll = Either[Seq[Result.ParamError], Seq[Any]]
 
   def validate(args: Seq[FailMaybe]): Result[Seq[Any]] = {
-    val lefts = args.collect{case Left(x) => x}.flatten
+    val lefts = args.collect { case Left(x) => x }.flatten
 
     if (lefts.nonEmpty) Result.Error.InvalidArguments(lefts)
     else {
-      val rights = args.collect{case Right(x) => x}
+      val rights = args.collect { case Right(x) => x }
       Result.Success(rights)
     }
   }
@@ -271,8 +289,7 @@ object Router{
   }
 }
 
-
-class Router [C <: Context](val c: C) {
+class Router[C <: Context](val c: C) {
   import c.universe._
   def getValsOrMeths(curCls: Type): Iterable[MethodSymbol] = {
     def isAMemberOfAnyRef(member: Symbol) = {
@@ -291,36 +308,39 @@ class Router [C <: Context](val c: C) {
       if !memTerm.isModule
     } yield memTerm.asMethod
 
-    extractableMembers flatMap { case memTerm =>
-      if (memTerm.isSetter || memTerm.isConstructor || memTerm.isGetter) Nil
-      else Seq(memTerm)
+    extractableMembers flatMap {
+      case memTerm =>
+        if (memTerm.isSetter || memTerm.isConstructor || memTerm.isGetter) Nil
+        else Seq(memTerm)
 
     }
   }
 
-
-
-  def extractMethod(meth: MethodSymbol, curCls: c.universe.Type): c.universe.Tree = {
+  def extractMethod(meth: MethodSymbol,
+                    curCls: c.universe.Type): c.universe.Tree = {
     val baseArgSym = TermName(c.freshName())
     val flattenedArgLists = meth.paramss.flatten
     def hasDefault(i: Int) = {
       val defaultName = s"${meth.name}$$default$$${i + 1}"
-      if (curCls.members.exists(_.name.toString == defaultName)) Some(defaultName)
+      if (curCls.members.exists(_.name.toString == defaultName))
+        Some(defaultName)
       else None
     }
     val argListSymbol = q"${c.fresh[TermName]("argsList")}"
     val extrasSymbol = q"${c.fresh[TermName]("extras")}"
     val defaults = for ((arg, i) <- flattenedArgLists.zipWithIndex) yield {
       val arg = TermName(c.freshName())
-      hasDefault(i).map(defaultName => q"($arg: $curCls) => $arg.${newTermName(defaultName)}")
+      hasDefault(i).map(defaultName =>
+        q"($arg: $curCls) => $arg.${newTermName(defaultName)}")
     }
 
     def getDocAnnotation(annotations: List[Annotation]) = {
-      val (docTrees, remaining) = annotations.partition(_.tpe =:= typeOf[Router.doc])
+      val (docTrees, remaining) =
+        annotations.partition(_.tpe =:= typeOf[Router.doc])
       val docValues = for {
         doc <- docTrees
         if doc.scalaArgs.head.isInstanceOf[Literal]
-        l =  doc.scalaArgs.head.asInstanceOf[Literal]
+        l = doc.scalaArgs.head.asInstanceOf[Literal]
         if l.value.value.isInstanceOf[String]
       } yield l.value.value.asInstanceOf[String]
       (remaining, docValues.headOption)
@@ -335,24 +355,23 @@ class Router [C <: Context](val c: C) {
       (vararg, unwrappedType)
     }
 
-
     val (_, methodDoc) = getDocAnnotation(meth.annotations)
-    val readArgSigs = for(
-      ((arg, defaultOpt), i) <- flattenedArgLists.zip(defaults).zipWithIndex
-    ) yield {
+    val readArgSigs = for (((arg, defaultOpt), i) <- flattenedArgLists
+                             .zip(defaults)
+                             .zipWithIndex) yield {
 
       val (vararg, varargUnwrappedType) = unwrapVarargType(arg)
 
       val default =
         if (vararg) q"scala.Some(scala.Nil)"
-        else defaultOpt match {
-          case Some(defaultExpr) => q"scala.Some($defaultExpr($baseArgSym))"
-          case None => q"scala.None"
-        }
+        else
+          defaultOpt match {
+            case Some(defaultExpr) => q"scala.Some($defaultExpr($baseArgSym))"
+            case None              => q"scala.None"
+          }
 
-      val (docUnwrappedType, docOpt) = varargUnwrappedType match{
+      val (docUnwrappedType, docOpt) = varargUnwrappedType match {
         case t: AnnotatedType =>
-
           val (remaining, docValue) = getDocAnnotation(t.annotations)
           if (remaining.isEmpty) (t.underlying, docValue)
           else (Compat.copyAnnotatedType(c)(t, remaining), docValue)
@@ -360,22 +379,22 @@ class Router [C <: Context](val c: C) {
         case t => (t, None)
       }
 
-      val docTree = docOpt match{
-        case None => q"scala.None"
+      val docTree = docOpt match {
+        case None    => q"scala.None"
         case Some(s) => q"scala.Some($s)"
       }
 
       val argSig = q"""
         mill.util.Router.ArgSig[$curCls, $docUnwrappedType](
           ${arg.name.toString},
-          ${docUnwrappedType.toString + (if(vararg) "*" else "")},
+          ${docUnwrappedType.toString + (if (vararg) "*" else "")},
           $docTree,
           $defaultOpt
         )
       """
 
       val reader =
-        if(vararg) q"""
+        if (vararg) q"""
           mill.util.Router.makeReadVarargsCall(
             $argSig,
             $extrasSymbol
@@ -398,17 +417,15 @@ class Router [C <: Context](val c: C) {
         pq"${arg.name.toTermName}",
         if (!vararg) q"${arg.name.toTermName}.asInstanceOf[$unwrappedType]"
         else q"${arg.name.toTermName}.asInstanceOf[Seq[$unwrappedType]]: _*"
-
       )
     }.unzip
-
 
     val res = q"""
     mill.util.Router.EntryPoint[$curCls](
       ${meth.name.toString},
       scala.Seq(..$argSigs),
-      ${methodDoc match{
-      case None => q"scala.None"
+      ${methodDoc match {
+      case None    => q"scala.None"
       case Some(s) => q"scala.Some($s)"
     }},
       ${varargs.contains(true)},
@@ -431,8 +448,8 @@ class Router [C <: Context](val c: C) {
   }
   def getAllRoutesForClass(curCls: Type,
                            pred: MethodSymbol => Boolean = hasMainAnnotation)
-  : Iterable[c.universe.Tree] = {
-    for{
+    : Iterable[c.universe.Tree] = {
+    for {
       t <- getValsOrMeths(curCls)
       if pred(t)
     } yield {

--- a/core/src/mill/util/Watched.scala
+++ b/core/src/mill/util/Watched.scala
@@ -3,6 +3,7 @@ package mill.util
 import mill.eval.PathRef
 
 case class Watched[T](value: T, watched: Seq[PathRef])
-object Watched{
-  implicit def readWrite[T: upickle.default.ReadWriter] = upickle.default.macroRW[Watched[T]]
+object Watched {
+  implicit def readWrite[T: upickle.default.ReadWriter] =
+    upickle.default.macroRW[Watched[T]]
 }

--- a/integration/test/src/mill/integration/AcyclicTests.scala
+++ b/integration/test/src/mill/integration/AcyclicTests.scala
@@ -4,8 +4,8 @@ import ammonite.ops._
 import utest._
 
 class AcyclicTests(fork: Boolean)
-  extends IntegrationTestSuite("MILL_ACYCLIC_REPO", "acyclic", fork) {
-  val tests = Tests{
+    extends IntegrationTestSuite("MILL_ACYCLIC_REPO", "acyclic", fork) {
+  val tests = Tests {
     initWorkspace()
 
     def check(scalaVersion: String) = {
@@ -16,7 +16,7 @@ class AcyclicTests(fork: Boolean)
         ls.rec(workspacePath).exists(_.last == "GraphAnalysis.class"),
         ls.rec(workspacePath).exists(_.last == "PluginPhase.class")
       )
-      for(scalaFile <- ls.rec(workspacePath).filter(_.ext == "scala")){
+      for (scalaFile <- ls.rec(workspacePath).filter(_.ext == "scala")) {
         write.append(scalaFile, "\n}")
       }
 

--- a/integration/test/src/mill/integration/AmmoniteTests.scala
+++ b/integration/test/src/mill/integration/AmmoniteTests.scala
@@ -4,23 +4,26 @@ import ammonite.ops._
 import utest._
 
 class AmmoniteTests(fork: Boolean)
-  extends IntegrationTestSuite("MILL_AMMONITE_REPO", "ammonite", fork) {
-  val tests = Tests{
+    extends IntegrationTestSuite("MILL_AMMONITE_REPO", "ammonite", fork) {
+  val tests = Tests {
     initWorkspace()
 
     def check(scalaVersion: String) = {
       val replTests = eval(
-        s"amm.repl[$scalaVersion].test", "{ammonite.unit,ammonite.session.ProjectTests.guava}"
+        s"amm.repl[$scalaVersion].test",
+        "{ammonite.unit,ammonite.session.ProjectTests.guava}"
       )
       val replTestMeta = meta(s"amm.repl[$scalaVersion].test.test")
       assert(
         replTests,
         replTestMeta.contains("ammonite.session.ProjectTests.guava"),
-        replTestMeta.contains("ammonite.unit.SourceTests.objectInfo.thirdPartyJava")
+        replTestMeta.contains(
+          "ammonite.unit.SourceTests.objectInfo.thirdPartyJava")
       )
 
       val compileResult = eval(
-        "all", s"{shell,sshd,amm,integration}[$scalaVersion].test.compile"
+        "all",
+        s"{shell,sshd,amm,integration}[$scalaVersion].test.compile"
       )
 
       assert(

--- a/integration/test/src/mill/integration/BetterFilesTests.scala
+++ b/integration/test/src/mill/integration/BetterFilesTests.scala
@@ -4,8 +4,8 @@ import ammonite.ops._
 import utest._
 
 class BetterFilesTests(fork: Boolean)
-  extends IntegrationTestSuite("MILL_BETTERFILES_REPO", "better-files", fork) {
-  val tests = Tests{
+    extends IntegrationTestSuite("MILL_BETTERFILES_REPO", "better-files", fork) {
+  val tests = Tests {
     initWorkspace()
     'test - {
 
@@ -17,7 +17,7 @@ class BetterFilesTests(fork: Boolean)
       assert(coreTestMeta.contains("better.files.FileSpec"))
       assert(coreTestMeta.contains("files should handle BOM"))
 
-      for(scalaFile <- ls.rec(workspacePath).filter(_.ext == "scala")){
+      for (scalaFile <- ls.rec(workspacePath).filter(_.ext == "scala")) {
         write.append(scalaFile, "\n}")
       }
       assert(!eval("akka.test"))

--- a/integration/test/src/mill/integration/CaffeineTests.scala
+++ b/integration/test/src/mill/integration/CaffeineTests.scala
@@ -2,13 +2,14 @@ package mill.integration
 
 import utest._
 
-class CaffeineTests(fork: Boolean) extends IntegrationTestSuite("MILL_CAFFEINE_REPO", "caffeine", fork) {
-  val tests = Tests{
+class CaffeineTests(fork: Boolean)
+    extends IntegrationTestSuite("MILL_CAFFEINE_REPO", "caffeine", fork) {
+  val tests = Tests {
     initWorkspace()
     'test - {
       // Caffeine only can build using Java 9 or up. Java 8 results in weird
       // type inference issues during the compile
-      if (mill.main.client.Util.isJava9OrAbove){
+      if (mill.main.client.Util.isJava9OrAbove) {
         assert(eval("caffeine.test.compile"))
 
         val suites = Seq(
@@ -17,10 +18,12 @@ class CaffeineTests(fork: Boolean) extends IntegrationTestSuite("MILL_CAFFEINE_R
           "com.github.benmanes.caffeine.cache.CaffeineTest",
           "com.github.benmanes.caffeine.cache.TimerWheelTest"
         )
-        assert(eval(
-          "caffeine.test",
-          "-testclass", suites.mkString(",")
-        ))
+        assert(
+          eval(
+            "caffeine.test",
+            "-testclass",
+            suites.mkString(",")
+          ))
         assert(eval("guava.test.compile"))
         assert(eval("guava.test"))
 

--- a/integration/test/src/mill/integration/IntegrationTestSuite.scala
+++ b/integration/test/src/mill/integration/IntegrationTestSuite.scala
@@ -4,8 +4,10 @@ import ammonite.ops._
 import mill.util.ScriptTestSuite
 import utest._
 
-abstract class IntegrationTestSuite(repoKey: String, val workspaceSlug: String, fork: Boolean)
-  extends ScriptTestSuite(fork){
+abstract class IntegrationTestSuite(repoKey: String,
+                                    val workspaceSlug: String,
+                                    fork: Boolean)
+    extends ScriptTestSuite(fork) {
   val buildFilePath = pwd / 'integration / 'test / 'resources / workspaceSlug
   def scriptSourcePath = {
     // The unzipped git repo snapshots we get from github come with a

--- a/integration/test/src/mill/integration/JawnTests.scala
+++ b/integration/test/src/mill/integration/JawnTests.scala
@@ -4,8 +4,8 @@ import ammonite.ops._
 import utest._
 
 class JawnTests(fork: Boolean)
-  extends IntegrationTestSuite("MILL_JAWN_REPO", "jawn", fork) {
-  val tests = Tests{
+    extends IntegrationTestSuite("MILL_JAWN_REPO", "jawn", fork) {
+  val tests = Tests {
     initWorkspace()
 
     def check(scalaVersion: String) = {
@@ -17,7 +17,7 @@ class JawnTests(fork: Boolean)
         ls.rec(workspacePath).exists(_.last == "CharBuilderSpec.class")
       )
 
-      for(scalaFile <- ls.rec(workspacePath).filter(_.ext == "scala")){
+      for (scalaFile <- ls.rec(workspacePath).filter(_.ext == "scala")) {
         write.append(scalaFile, "\n}")
       }
 

--- a/integration/test/src/mill/integration/PlayJsonTests.scala
+++ b/integration/test/src/mill/integration/PlayJsonTests.scala
@@ -3,13 +3,14 @@ package mill.integration
 import ammonite.ops._
 import utest._
 
-class PlayJsonTests(fork: Boolean) extends IntegrationTestSuite("MILL_PLAY_JSON_REPO", "play-json", fork) {
+class PlayJsonTests(fork: Boolean)
+    extends IntegrationTestSuite("MILL_PLAY_JSON_REPO", "play-json", fork) {
 
   override def buildFiles: Seq[Path] = {
     ls(buildFilePath).filter(_.ext == "sc")
   }
 
-  val tests = Tests{
+  val tests = Tests {
     initWorkspace()
 
     'jvm - {
@@ -37,7 +38,8 @@ class PlayJsonTests(fork: Boolean) extends IntegrationTestSuite("MILL_PLAY_JSON_
 
       assert(
         jsMeta.contains("play.api.libs.json.JsonSpec"),
-        jsMeta.contains("Complete JSON should create full object when lose precision when parsing BigDecimals")
+        jsMeta.contains(
+          "Complete JSON should create full object when lose precision when parsing BigDecimals")
       )
     }
     'playJoda - {

--- a/integration/test/src/mill/integration/UpickleTests.scala
+++ b/integration/test/src/mill/integration/UpickleTests.scala
@@ -3,28 +3,33 @@ package mill.integration
 import ammonite.ops._
 import utest._
 
-class UpickleTests(fork: Boolean) extends IntegrationTestSuite("MILL_UPICKLE_REPO", "upickle", fork) {
-  val tests = Tests{
+class UpickleTests(fork: Boolean)
+    extends IntegrationTestSuite("MILL_UPICKLE_REPO", "upickle", fork) {
+  val tests = Tests {
     initWorkspace()
     'jvm21111 - {
       mill.util.TestUtil.disableInJava9OrAbove({
         assert(eval("upickleJvm[2.11.11].test"))
         val jvmMeta = meta("upickleJvm[2.11.11].test.test")
         assert(jvmMeta.contains("example.ExampleTests.simple"))
-        assert(jvmMeta.contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
+        assert(
+          jvmMeta.contains(
+            "upickle.MacroTests.commonCustomStructures.simpleAdt"))
       })
     }
     'jvm2124 - {
       assert(eval("upickleJvm[2.12.4].test"))
       val jvmMeta = meta("upickleJvm[2.12.4].test.test")
       assert(jvmMeta.contains("example.ExampleTests.simple"))
-      assert(jvmMeta.contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
+      assert(
+        jvmMeta.contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
     }
     'js - {
       assert(eval("upickleJs[2.12.4].test"))
       val jsMeta = meta("upickleJs[2.12.4].test.test")
-      assert(jsMeta .contains("example.ExampleTests.simple"))
-      assert(jsMeta .contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
+      assert(jsMeta.contains("example.ExampleTests.simple"))
+      assert(
+        jsMeta.contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
     }
 
   }

--- a/main/graphviz/src/mill/main/graphviz/GraphvizTools.scala
+++ b/main/graphviz/src/mill/main/graphviz/GraphvizTools.scala
@@ -2,52 +2,52 @@ package mill.main.graphviz
 import ammonite.ops.Path
 import mill.define.{Graph, NamedTask}
 import org.jgrapht.graph.{DefaultEdge, SimpleDirectedGraph}
-object GraphvizTools{
+object GraphvizTools {
   def apply(rs: Seq[NamedTask[Any]], dest: Path) = {
     val transitive = Graph.transitiveTargets(rs.distinct)
     val topoSorted = Graph.topoSorted(transitive)
     val goalSet = rs.toSet
-    val sortedGroups = Graph.groupAroundImportantTargets(topoSorted){
+    val sortedGroups = Graph.groupAroundImportantTargets(topoSorted) {
       case x: NamedTask[Any] if goalSet.contains(x) => x
     }
     import guru.nidi.graphviz.model.Factory._
     import guru.nidi.graphviz.engine.{Format, Graphviz}
 
     val edgesIterator =
-      for((k, vs) <- sortedGroups.items())
-        yield (
-          k,
-          for {
-            v <- vs.items
-            dest <- v.inputs.collect { case v: NamedTask[Any] => v }
-            if goalSet.contains(dest)
-          } yield dest
-        )
+      for ((k, vs) <- sortedGroups.items())
+        yield
+          (
+            k,
+            for {
+              v <- vs.items
+              dest <- v.inputs.collect { case v: NamedTask[Any] => v }
+              if goalSet.contains(dest)
+            } yield dest
+          )
 
-    val edges = edgesIterator.map{case (k, v) => (k, v.toArray.distinct)}.toArray
+    val edges = edgesIterator.map { case (k, v) => (k, v.toArray.distinct) }.toArray
 
-    val indexToTask = edges.flatMap{case (k, vs) => Iterator(k) ++ vs}.distinct
+    val indexToTask = edges.flatMap { case (k, vs) => Iterator(k) ++ vs }.distinct
     val taskToIndex = indexToTask.zipWithIndex.toMap
 
     val jgraph = new SimpleDirectedGraph[Int, DefaultEdge](classOf[DefaultEdge])
 
-    for(i <- indexToTask.indices) jgraph.addVertex(i)
-    for((src, dests) <- edges; dest <- dests) {
+    for (i <- indexToTask.indices) jgraph.addVertex(i)
+    for ((src, dests) <- edges; dest <- dests) {
       jgraph.addEdge(taskToIndex(src), taskToIndex(dest))
     }
-
 
     org.jgrapht.alg.TransitiveReduction.INSTANCE.reduce(jgraph)
     val nodes = indexToTask.map(t => node(t.ctx.segments.render))
 
     var g = graph("example1").directed
-    for(i <- indexToTask.indices){
-      val outgoing = for{
+    for (i <- indexToTask.indices) {
+      val outgoing = for {
         e <- edges(i)._2
         j = taskToIndex(e)
         if jgraph.containsEdge(i, j)
       } yield nodes(j)
-      g = g.`with`(nodes(i).link(outgoing:_*))
+      g = g.`with`(nodes(i).link(outgoing: _*))
     }
 
     val gv = Graphviz.fromGraph(g).totalMemory(100 * 1000 * 1000)
@@ -58,7 +58,7 @@ object GraphvizTools{
       Format.PNG -> "out.png",
       Format.SVG -> "out.svg"
     )
-    for((fmt, name) <- outputs) {
+    for ((fmt, name) <- outputs) {
       gv.render(fmt).toFile((dest / name).toIO)
     }
     outputs.map(x => mill.PathRef(dest / x._2))

--- a/main/src/mill/main/MainScopts.scala
+++ b/main/src/mill/main/MainScopts.scala
@@ -3,7 +3,7 @@ import mill.eval.Evaluator
 
 case class Tasks[T](value: Seq[mill.define.NamedTask[T]])
 
-object Tasks{
+object Tasks {
 
   class Scopt[T]() extends scopt.Read[Tasks[T]] {
     def arity = 1
@@ -14,18 +14,19 @@ object Tasks{
         Evaluator.currentEvaluator.get,
         Seq(s),
         multiSelect = false
-      ) match{
-        case Left(err) => throw new Exception(err)
+      ) match {
+        case Left(err)    => throw new Exception(err)
         case Right(tasks) => Tasks(tasks).asInstanceOf[Tasks[T]]
       }
     }
   }
 }
 
-class EvaluatorScopt[T]()
-  extends scopt.Read[mill.eval.Evaluator[T]]{
+class EvaluatorScopt[T]() extends scopt.Read[mill.eval.Evaluator[T]] {
   def arity = 0
-  def reads = s => try{
-    Evaluator.currentEvaluator.get.asInstanceOf[mill.eval.Evaluator[T]]
-  }
+  def reads =
+    s =>
+      try {
+        Evaluator.currentEvaluator.get.asInstanceOf[mill.eval.Evaluator[T]]
+    }
 }

--- a/main/src/mill/main/ReplApplyHandler.scala
+++ b/main/src/mill/main/ReplApplyHandler.scala
@@ -1,6 +1,5 @@
 package mill.main
 
-
 import ammonite.ops.Path
 import mill.define.Applicative.ApplyHandler
 import mill.define.Segment.Label
@@ -9,7 +8,7 @@ import mill.eval.{Evaluator, Result}
 import mill.util.Strict.Agg
 
 import scala.collection.mutable
-object ReplApplyHandler{
+object ReplApplyHandler {
   def apply[T](home: Path,
                colors: ammonite.util.Colors,
                pprinter0: pprint.PPrinter,
@@ -34,86 +33,110 @@ object ReplApplyHandler{
     )
   }
   def pprintCross(c: mill.define.Cross[_], evaluator: Evaluator[_]) = {
-    pprint.Tree.Lazy( ctx =>
-      Iterator(c.millOuterCtx.enclosing , ":", c.millOuterCtx.lineNum.toString, ctx.applyPrefixColor("\nChildren:").toString) ++
-        c.items.iterator.map(x =>
-          "\n    (" + x._1.map(pprint.PPrinter.BlackWhite.apply(_)).mkString(", ") + ")"
-        )
-    )
+    pprint.Tree.Lazy(
+      ctx =>
+        Iterator(c.millOuterCtx.enclosing,
+                 ":",
+                 c.millOuterCtx.lineNum.toString,
+                 ctx.applyPrefixColor("\nChildren:").toString) ++
+          c.items.iterator.map(
+            x =>
+              "\n    (" + x._1
+                .map(pprint.PPrinter.BlackWhite.apply(_))
+                .mkString(", ") + ")"))
   }
   def pprintModule(m: mill.define.Module, evaluator: Evaluator[_]) = {
-    pprint.Tree.Lazy( ctx =>
-      Iterator(m.millInternal.millModuleEnclosing, ":", m.millInternal.millModuleLine.toString) ++
-        (if (m.millInternal.reflect[mill.Module].isEmpty) Nil
-        else
-          ctx.applyPrefixColor("\nChildren:").toString +:
-            m.millInternal.reflect[mill.Module].map("\n    ." + _.millOuterCtx.segment.pathSegments.mkString("."))) ++
-        (evaluator.rootModule.millDiscover.value.get(m.getClass) match{
-          case None => Nil
-          case Some(commands) =>
-            ctx.applyPrefixColor("\nCommands:").toString +: commands.map{c =>
-              "\n    ." + c._2.name + "(" +
-                c._2.argSignatures.map(s => s.name + ": " + s.typeString).mkString(", ") +
-                ")()"
-            }
-        }) ++
-        (if (m.millInternal.reflect[Target[_]].isEmpty) Nil
-        else {
-          Seq(ctx.applyPrefixColor("\nTargets:").toString) ++
-            m.millInternal.reflect[Target[_]].sortBy(_.label).map(t =>
-              "\n    ." + t.label + "()"
-            )
-        })
-
-    )
+    pprint.Tree.Lazy(
+      ctx =>
+        Iterator(m.millInternal.millModuleEnclosing,
+                 ":",
+                 m.millInternal.millModuleLine.toString) ++
+          (if (m.millInternal.reflect[mill.Module].isEmpty) Nil
+           else
+             ctx.applyPrefixColor("\nChildren:").toString +:
+               m.millInternal
+               .reflect[mill.Module]
+               .map("\n    ." + _.millOuterCtx.segment.pathSegments
+                 .mkString("."))) ++
+          (evaluator.rootModule.millDiscover.value.get(m.getClass) match {
+            case None => Nil
+            case Some(commands) =>
+              ctx.applyPrefixColor("\nCommands:").toString +: commands.map {
+                c =>
+                  "\n    ." + c._2.name + "(" +
+                    c._2.argSignatures
+                      .map(s => s.name + ": " + s.typeString)
+                      .mkString(", ") +
+                    ")()"
+              }
+          }) ++
+          (if (m.millInternal.reflect[Target[_]].isEmpty) Nil
+           else {
+             Seq(ctx.applyPrefixColor("\nTargets:").toString) ++
+               m.millInternal
+                 .reflect[Target[_]]
+                 .sortBy(_.label)
+                 .map(t => "\n    ." + t.label + "()")
+           }))
   }
   def pprintTask(t: NamedTask[_], evaluator: Evaluator[_]) = {
     val seen = mutable.Set.empty[Task[_]]
     def rec(t: Task[_]): Seq[Segments] = {
       if (seen(t)) Nil // do nothing
-      else t match {
-        case t: Target[_] if evaluator.rootModule.millInternal.targets.contains(t) =>
-          Seq(t.ctx.segments)
-        case _ =>
-          seen.add(t)
-          t.inputs.flatMap(rec)
-      }
+      else
+        t match {
+          case t: Target[_]
+              if evaluator.rootModule.millInternal.targets.contains(t) =>
+            Seq(t.ctx.segments)
+          case _ =>
+            seen.add(t)
+            t.inputs.flatMap(rec)
+        }
     }
-    pprint.Tree.Lazy(ctx =>
-      Iterator(
-        t.toString, "(", t.ctx.fileName.split('/').last, ":", t.ctx.lineNum.toString, ")",
-        "\n", ctx.applyPrefixColor("Inputs:").toString
-      ) ++ t.inputs.iterator.flatMap(rec).map("\n    " + _.render)
-    )
+    pprint.Tree.Lazy(
+      ctx =>
+        Iterator(
+          t.toString,
+          "(",
+          t.ctx.fileName.split('/').last,
+          ":",
+          t.ctx.lineNum.toString,
+          ")",
+          "\n",
+          ctx.applyPrefixColor("Inputs:").toString
+        ) ++ t.inputs.iterator.flatMap(rec).map("\n    " + _.render))
   }
 
 }
-class ReplApplyHandler(pprinter0: pprint.PPrinter,
-                       evaluator: Evaluator[_]) extends ApplyHandler[Task] {
+class ReplApplyHandler(pprinter0: pprint.PPrinter, evaluator: Evaluator[_])
+    extends ApplyHandler[Task] {
   // Evaluate classLoaderSig only once in the REPL to avoid busting caches
   // as the user enters more REPL commands and changes the classpath
   val classLoaderSig = Evaluator.classLoaderSig
   override def apply[V](t: Task[V]) = {
     val res = evaluator.evaluate(Agg(t))
-    res.values match{
+    res.values match {
       case Seq(head: V) => head
       case Nil =>
         val msg = new mutable.StringBuilder()
         msg.append(res.failing.keyCount + " targets failed\n")
-        for((k, vs) <- res.failing.items){
-          msg.append(k match{
-            case Left(t) => "Anonymous Task\n"
+        for ((k, vs) <- res.failing.items) {
+          msg.append(k match {
+            case Left(t)  => "Anonymous Task\n"
             case Right(k) => k.segments.render + "\n"
           })
 
-          for(v <- vs){
-            v match{
+          for (v <- vs) {
+            v match {
               case Result.Failure(m, _) => msg.append(m + "\n")
               case Result.Exception(t, outerStack) =>
                 msg.append(
                   t.toString +
-                  t.getStackTrace.dropRight(outerStack.value.length).map("\n    " + _).mkString +
-                  "\n"
+                    t.getStackTrace
+                      .dropRight(outerStack.value.length)
+                      .map("\n    " + _)
+                      .mkString +
+                    "\n"
                 )
 
             }
@@ -128,9 +151,11 @@ class ReplApplyHandler(pprinter0: pprint.PPrinter,
   val millHandlers: PartialFunction[Any, pprint.Tree] = {
     case c: Cross[_] =>
       ReplApplyHandler.pprintCross(c, evaluator)
-    case m: mill.Module if evaluator.rootModule.millInternal.modules.contains(m) =>
+    case m: mill.Module
+        if evaluator.rootModule.millInternal.modules.contains(m) =>
       ReplApplyHandler.pprintModule(m, evaluator)
-    case t: mill.define.Target[_] if evaluator.rootModule.millInternal.targets.contains(t) =>
+    case t: mill.define.Target[_]
+        if evaluator.rootModule.millInternal.targets.contains(t) =>
       ReplApplyHandler.pprintTask(t, evaluator)
 
   }

--- a/main/src/mill/main/Resolve.scala
+++ b/main/src/mill/main/Resolve.scala
@@ -9,15 +9,16 @@ import mill.util.Scripts
 
 import scala.reflect.ClassTag
 
-object ResolveMetadata extends Resolve[String]{
-  def singleModuleMeta(obj: Module, discover: Discover[_], isRootModule: Boolean) = {
+object ResolveMetadata extends Resolve[String] {
+  def singleModuleMeta(obj: Module,
+                       discover: Discover[_],
+                       isRootModule: Boolean) = {
     val modules = obj.millModuleDirectChildren.map(_.toString)
     val targets =
-      obj
-        .millInternal
+      obj.millInternal
         .reflect[Target[_]]
         .map(_.toString)
-    val commands = for{
+    val commands = for {
       (cls, entryPoints) <- discover.value
       if cls.isAssignableFrom(obj.getClass)
       ep <- entryPoints
@@ -35,7 +36,7 @@ object ResolveMetadata extends Resolve[String]{
                       rest: Seq[String]): Either[String, List[String]] = {
 
     val direct = singleModuleMeta(obj, discover, revSelectorsSoFar.isEmpty)
-    last match{
+    last match {
       case "__" =>
         Right(
           // Filter out our own module in
@@ -46,8 +47,8 @@ object ResolveMetadata extends Resolve[String]{
         )
       case "_" => Right(direct.toList)
       case _ =>
-        direct.find(_.split('.').last == last) match{
-          case None => Resolve.errorMsgLabel(direct, last, revSelectorsSoFar)
+        direct.find(_.split('.').last == last) match {
+          case None    => Resolve.errorMsgLabel(direct, last, revSelectorsSoFar)
           case Some(s) => Right(List(s))
         }
     }
@@ -58,15 +59,17 @@ object ResolveMetadata extends Resolve[String]{
                       last: List[String],
                       discover: Discover[_],
                       rest: Seq[String]): Either[String, List[String]] = {
-    obj match{
+    obj match {
       case c: Cross[Module] =>
-        last match{
+        last match {
           case List("__") => Right(c.items.map(_._2.toString))
           case items =>
             c.items
               .filter(_._1.length == items.length)
-              .filter(_._1.zip(last).forall{case (a, b) => b == "_" || a.toString == b})
-              .map(_._2.toString) match{
+              .filter(_._1.zip(last).forall {
+                case (a, b) => b == "_" || a.toString == b
+              })
+              .map(_._2.toString) match {
               case Nil =>
                 Resolve.errorMsgCross(
                   c.items.map(_._1.map(_.toString)),
@@ -80,7 +83,7 @@ object ResolveMetadata extends Resolve[String]{
       case _ =>
         Left(
           Resolve.unableToResolve(Segment.Cross(last), revSelectorsSoFar) +
-          Resolve.hintListLabel(revSelectorsSoFar)
+            Resolve.hintListLabel(revSelectorsSoFar)
         )
     }
   }
@@ -88,19 +91,22 @@ object ResolveMetadata extends Resolve[String]{
 
 object ResolveSegments extends Resolve[Segments] {
 
-  override def endResolveCross(obj: Module,
-                               revSelectorsSoFar: List[Segment],
-                               last: List[String],
-                               discover: Discover[_],
-                               rest: Seq[String]): Either[String, Seq[Segments]] = {
-    obj match{
+  override def endResolveCross(
+      obj: Module,
+      revSelectorsSoFar: List[Segment],
+      last: List[String],
+      discover: Discover[_],
+      rest: Seq[String]): Either[String, Seq[Segments]] = {
+    obj match {
       case c: Cross[Module] =>
-        last match{
+        last match {
           case List("__") => Right(c.items.map(_._2.millModuleSegments))
           case items =>
             c.items
               .filter(_._1.length == items.length)
-              .filter(_._1.zip(last).forall{case (a, b) => b == "_" || a.toString == b})
+              .filter(_._1.zip(last).forall {
+                case (a, b) => b == "_" || a.toString == b
+              })
               .map(_._2.millModuleSegments) match {
               case Nil =>
                 Resolve.errorMsgCross(
@@ -125,8 +131,7 @@ object ResolveSegments extends Resolve[Segments] {
                       discover: Discover[_],
                       rest: Seq[String]): Either[String, Seq[Segments]] = {
     val target =
-      obj
-        .millInternal
+      obj.millInternal
         .reflect[Target[_]]
         .find(_.label == last)
         .map(t => Right(t.ctx.segments))
@@ -156,30 +161,31 @@ object ResolveSegments extends Resolve[Segments] {
   }
 }
 
-object ResolveTasks extends Resolve[NamedTask[Any]]{
-
+object ResolveTasks extends Resolve[NamedTask[Any]] {
 
   def endResolveCross(obj: Module,
                       revSelectorsSoFar: List[Segment],
                       last: List[String],
                       discover: Discover[_],
-                      rest: Seq[String])= {
+                      rest: Seq[String]) = {
 
-    obj match{
+    obj match {
       case c: Cross[Module] =>
-
-        Resolve.runDefault(obj, Segment.Cross(last), discover, rest).flatten.headOption match{
+        Resolve
+          .runDefault(obj, Segment.Cross(last), discover, rest)
+          .flatten
+          .headOption match {
           case None =>
             Left(
               "Cannot find default task to evaluate for module " +
-              Segments((Segment.Cross(last) :: revSelectorsSoFar).reverse:_*).render
+                Segments((Segment.Cross(last) :: revSelectorsSoFar).reverse: _*).render
             )
           case Some(v) => v.map(Seq(_))
         }
       case _ =>
         Left(
           Resolve.unableToResolve(Segment.Cross(last), revSelectorsSoFar) +
-          Resolve.hintListLabel(revSelectorsSoFar)
+            Resolve.hintListLabel(revSelectorsSoFar)
         )
     }
   }
@@ -188,7 +194,7 @@ object ResolveTasks extends Resolve[NamedTask[Any]]{
                       revSelectorsSoFar: List[Segment],
                       last: String,
                       discover: Discover[_],
-                      rest: Seq[String]) = last match{
+                      rest: Seq[String]) = last match {
     case "__" =>
       Right(
         obj.millInternal.modules
@@ -199,15 +205,17 @@ object ResolveTasks extends Resolve[NamedTask[Any]]{
 
     case _ =>
       val target =
-        obj
-          .millInternal
+        obj.millInternal
           .reflect[Target[_]]
           .find(_.label == last)
           .map(Right(_))
 
       val command = Resolve.invokeCommand(obj, last, discover, rest).headOption
 
-      command orElse target orElse Resolve.runDefault(obj, Segment.Label(last), discover, rest).flatten.headOption match {
+      command orElse target orElse Resolve
+        .runDefault(obj, Segment.Label(last), discover, rest)
+        .flatten
+        .headOption match {
         case None =>
           Resolve.errorMsgLabel(
             singleModuleMeta(obj, discover, revSelectorsSoFar.isEmpty),
@@ -221,8 +229,8 @@ object ResolveTasks extends Resolve[NamedTask[Any]]{
       }
   }
 }
-object Resolve{
-  def minimum(i1: Int, i2: Int, i3: Int)= math.min(math.min(i1, i2), i3)
+object Resolve {
+  def minimum(i1: Int, i2: Int, i3: Int) = math.min(math.min(i1, i2), i3)
 
   /**
     * Short Levenshtein distance algorithm, based on
@@ -230,20 +238,28 @@ object Resolve{
     * https://rosettacode.org/wiki/Levenshtein_distance#Scala
     */
   def editDistance(s1: String, s2: String) = {
-    val dist = Array.tabulate(s2.length+1, s1.length+1){(j, i) => if(j==0) i else if (i==0) j else 0}
+    val dist = Array.tabulate(s2.length + 1, s1.length + 1) { (j, i) =>
+      if (j == 0) i else if (i == 0) j else 0
+    }
 
-    for(j <- 1 to s2.length; i <- 1 to s1.length)
-      dist(j)(i) = if(s2(j - 1) == s1(i-1)) dist(j - 1)(i-1)
-      else minimum(dist(j - 1)(i) + 1, dist(j)(i - 1) + 1, dist(j - 1)(i - 1) + 1)
+    for (j <- 1 to s2.length; i <- 1 to s1.length)
+      dist(j)(i) =
+        if (s2(j - 1) == s1(i - 1)) dist(j - 1)(i - 1)
+        else
+          minimum(dist(j - 1)(i) + 1,
+                  dist(j)(i - 1) + 1,
+                  dist(j - 1)(i - 1) + 1)
 
     dist(s2.length)(s1.length)
   }
 
-  def unableToResolve(last: Segment, revSelectorsSoFar: List[Segment]): String = {
+  def unableToResolve(last: Segment,
+                      revSelectorsSoFar: List[Segment]): String = {
     unableToResolve(Segments((last :: revSelectorsSoFar).reverse: _*).render)
   }
 
-  def unableToResolve(segments: String): String = "Cannot resolve " + segments + "."
+  def unableToResolve(segments: String): String =
+    "Cannot resolve " + segments + "."
 
   def hintList(revSelectorsSoFar: List[Segment]) = {
     val search = Segments(revSelectorsSoFar.reverse: _*).render
@@ -262,37 +278,45 @@ object Resolve{
                       last0: T,
                       revSelectorsSoFar: List[Segment],
                       editSplit: String => String,
-                      defaultErrorMsg: String)
-                     (strings: T => Seq[String],
-                      render: T => String): Left[String, Nothing] = {
+                      defaultErrorMsg: String)(
+      strings: T => Seq[String],
+      render: T => String): Left[String, Nothing] = {
     val last = strings(last0)
     val similar =
       direct
         .map(x => (x, strings(x)))
         .filter(_._2.length == last.length)
-        .map{ case (d, s) => (d, s.zip(last).map{case (a, b) => Resolve.editDistance(editSplit(a), b)}.sum)}
+        .map {
+          case (d, s) =>
+            (d,
+             s.zip(last)
+               .map { case (a, b) => Resolve.editDistance(editSplit(a), b) }
+               .sum)
+        }
         .filter(_._2 < 3)
         .sortBy(_._2)
 
-    if (similar.headOption.exists(_._1 == last0)){
+    if (similar.headOption.exists(_._1 == last0)) {
       // Special case: if the most similar segment is the desired segment itself,
       // this means we are trying to resolve a module where a task is present.
       // Special case the error message to make it something meaningful
       Left("Task " + last0 + " is not a module and has no children.")
-    }else{
+    } else {
 
-      val hint = similar match{
-        case Nil => defaultErrorMsg
+      val hint = similar match {
+        case Nil   => defaultErrorMsg
         case items => " Did you mean " + render(items.head._1) + "?"
       }
       Left(unableToResolve(render(last0)) + hint)
     }
   }
 
-  def errorMsgLabel(direct: Seq[String], last: String, revSelectorsSoFar: List[Segment]) = {
+  def errorMsgLabel(direct: Seq[String],
+                    last: String,
+                    revSelectorsSoFar: List[Segment]) = {
     errorMsgBase(
       direct,
-      Segments((Segment.Label(last) :: revSelectorsSoFar).reverse:_*).render,
+      Segments((Segment.Label(last) :: revSelectorsSoFar).reverse: _*).render,
       revSelectorsSoFar,
       _.split('.').last,
       hintListLabel(revSelectorsSoFar)
@@ -313,42 +337,52 @@ object Resolve{
       hintListCross(revSelectorsSoFar)
     )(
       crossKeys => crossKeys,
-      crossKeys => Segments((Segment.Cross(crossKeys) :: revSelectorsSoFar).reverse:_*).render
+      crossKeys =>
+        Segments((Segment.Cross(crossKeys) :: revSelectorsSoFar).reverse: _*).render
     )
   }
 
   def invokeCommand(target: Module,
                     name: String,
                     discover: Discover[_],
-                    rest: Seq[String]) = for {
-    (cls, entryPoints) <- discover.value
-    if cls.isAssignableFrom(target.getClass)
-    ep <- entryPoints
-    if ep._2.name == name
-  } yield Scripts.runMainMethod(
-    target,
-    ep._2.asInstanceOf[EntryPoint[Module]],
-    ammonite.main.Scripts.groupArgs(rest.toList)
-  ) match {
-    case Res.Success(v: Command[_]) => Right(v)
-    case Res.Failure(msg) => Left(msg)
-    case Res.Exception(ex, msg) =>
-      val sw = new java.io.StringWriter()
-      ex.printStackTrace(new java.io.PrintWriter(sw))
-      val prefix = if (msg.nonEmpty) msg + "\n" else msg
-      Left(prefix + sw.toString)
+                    rest: Seq[String]) =
+    for {
+      (cls, entryPoints) <- discover.value
+      if cls.isAssignableFrom(target.getClass)
+      ep <- entryPoints
+      if ep._2.name == name
+    } yield
+      Scripts.runMainMethod(
+        target,
+        ep._2.asInstanceOf[EntryPoint[Module]],
+        ammonite.main.Scripts.groupArgs(rest.toList)
+      ) match {
+        case Res.Success(v: Command[_]) => Right(v)
+        case Res.Failure(msg)           => Left(msg)
+        case Res.Exception(ex, msg) =>
+          val sw = new java.io.StringWriter()
+          ex.printStackTrace(new java.io.PrintWriter(sw))
+          val prefix = if (msg.nonEmpty) msg + "\n" else msg
+          Left(prefix + sw.toString)
 
-  }
+      }
 
-  def runDefault(obj: Module, last: Segment, discover: Discover[_], rest: Seq[String]) = for {
-    child <- obj.millInternal.reflectNestedObjects[Module]
-    if child.millOuterCtx.segment == last
-    res <- child match {
-      case taskMod: TaskModule =>
-        Some(invokeCommand(child, taskMod.defaultCommandName(), discover, rest).headOption)
-      case _ => None
-    }
-  } yield res
+  def runDefault(obj: Module,
+                 last: Segment,
+                 discover: Discover[_],
+                 rest: Seq[String]) =
+    for {
+      child <- obj.millInternal.reflectNestedObjects[Module]
+      if child.millOuterCtx.segment == last
+      res <- child match {
+        case taskMod: TaskModule =>
+          Some(invokeCommand(child,
+                             taskMod.defaultCommandName(),
+                             discover,
+                             rest).headOption)
+        case _ => None
+      }
+    } yield res
 
 }
 abstract class Resolve[R: ClassTag] {
@@ -370,60 +404,78 @@ abstract class Resolve[R: ClassTag] {
               remainingCrossSelectors: List[List[String]],
               revSelectorsSoFar: List[Segment]): Either[String, Seq[R]] = {
 
-    remainingSelector match{
+    remainingSelector match {
       case Segment.Cross(last) :: Nil =>
-        endResolveCross(obj, revSelectorsSoFar, last.map(_.toString).toList, discover, rest)
+        endResolveCross(obj,
+                        revSelectorsSoFar,
+                        last.map(_.toString).toList,
+                        discover,
+                        rest)
       case Segment.Label(last) :: Nil =>
         endResolveLabel(obj, revSelectorsSoFar, last, discover, rest)
 
       case head :: tail =>
         val newRevSelectorsSoFar = head :: revSelectorsSoFar
 
-        def recurse(searchModules: Seq[Module], resolveFailureMsg: => Left[String, Nothing]) = {
+        def recurse(searchModules: Seq[Module],
+                    resolveFailureMsg: => Left[String, Nothing]) = {
           val matching = searchModules
-            .map(resolve(tail, _, discover, rest, remainingCrossSelectors, newRevSelectorsSoFar))
+            .map(
+              resolve(tail,
+                      _,
+                      discover,
+                      rest,
+                      remainingCrossSelectors,
+                      newRevSelectorsSoFar))
 
-          matching match{
+          matching match {
             case Seq(Left(err)) => Left(err)
             case items =>
-              items.collect{case Right(v) => v} match{
-                case Nil => resolveFailureMsg
+              items.collect { case Right(v) => v } match {
+                case Nil    => resolveFailureMsg
                 case values => Right(values.flatten)
               }
           }
         }
-        head match{
+        head match {
           case Segment.Label(singleLabel) =>
             recurse(
               if (singleLabel == "__") obj.millInternal.modules
               else if (singleLabel == "_") obj.millModuleDirectChildren.toSeq
-              else{
-                obj.millInternal.reflectNestedObjects[mill.Module]
+              else {
+                obj.millInternal
+                  .reflectNestedObjects[mill.Module]
                   .find(_.millOuterCtx.segment == Segment.Label(singleLabel))
                   .toSeq
               },
-              if (singleLabel != "_") Resolve.errorMsgLabel(
-                singleModuleMeta(obj, discover, revSelectorsSoFar.isEmpty),
-                singleLabel,
-                revSelectorsSoFar
-              )
-              else Left(
-                "Cannot resolve " + Segments((remainingSelector.reverse ++ revSelectorsSoFar).reverse:_*).render +
-                ". Try `mill resolve " + Segments((Segment.Label("_") :: revSelectorsSoFar).reverse:_*).render + "` to see what's available"
-              )
+              if (singleLabel != "_")
+                Resolve.errorMsgLabel(
+                  singleModuleMeta(obj, discover, revSelectorsSoFar.isEmpty),
+                  singleLabel,
+                  revSelectorsSoFar
+                )
+              else
+                Left(
+                  "Cannot resolve " + Segments(
+                    (remainingSelector.reverse ++ revSelectorsSoFar).reverse: _*).render +
+                    ". Try `mill resolve " + Segments((Segment
+                    .Label("_") :: revSelectorsSoFar).reverse: _*).render + "` to see what's available"
+                )
             )
           case Segment.Cross(cross) =>
-            obj match{
+            obj match {
               case c: Cross[Module] =>
                 recurse(
-                  if(cross == Seq("__")) for ((k, v) <- c.items) yield v
-                  else if (cross.contains("_")){
+                  if (cross == Seq("__")) for ((k, v) <- c.items) yield v
+                  else if (cross.contains("_")) {
                     for {
                       (k, v) <- c.items
                       if k.length == cross.length
-                      if k.zip(cross).forall { case (l, r) => l == r || r == "_" }
+                      if k.zip(cross).forall {
+                        case (l, r) => l == r || r == "_"
+                      }
                     } yield v
-                  }else c.itemMap.get(cross.toList).toSeq,
+                  } else c.itemMap.get(cross.toList).toSeq,
                   Resolve.errorMsgCross(
                     c.items.map(_._1.map(_.toString)),
                     cross.map(_.toString),
@@ -432,8 +484,9 @@ abstract class Resolve[R: ClassTag] {
                 )
               case _ =>
                 Left(
-                  Resolve.unableToResolve(Segment.Cross(cross.map(_.toString)), tail) +
-                  Resolve.hintListLabel(tail)
+                  Resolve.unableToResolve(Segment.Cross(cross.map(_.toString)),
+                                          tail) +
+                    Resolve.hintListLabel(tail)
                 )
             }
         }

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -18,7 +18,6 @@ import mill.util.Loose.Agg
 
 import scala.collection.mutable
 
-
 object Jvm {
 
   def interactiveSubprocess(mainClass: String,
@@ -42,16 +41,16 @@ object Jvm {
                                 workingDir: Path) = {
     val builder = new java.lang.ProcessBuilder()
 
-    for ((k, v) <- envArgs){
+    for ((k, v) <- envArgs) {
       if (v != null) builder.environment().put(k, v)
       else builder.environment().remove(k)
     }
     builder.directory(workingDir.toIO)
 
-    val process = if (System.in.isInstanceOf[ByteArrayInputStream]){
+    val process = if (System.in.isInstanceOf[ByteArrayInputStream]) {
 
       val process = builder
-        .command(commandArgs:_*)
+        .command(commandArgs: _*)
         .start()
 
       val sources = Seq(
@@ -60,13 +59,13 @@ object Jvm {
         System.in -> process.getOutputStream
       )
 
-      for((std, dest) <- sources){
+      for ((std, dest) <- sources) {
         new Thread(new InputPumper(std, dest, false)).start()
       }
       process
-    }else{
+    } else {
       builder
-        .command(commandArgs:_*)
+        .command(commandArgs: _*)
         .inheritIO()
         .start()
     }
@@ -78,11 +77,13 @@ object Jvm {
 
   def runLocal(mainClass: String,
                classPath: Agg[Path],
-               mainArgs: Seq[String] = Seq.empty)
-              (implicit ctx: Ctx): Unit = {
-    inprocess(classPath, classLoaderOverrideSbtTesting = false, isolated = true, cl => {
-      getMainMethod(mainClass, cl).invoke(null, mainArgs.toArray)
-    })
+               mainArgs: Seq[String] = Seq.empty)(implicit ctx: Ctx): Unit = {
+    inprocess(classPath,
+              classLoaderOverrideSbtTesting = false,
+              isolated = true,
+              cl => {
+                getMainMethod(mainClass, cl).invoke(null, mainArgs.toArray)
+              })
   }
 
   private def getMainMethod(mainClassName: String, cl: ClassLoader) = {
@@ -99,32 +100,30 @@ object Jvm {
     method
   }
 
-
-
   def inprocess[T](classPath: Agg[Path],
                    classLoaderOverrideSbtTesting: Boolean,
                    isolated: Boolean,
-                   body: ClassLoader => T)
-                  (implicit ctx: Ctx.Home): T = {
+                   body: ClassLoader => T)(implicit ctx: Ctx.Home): T = {
     val urls = classPath.map(_.toIO.toURI.toURL)
     val cl = if (classLoaderOverrideSbtTesting) {
       val outerClassLoader = getClass.getClassLoader
-      mill.util.ClassLoader.create(urls.toVector, null, customFindClass = { name =>
-        if (name.startsWith("sbt.testing."))
-          Some(outerClassLoader.loadClass(name))
-        else None
+      mill.util.ClassLoader.create(urls.toVector, null, customFindClass = {
+        name =>
+          if (name.startsWith("sbt.testing."))
+            Some(outerClassLoader.loadClass(name))
+          else None
       })
-    } else if (isolated){
+    } else if (isolated) {
 
       mill.util.ClassLoader.create(urls.toVector, null)
-    }else{
+    } else {
       mill.util.ClassLoader.create(urls.toVector, getClass.getClassLoader)
     }
     val oldCl = Thread.currentThread().getContextClassLoader
     Thread.currentThread().setContextClassLoader(cl)
     try {
       body(cl)
-    }finally{
+    } finally {
       Thread.currentThread().setContextClassLoader(oldCl)
       cl.close()
     }
@@ -135,42 +134,39 @@ object Jvm {
                  jvmArgs: Seq[String] = Seq.empty,
                  envArgs: Map[String, String] = Map.empty,
                  mainArgs: Seq[String] = Seq.empty,
-                 workingDir: Path = null)
-                (implicit ctx: Ctx) = {
+                 workingDir: Path = null)(implicit ctx: Ctx) = {
 
     val commandArgs =
       Vector("java") ++
-      jvmArgs ++
-      Vector("-cp", classPath.mkString(File.pathSeparator), mainClass) ++
-      mainArgs
+        jvmArgs ++
+        Vector("-cp", classPath.mkString(File.pathSeparator), mainClass) ++
+        mainArgs
 
     val workingDir1 = Option(workingDir).getOrElse(ctx.dest)
     mkdir(workingDir1)
     val builder =
       new java.lang.ProcessBuilder()
         .directory(workingDir1.toIO)
-        .command(commandArgs:_*)
+        .command(commandArgs: _*)
         .redirectOutput(ProcessBuilder.Redirect.PIPE)
         .redirectError(ProcessBuilder.Redirect.PIPE)
 
-    for((k, v) <- envArgs) builder.environment().put(k, v)
+    for ((k, v) <- envArgs) builder.environment().put(k, v)
     val proc = builder.start()
     val stdout = proc.getInputStream
     val stderr = proc.getErrorStream
     val sources = Seq(
       (stdout, Left(_: Bytes), ctx.log.outputStream),
-      (stderr, Right(_: Bytes),ctx.log.errorStream )
+      (stderr, Right(_: Bytes), ctx.log.errorStream)
     )
     val chunks = mutable.Buffer.empty[Either[Bytes, Bytes]]
-    while(
-    // Process.isAlive doesn't exist on JDK 7 =/
-      util.Try(proc.exitValue).isFailure ||
-        stdout.available() > 0 ||
-        stderr.available() > 0
-    ){
+    while (// Process.isAlive doesn't exist on JDK 7 =/
+           util.Try(proc.exitValue).isFailure ||
+           stdout.available() > 0 ||
+           stderr.available() > 0) {
       var readSomething = false
-      for ((subStream, wrapper, parentStream) <- sources){
-        while (subStream.available() > 0){
+      for ((subStream, wrapper, parentStream) <- sources) {
+        while (subStream.available() > 0) {
           readSomething = true
           val array = new Array[Byte](subStream.available())
           val actuallyRead = subStream.read(array)
@@ -179,7 +175,7 @@ object Jvm {
         }
       }
       // if we did not read anything sleep briefly to avoid spinning
-      if(!readSomething)
+      if (!readSomething)
         Thread.sleep(2)
     }
 
@@ -189,16 +185,17 @@ object Jvm {
 
   private def createManifest(mainClass: Option[String]) = {
     val m = new java.util.jar.Manifest()
-    m.getMainAttributes.put(java.util.jar.Attributes.Name.MANIFEST_VERSION, "1.0")
-    m.getMainAttributes.putValue( "Created-By", "Scala mill" )
+    m.getMainAttributes
+      .put(java.util.jar.Attributes.Name.MANIFEST_VERSION, "1.0")
+    m.getMainAttributes.putValue("Created-By", "Scala mill")
     mainClass.foreach(
       m.getMainAttributes.put(java.util.jar.Attributes.Name.MAIN_CLASS, _)
     )
     m
   }
 
-  def createJar(inputPaths: Agg[Path], mainClass: Option[String] = None)
-               (implicit ctx: Ctx.Dest): PathRef = {
+  def createJar(inputPaths: Agg[Path], mainClass: Option[String] = None)(
+      implicit ctx: Ctx.Dest): PathRef = {
     val outputPath = ctx.dest / "out.jar"
     rm(outputPath)
 
@@ -209,13 +206,12 @@ object Jvm {
       createManifest(mainClass)
     )
 
-    try{
+    try {
       assert(inputPaths.forall(exists(_)))
-      for{
+      for {
         p <- inputPaths
-        (file, mapping) <-
-          if (p.isFile) Iterator(p -> empty/p.last)
-          else ls.rec(p).filter(_.isFile).map(sub => sub -> sub.relativeTo(p))
+        (file, mapping) <- if (p.isFile) Iterator(p -> empty / p.last)
+        else ls.rec(p).filter(_.isFile).map(sub => sub -> sub.relativeTo(p))
         if !seen(mapping)
       } {
         seen.add(mapping)
@@ -238,20 +234,20 @@ object Jvm {
     StandardOpenOption.CREATE
   )
 
-  def createAssembly(inputPaths: Agg[Path],
-                     mainClass: Option[String] = None,
-                     prependShellScript: String = "",
-                     base: Option[Path] = None,
-                     isWin: Boolean = scala.util.Properties.isWin)
-                    (implicit ctx: Ctx.Dest) = {
+  def createAssembly(
+      inputPaths: Agg[Path],
+      mainClass: Option[String] = None,
+      prependShellScript: String = "",
+      base: Option[Path] = None,
+      isWin: Boolean = scala.util.Properties.isWin)(implicit ctx: Ctx.Dest) = {
     val tmp = ctx.dest / "out-tmp.jar"
 
     val baseUri = "jar:" + tmp.toIO.getCanonicalFile.toURI.toASCIIString
     val hm = new java.util.HashMap[String, String]()
 
-    base match{
+    base match {
       case Some(b) => cp(b, tmp)
-      case None => hm.put("create", "true")
+      case None    => hm.put("create", "true")
     }
 
     val zipFs = FileSystems.newFileSystem(URI.create(baseUri), hm)
@@ -264,9 +260,10 @@ object Jvm {
     manifestOut.close()
 
     def isSignatureFile(mapping: String): Boolean =
-      Set("sf", "rsa", "dsa").exists(ext => mapping.toLowerCase.endsWith(s".$ext"))
+      Set("sf", "rsa", "dsa").exists(ext =>
+        mapping.toLowerCase.endsWith(s".$ext"))
 
-    for(v <- classpathIterator(inputPaths)){
+    for (v <- classpathIterator(inputPaths)) {
       val (file, mapping) = v
       val p = zipFs.getPath(mapping)
       if (p.getParent != null) Files.createDirectories(p.getParent)
@@ -282,10 +279,12 @@ object Jvm {
 
     // Prepend shell script and make it executable
     if (prependShellScript.isEmpty) mv(tmp, output)
-    else{
+    else {
       val lineSep = if (!prependShellScript.endsWith("\n")) "\n\r\n" else ""
       val outputStream = newOutputStream(output.toNIO)
-      IO.stream(new ByteArrayInputStream((prependShellScript + lineSep).getBytes()), outputStream)
+      IO.stream(
+        new ByteArrayInputStream((prependShellScript + lineSep).getBytes()),
+        outputStream)
       IO.stream(read.getInputStream(tmp), outputStream)
       outputStream.close()
 
@@ -301,26 +300,26 @@ object Jvm {
     PathRef(output)
   }
 
-
   def classpathIterator(inputPaths: Agg[Path]) = {
-    Generator.from(inputPaths)
+    Generator
+      .from(inputPaths)
       .filter(exists)
-      .flatMap{
-        p =>
-          if (p.isFile) {
-            val jf = new JarFile(p.toIO)
-            import collection.JavaConverters._
-            Generator.selfClosing((
-              for(entry <- jf.entries().asScala if !entry.isDirectory)
+      .flatMap { p =>
+        if (p.isFile) {
+          val jf = new JarFile(p.toIO)
+          import collection.JavaConverters._
+          Generator.selfClosing(
+            (
+              for (entry <- jf.entries().asScala if !entry.isDirectory)
                 yield (jf.getInputStream(entry), entry.getName),
               () => jf.close()
             ))
-          }
-          else {
-            ls.rec.iter(p)
-              .filter(_.isFile)
-              .map(sub => read.getInputStream(sub) -> sub.relativeTo(p).toString)
-          }
+        } else {
+          ls.rec
+            .iter(p)
+            .filter(_.isFile)
+            .map(sub => read.getInputStream(sub) -> sub.relativeTo(p).toString)
+        }
       }
 
   }
@@ -352,16 +351,17 @@ object Jvm {
                               shebang: Boolean = false) = {
     universalScript(
       shellCommands =
-        s"""exec java ${jvmArgs.mkString(" ")} $$JAVA_OPTS -cp "${shellClassPath.mkString(":")}" $mainClass "$$@"""",
+        s"""exec java ${jvmArgs.mkString(" ")} $$JAVA_OPTS -cp "${shellClassPath
+          .mkString(":")}" $mainClass "$$@"""",
       cmdCommands =
-        s"""java ${jvmArgs.mkString(" ")} %JAVA_OPTS% -cp "${cmdClassPath.mkString(";")}" $mainClass %*""",
+        s"""java ${jvmArgs.mkString(" ")} %JAVA_OPTS% -cp "${cmdClassPath
+          .mkString(";")}" $mainClass %*""",
       shebang = shebang
     )
   }
   def createLauncher(mainClass: String,
                      classPath: Agg[Path],
-                     jvmArgs: Seq[String])
-                    (implicit ctx: Ctx.Dest)= {
+                     jvmArgs: Seq[String])(implicit ctx: Ctx.Dest) = {
     val isWin = scala.util.Properties.isWin
     val isBatch = isWin &&
       !(org.jline.utils.OSUtils.IS_CYGWIN
@@ -370,7 +370,9 @@ object Jvm {
     val outputPath = ctx.dest / (if (isBatch) "run.bat" else "run")
     val classPathStrs = classPath.map(_.toString)
 
-    write(outputPath, launcherUniversalScript(mainClass, classPathStrs, classPathStrs, jvmArgs))
+    write(
+      outputPath,
+      launcherUniversalScript(mainClass, classPathStrs, classPathStrs, jvmArgs))
 
     if (!isWin) {
       val perms = Files.getPosixFilePermissions(outputPath.toNIO)
@@ -393,36 +395,48 @@ object Jvm {
                           deps: TraversableOnce[coursier.Dependency],
                           force: TraversableOnce[coursier.Dependency],
                           sources: Boolean = false,
-                          mapDependencies: Option[Dependency => Dependency] = None): Result[Agg[PathRef]] = {
+                          mapDependencies: Option[Dependency => Dependency] =
+                            None): Result[Agg[PathRef]] = {
 
     val (_, resolution) = resolveDependenciesMetadata(
-      repositories, deps, force, mapDependencies
+      repositories,
+      deps,
+      force,
+      mapDependencies
     )
     val errs = resolution.metadataErrors
-    if(errs.nonEmpty) {
+    if (errs.nonEmpty) {
       val header =
         s"""|
             |Resolution failed for ${errs.length} modules:
             |--------------------------------------------
             |""".stripMargin
 
-      val errLines = errs.map {
-        case ((module, vsn), errMsgs) => s"  ${module.trim}:$vsn \n\t" + errMsgs.mkString("\n\t")
-      }.mkString("\n")
+      val errLines = errs
+        .map {
+          case ((module, vsn), errMsgs) =>
+            s"  ${module.trim}:$vsn \n\t" + errMsgs.mkString("\n\t")
+        }
+        .mkString("\n")
       val msg = header + errLines + "\n"
       Result.Failure(msg)
     } else {
 
       def load(artifacts: Seq[coursier.Artifact]) = {
         val logger = None
-        val loadedArtifacts = scalaz.concurrent.Task.gatherUnordered(
-          for (a <- artifacts)
-            yield coursier.Cache.file(a, logger = logger).run
-              .map(a.isOptional -> _)
-        ).unsafePerformSync
+        val loadedArtifacts = scalaz.concurrent.Task
+          .gatherUnordered(
+            for (a <- artifacts)
+              yield
+                coursier.Cache
+                  .file(a, logger = logger)
+                  .run
+                  .map(a.isOptional -> _)
+          )
+          .unsafePerformSync
 
         val errors = loadedArtifacts.collect {
-          case (false, scalaz.-\/(x)) => x
+          case (false, scalaz.-\/(x))               => x
           case (true, scalaz.-\/(x)) if !x.notFound => x
         }
         val successes = loadedArtifacts.collect { case (_, scalaz.\/-(x)) => x }
@@ -433,26 +447,32 @@ object Jvm {
         if (sources) resolution.classifiersArtifacts(Seq("sources"))
         else resolution.artifacts(true)
       val (errors, successes) = load(sourceOrJar)
-      if(errors.isEmpty){
+      if (errors.isEmpty) {
         mill.Agg.from(
-          successes.map(p => PathRef(Path(p), quick = true)).filter(_.path.ext == "jar")
+          successes
+            .map(p => PathRef(Path(p), quick = true))
+            .filter(_.path.ext == "jar")
         )
-      }else{
-        val errorDetails = errors.map(e => s"${ammonite.util.Util.newLine}  ${e.describe}").mkString
+      } else {
+        val errorDetails = errors
+          .map(e => s"${ammonite.util.Util.newLine}  ${e.describe}")
+          .mkString
         Result.Failure("Failed to load source dependencies" + errorDetails)
       }
     }
   }
 
-
-  def resolveDependenciesMetadata(repositories: Seq[Repository],
-                                  deps: TraversableOnce[coursier.Dependency],
-                                  force: TraversableOnce[coursier.Dependency],
-                                  mapDependencies: Option[Dependency => Dependency] = None) = {
+  def resolveDependenciesMetadata(
+      repositories: Seq[Repository],
+      deps: TraversableOnce[coursier.Dependency],
+      force: TraversableOnce[coursier.Dependency],
+      mapDependencies: Option[Dependency => Dependency] = None) = {
 
     val forceVersions = force
       .map(mapDependencies.getOrElse(identity[Dependency](_)))
-      .map{d => d.module -> d.version}
+      .map { d =>
+        d.module -> d.version
+      }
       .toMap
 
     val start = Resolution(

--- a/main/src/mill/modules/Util.scala
+++ b/main/src/mill/modules/Util.scala
@@ -1,45 +1,45 @@
 package mill.modules
 
-
 import ammonite.ops.{Path, RelPath, empty, mkdir, read}
 import coursier.Repository
 import mill.eval.PathRef
 import mill.util.{Ctx, IO, Loose}
 
 object Util {
-  def download(url: String, dest: RelPath = "download")(implicit ctx: Ctx.Dest) = {
+  def download(url: String, dest: RelPath = "download")(
+      implicit ctx: Ctx.Dest) = {
     val out = ctx.dest / dest
 
     val website = new java.net.URI(url).toURL
     val rbc = java.nio.channels.Channels.newChannel(website.openStream)
-    try{
+    try {
       val fos = new java.io.FileOutputStream(out.toIO)
-      try{
+      try {
         fos.getChannel.transferFrom(rbc, 0, java.lang.Long.MAX_VALUE)
         PathRef(out)
-      } finally{
+      } finally {
         fos.close()
       }
-    } finally{
+    } finally {
       rbc.close()
     }
   }
 
-  def downloadUnpackZip(url: String, dest: RelPath = "unpacked")
-                       (implicit ctx: Ctx.Dest) = {
+  def downloadUnpackZip(url: String, dest: RelPath = "unpacked")(
+      implicit ctx: Ctx.Dest) = {
 
     val tmpName = if (dest == empty / "tmp.zip") "tmp2.zip" else "tmp.zip"
     val downloaded = download(url, tmpName)
     unpackZip(downloaded.path, dest)
   }
 
-  def unpackZip(src: Path, dest: RelPath = "unpacked")
-               (implicit ctx: Ctx.Dest) = {
+  def unpackZip(src: Path, dest: RelPath = "unpacked")(
+      implicit ctx: Ctx.Dest) = {
 
     val byteStream = read.getInputStream(src)
     val zipStream = new java.util.zip.ZipInputStream(byteStream)
-    while({
-      zipStream.getNextEntry match{
+    while ({
+      zipStream.getNextEntry match {
         case null => false
         case entry =>
           if (!entry.isDirectory) {
@@ -52,7 +52,7 @@ object Util {
           zipStream.closeEntry()
           true
       }
-    })()
+    }) ()
     PathRef(ctx.dest / dest)
   }
 
@@ -63,19 +63,22 @@ object Util {
     val localPath = sys.props(key)
     if (localPath != null) {
       mill.eval.Result.Success(
-        Loose.Agg.from(localPath.split(',').map(p => PathRef(Path(p), quick = true)))
+        Loose.Agg.from(
+          localPath.split(',').map(p => PathRef(Path(p), quick = true)))
       )
     } else {
-      mill.modules.Jvm.resolveDependencies(
-        repositories,
-        Seq(
-          coursier.Dependency(
-            coursier.Module("com.lihaoyi", artifact + "_2.12"),
-            sys.props("MILL_VERSION")
-          )
-        ),
-        Nil
-      ).map(_.filter(x => resolveFilter(x.path)))
+      mill.modules.Jvm
+        .resolveDependencies(
+          repositories,
+          Seq(
+            coursier.Dependency(
+              coursier.Module("com.lihaoyi", artifact + "_2.12"),
+              sys.props("MILL_VERSION")
+            )
+          ),
+          Nil
+        )
+        .map(_.filter(x => resolveFilter(x.path)))
     }
   }
 }

--- a/main/src/mill/package.scala
+++ b/main/src/mill/package.scala
@@ -1,6 +1,6 @@
 import mill.util.JsonFormatters
 
-package object mill extends JsonFormatters{
+package object mill extends JsonFormatters {
   val T = define.Target
   type T[T] = define.Target[T]
   val PathRef = mill.eval.PathRef

--- a/main/test/src/mill/TestMain.scala
+++ b/main/test/src/mill/TestMain.scala
@@ -1,6 +1,5 @@
 package mill
 
 object TestMain {
-  def main(args: Array[String]): Unit = {
-  }
+  def main(args: Array[String]): Unit = {}
 }

--- a/main/test/src/mill/define/ApplicativeTests.scala
+++ b/main/test/src/mill/define/ApplicativeTests.scala
@@ -6,21 +6,23 @@ import utest._
 import scala.annotation.compileTimeOnly
 import scala.language.experimental.macros
 
-
 object ApplicativeTests extends TestSuite {
   implicit def optionToOpt[T](o: Option[T]): Opt[T] = new Opt(o)
   class Opt[T](val self: Option[T]) extends Applicative.Applyable[Option, T]
-  object Opt extends OptGenerated with Applicative.Applyer[Opt, Option, Applicative.Id, String]{
+  object Opt
+      extends OptGenerated
+      with Applicative.Applyer[Opt, Option, Applicative.Id, String] {
 
     val injectedCtx = "helloooo"
     def underlying[A](v: Opt[A]) = v.self
     def apply[T](t: T): Option[T] = macro Applicative.impl[Option, T, String]
 
-    def mapCtx[A, B](a: Option[A])(f: (A, String) => B): Option[B] = a.map(f(_, injectedCtx))
+    def mapCtx[A, B](a: Option[A])(f: (A, String) => B): Option[B] =
+      a.map(f(_, injectedCtx))
     def zip() = Some(())
     def zip[A](a: Option[A]) = a.map(Tuple1(_))
   }
-  class Counter{
+  class Counter {
     var value = 0
     def apply() = {
       value += 1
@@ -31,13 +33,14 @@ object ApplicativeTests extends TestSuite {
   @ImplicitStub
   implicit def taskCtx: String = ???
 
-  val tests = Tests{
+  val tests = Tests {
 
     'selfContained - {
 
       'simple - assert(Opt("lol " + 1) == Some("lol 1"))
       'singleSome - assert(Opt("lol " + Some("hello")()) == Some("lol hello"))
-      'twoSomes - assert(Opt(Some("lol ")() + Some("hello")()) == Some("lol hello"))
+      'twoSomes - assert(
+        Opt(Some("lol ")() + Some("hello")()) == Some("lol hello"))
       'singleNone - assert(Opt("lol " + None()) == None)
       'twoNones - assert(Opt("lol " + None() + None()) == None)
     }
@@ -49,7 +52,8 @@ object ApplicativeTests extends TestSuite {
       def hell(o: String) = "hell" + o
       'simple - assert(Opt(lol + 1) == Some("lol 1"))
       'singleSome - assert(Opt(lol + Some(hell("o"))()) == Some("lol hello"))
-      'twoSomes - assert(Opt(Some(lol)() + Some(hell("o"))()) == Some("lol hello"))
+      'twoSomes - assert(
+        Opt(Some(lol)() + Some(hell("o"))()) == Some("lol hello"))
       'singleNone - assert(Opt(lol + None()) == None)
       'twoNones - assert(Opt(lol + None() + None()) == None)
     }
@@ -57,7 +61,7 @@ object ApplicativeTests extends TestSuite {
       // Although x is defined inside the Opt{...} block, it is also defined
       // within the LHS of the Applyable#apply call, so it is safe to life it
       // out into the `zipMap` arguments list.
-      val res = Opt{ "lol " + Some("hello").flatMap(x => Some(x)).apply() }
+      val res = Opt { "lol " + Some("hello").flatMap(x => Some(x)).apply() }
       assert(res == Some("lol hello"))
     }
     'upstreamAlwaysEvaluated - {
@@ -65,8 +69,8 @@ object ApplicativeTests extends TestSuite {
       // Opt{...} block, we always evaluate the LHS of the Applyable#apply
       // because it gets lifted out of any control flow statements
       val counter = new Counter()
-      def up = Opt{ "lol " + counter() }
-      val down = Opt{ if ("lol".length > 10) up() else "fail" }
+      def up = Opt { "lol " + counter() }
+      val down = Opt { if ("lol".length > 10) up() else "fail" }
       assert(
         down == Some("fail"),
         counter.value == 1
@@ -76,9 +80,9 @@ object ApplicativeTests extends TestSuite {
       // Even if control-flow reaches the Applyable#apply call more than once,
       // it only gets evaluated once due to its lifting out of the Opt{...} block
       val counter = new Counter()
-      def up = Opt{ "lol " + counter() }
+      def up = Opt { "lol " + counter() }
       def runTwice[T](t: => T) = (t, t)
-      val down = Opt{ runTwice(up()) }
+      val down = Opt { runTwice(up()) }
       assert(
         down == Some(("lol 1", "lol 1")),
         counter.value == 1
@@ -88,9 +92,9 @@ object ApplicativeTests extends TestSuite {
       // This required some fiddling with owner chains inside the macro to get
       // working, so ensure it doesn't regress
       val counter = new Counter()
-      def up = Opt{ "hello" + counter() }
-      val down1 = Opt{ (() => up())() }
-      val down2 = Opt{ Seq(1, 2, 3).map(n => up() * n) }
+      def up = Opt { "hello" + counter() }
+      val down1 = Opt { (() => up())() }
+      val down2 = Opt { Seq(1, 2, 3).map(n => up() * n) }
       assert(
         down1 == Some("hello1"),
         down2 == Some(Seq("hello2", "hello2hello2", "hello2hello2hello2"))
@@ -102,17 +106,18 @@ object ApplicativeTests extends TestSuite {
       // apply() call is identical. It's up to the downstream zipMap()
       // implementation to decide if it wants to dedup them or do other things.
       val counter = new Counter()
-      def up = Opt{ "hello" + counter() }
-      val down = Opt{ Seq(1, 2, 3).map(n => n + up() + up()) }
-      assert(down == Some(Seq("1hello1hello2", "2hello1hello2", "3hello1hello2")))
+      def up = Opt { "hello" + counter() }
+      val down = Opt { Seq(1, 2, 3).map(n => n + up() + up()) }
+      assert(
+        down == Some(Seq("1hello1hello2", "2hello1hello2", "3hello1hello2")))
     }
     'appliesEvaluateBeforehand - {
       // Every Applyable#apply() within a Opt{...} block evaluates before any
       // other logic within that block, even if they would happen first in the
       // normal Scala evaluation order
       val counter = new Counter()
-      def up = Opt{ counter() }
-      val down = Opt{
+      def up = Opt { counter() }
+      val down = Opt {
         val res = counter()
         val one = up()
         val two = up()

--- a/main/test/src/mill/define/BasePathTests.scala
+++ b/main/test/src/mill/define/BasePathTests.scala
@@ -4,9 +4,9 @@ import mill.util.{TestGraphs, TestUtil}
 import utest._
 import ammonite.ops._
 import mill.{Module, T}
-object BasePathTests extends TestSuite{
+object BasePathTests extends TestSuite {
   val testGraphs = new TestGraphs
-  val tests = Tests{
+  val tests = Tests {
     def check[T <: Module](m: T)(f: T => Module, segments: String*) = {
       val remaining = f(m).millSourcePath.relativeTo(m.millSourcePath).segments
       assert(remaining == segments)
@@ -20,7 +20,7 @@ object BasePathTests extends TestSuite{
     'TraitWithModuleObject - {
       check(TestGraphs.TraitWithModuleObject)(
         _.TraitModule,
-       "TraitModule"
+        "TraitModule"
       )
     }
     'nestedModuleNested - {
@@ -36,23 +36,31 @@ object BasePathTests extends TestSuite{
     }
     'doubleCross - {
       check(TestGraphs.doubleCross)(_.cross, "cross")
-      check(TestGraphs.doubleCross)(_.cross("210", "jvm"), "cross", "210", "jvm")
+      check(TestGraphs.doubleCross)(_.cross("210", "jvm"),
+                                    "cross",
+                                    "210",
+                                    "jvm")
       check(TestGraphs.doubleCross)(_.cross("212", "js"), "cross", "212", "js")
     }
     'nestedCrosses - {
       check(TestGraphs.nestedCrosses)(_.cross, "cross")
       check(TestGraphs.nestedCrosses)(
         _.cross("210").cross2("js"),
-        "cross", "210", "cross2", "js"
+        "cross",
+        "210",
+        "cross2",
+        "js"
       )
     }
     'overriden - {
       object overridenBasePath extends TestUtil.BaseModule {
         override def millSourcePath = pwd / 'overridenBasePathRootValue
-        object nested extends Module{
-          override def millSourcePath = super.millSourcePath / 'overridenBasePathNested
-          object nested extends Module{
-            override def millSourcePath = super.millSourcePath / 'overridenBasePathDoubleNested
+        object nested extends Module {
+          override def millSourcePath =
+            super.millSourcePath / 'overridenBasePathNested
+          object nested extends Module {
+            override def millSourcePath =
+              super.millSourcePath / 'overridenBasePathDoubleNested
           }
         }
       }
@@ -65,4 +73,3 @@ object BasePathTests extends TestSuite{
 
   }
 }
-

--- a/main/test/src/mill/define/CacherTests.scala
+++ b/main/test/src/mill/define/CacherTests.scala
@@ -8,26 +8,25 @@ import mill.eval.Result.Success
 import utest._
 import utest.framework.TestPath
 
-
-object CacherTests extends TestSuite{
+object CacherTests extends TestSuite {
   object Base extends Base
-  trait Base extends TestUtil.BaseModule{
-    def value = T{ 1 }
-    def result = T{ Success(1) }
+  trait Base extends TestUtil.BaseModule {
+    def value = T { 1 }
+    def result = T { Success(1) }
   }
   object Middle extends Middle
-  trait Middle extends Base{
-    override def value = T{ super.value() + 2}
-    def overriden = T{ super.value()}
+  trait Middle extends Base {
+    override def value = T { super.value() + 2 }
+    def overriden = T { super.value() }
   }
-  object Terminal extends  Terminal
-  trait Terminal extends Middle{
-    override def value = T{ super.value() + 4}
+  object Terminal extends Terminal
+  trait Terminal extends Middle {
+    override def value = T { super.value() + 4 }
   }
 
-  val tests = Tests{
-    def eval[T <: TestUtil.BaseModule, V](mapping: T, v: Task[V])
-                                         (implicit tp: TestPath) = {
+  val tests = Tests {
+    def eval[T <: TestUtil.BaseModule, V](mapping: T,
+                                          v: Task[V])(implicit tp: TestPath) = {
       val evaluator = new TestEvaluator(mapping)
       evaluator(v).right.get._1
     }
@@ -43,7 +42,6 @@ object CacherTests extends TestSuite{
       Predef.assert(eval(Base, Base.result) == 1)
     }
 
-
     'overridingDefIsAlsoCached - {
       Predef.assert(eval(Middle, Middle.value) == 3)
       Predef.assert(Middle.value eq Middle.value)
@@ -53,8 +51,7 @@ object CacherTests extends TestSuite{
       Predef.assert(eval(Middle, Middle.overriden) == 1)
     }
 
-
-    'multipleOverridesWork- {
+    'multipleOverridesWork - {
       Predef.assert(eval(Terminal, Terminal.value) == 7)
       Predef.assert(eval(Terminal, Terminal.overriden) == 1)
     }
@@ -73,4 +70,3 @@ object CacherTests extends TestSuite{
     //    }
   }
 }
-

--- a/main/test/src/mill/define/DiscoverTests.scala
+++ b/main/test/src/mill/define/DiscoverTests.scala
@@ -3,9 +3,9 @@ package mill.define
 import mill.util.TestGraphs
 import utest._
 
-object DiscoverTests extends TestSuite{
+object DiscoverTests extends TestSuite {
   val testGraphs = new TestGraphs
-  val tests = Tests{
+  val tests = Tests {
     def check[T <: Module](m: T)(targets: (T => Target[_])*) = {
       val discovered = m.millInternal.targets
       val expected = targets.map(_(m)).toSet
@@ -21,7 +21,9 @@ object DiscoverTests extends TestSuite{
       check(TestGraphs.TraitWithModuleObject)(_.TraitModule.testFrameworks)
     }
     'nestedModule - {
-      check(TestGraphs.nestedModule)(_.single, _.nested.single, _.classInstance.single)
+      check(TestGraphs.nestedModule)(_.single,
+                                     _.nested.single,
+                                     _.classInstance.single)
     }
     'singleCross - {
       check(TestGraphs.singleCross)(
@@ -57,4 +59,3 @@ object DiscoverTests extends TestSuite{
 
   }
 }
-

--- a/main/test/src/mill/define/GraphTests.scala
+++ b/main/test/src/mill/define/GraphTests.scala
@@ -1,14 +1,12 @@
 package mill.define
 
-
 import mill.eval.Evaluator
 import mill.util.{TestGraphs, TestUtil}
 import utest._
 import mill.util.Strict.Agg
-object GraphTests extends TestSuite{
+object GraphTests extends TestSuite {
 
-  val tests = Tests{
-
+  val tests = Tests {
 
     val graphs = new TestGraphs()
     import graphs._
@@ -31,7 +29,8 @@ object GraphTests extends TestSuite{
       )
       'anonTriple - check(
         targets = Agg(anonTriple.down),
-        expected = Agg(anonTriple.up, anonTriple.down.inputs(0), anonTriple.down)
+        expected =
+          Agg(anonTriple.up, anonTriple.down.inputs(0), anonTriple.down)
       )
       'diamond - check(
         targets = Agg(diamond.down),
@@ -60,21 +59,23 @@ object GraphTests extends TestSuite{
         )
       )
       'bigSingleTerminal - {
-        val result = Graph.topoSorted(Graph.transitiveTargets(Agg(bigSingleTerminal.j))).values
+        val result = Graph
+          .topoSorted(Graph.transitiveTargets(Agg(bigSingleTerminal.j)))
+          .values
         TestUtil.checkTopological(result)
         assert(result.size == 28)
       }
     }
 
     'groupAroundNamedTargets - {
-      def check[T, R <: Target[Int]](base: T)
-                                    (target: T => R,
-                                     important0: Agg[T => Target[_]],
-                                     expected: Agg[(R, Int)]) = {
+      def check[T, R <: Target[Int]](base: T)(target: T => R,
+                                              important0: Agg[T => Target[_]],
+                                              expected: Agg[(R, Int)]) = {
 
-        val topoSorted = Graph.topoSorted(Graph.transitiveTargets(Agg(target(base))))
+        val topoSorted =
+          Graph.topoSorted(Graph.transitiveTargets(Agg(target(base))))
 
-        val important = important0.map(_ (base))
+        val important = important0.map(_(base))
         val grouped = Graph.groupAroundImportantTargets(topoSorted) {
           case t: Target[_] if important.contains(t) => t
         }
@@ -85,7 +86,9 @@ object GraphTests extends TestSuite{
           val grouping = grouped.lookupKey(terminal)
           assert(
             grouping.size == expectedSize,
-            grouping.flatMap(_.asTarget: Option[Target[_]]).filter(important.contains) == Agg(terminal)
+            grouping
+              .flatMap(_.asTarget: Option[Target[_]])
+              .filter(important.contains) == Agg(terminal)
           )
         }
       }
@@ -155,7 +158,7 @@ object GraphTests extends TestSuite{
           Graph.transitiveTargets(Agg.from(goals))
         )
         val grouped = Graph.groupAroundImportantTargets(topoSorted) {
-          case t: NamedTask[Any] => t
+          case t: NamedTask[Any]      => t
           case t if goals.contains(t) => t
         }
         grouped.keyCount
@@ -176,14 +179,12 @@ object GraphTests extends TestSuite{
         assert(groupCount == 2)
       }
 
-
       'multiTerminalGroup - {
         // Make sure the following graph ends up as two groups
         import multiTerminalGroup._
         val groupCount = countGroups(right, left)
         assert(groupCount == 2)
       }
-
 
       'multiTerminalBoundary - {
         // Make sure the following graph ends up as a three groups: one for
@@ -193,7 +194,6 @@ object GraphTests extends TestSuite{
         assert(groupCount == 3)
       }
     }
-
 
   }
 }

--- a/main/test/src/mill/define/MacroErrorTests.scala
+++ b/main/test/src/mill/define/MacroErrorTests.scala
@@ -3,15 +3,16 @@ package mill.define
 import utest._
 import mill.{T, Module}
 import mill.util.TestUtil
-object MacroErrorTests extends TestSuite{
+object MacroErrorTests extends TestSuite {
 
-  val tests = Tests{
+  val tests = Tests {
 
-    'errors{
+    'errors {
       val expectedMsg =
         "T{} members must be defs defined in a Cacher class/trait/object body"
 
-      val err = compileError("object Foo extends TestUtil.BaseModule{ val x = T{1} }")
+      val err =
+        compileError("object Foo extends TestUtil.BaseModule{ val x = T{1} }")
       assert(err.msg == expectedMsg)
     }
 
@@ -72,7 +73,8 @@ object MacroErrorTests extends TestSuite{
           mill.define.Discover[foo.type]
         """)
         assert(
-          e.msg.contains("`T.persistent` definitions must have 0 parameter lists"),
+          e.msg.contains(
+            "`T.persistent` definitions must have 0 parameter lists"),
           e.pos.contains("def a() = ")
         )
       }
@@ -93,8 +95,7 @@ object MacroErrorTests extends TestSuite{
           }
         """)
         assert(e.msg.contains(
-          "Modules, Targets and Commands can only be defined within a mill Module")
-        )
+          "Modules, Targets and Commands can only be defined within a mill Module"))
       }
       'neg - {
 
@@ -127,8 +128,9 @@ object MacroErrorTests extends TestSuite{
         }""")
         assert(err.msg == expectedMsg)
       }
-      'neg3{
-        val borkedCachedDiamond1 = utest.compileError("""
+      'neg3 {
+        val borkedCachedDiamond1 =
+          utest.compileError("""
           object borkedCachedDiamond1 {
             def up = T{ TestUtil.test() }
             def left = T{ TestUtil.test(up) }
@@ -137,8 +139,7 @@ object MacroErrorTests extends TestSuite{
           }
         """)
         assert(borkedCachedDiamond1.msg.contains(
-          "Modules, Targets and Commands can only be defined within a mill Module")
-        )
+          "Modules, Targets and Commands can only be defined within a mill Module"))
       }
     }
   }

--- a/main/test/src/mill/eval/CrossTests.scala
+++ b/main/test/src/mill/eval/CrossTests.scala
@@ -4,10 +4,15 @@ import ammonite.ops._
 import mill.define.Discover
 import mill.util.TestEvaluator
 
-import mill.util.TestGraphs.{crossResolved, doubleCross, nestedCrosses, singleCross}
+import mill.util.TestGraphs.{
+  crossResolved,
+  doubleCross,
+  nestedCrosses,
+  singleCross
+}
 import utest._
-object CrossTests extends TestSuite{
-  val tests = Tests{
+object CrossTests extends TestSuite {
+  val tests = Tests {
     'singleCross - {
       val check = new TestEvaluator(singleCross)
 
@@ -23,34 +28,50 @@ object CrossTests extends TestSuite{
       val Right(("2.11", 1)) = check.apply(crossResolved.foo("2.11").suffix)
       val Right(("2.12", 1)) = check.apply(crossResolved.foo("2.12").suffix)
 
-      val Right(("_2.10", 1)) = check.apply(crossResolved.bar("2.10").longSuffix)
-      val Right(("_2.11", 1)) = check.apply(crossResolved.bar("2.11").longSuffix)
-      val Right(("_2.12", 1)) = check.apply(crossResolved.bar("2.12").longSuffix)
+      val Right(("_2.10", 1)) =
+        check.apply(crossResolved.bar("2.10").longSuffix)
+      val Right(("_2.11", 1)) =
+        check.apply(crossResolved.bar("2.11").longSuffix)
+      val Right(("_2.12", 1)) =
+        check.apply(crossResolved.bar("2.12").longSuffix)
     }
-
 
     'doubleCross - {
       val check = new TestEvaluator(doubleCross)
 
-      val Right(("210_jvm", 1)) = check.apply(doubleCross.cross("210", "jvm").suffix)
-      val Right(("210_js", 1)) = check.apply(doubleCross.cross("210", "js").suffix)
-      val Right(("211_jvm", 1)) = check.apply(doubleCross.cross("211", "jvm").suffix)
-      val Right(("211_js", 1)) = check.apply(doubleCross.cross("211", "js").suffix)
-      val Right(("212_jvm", 1)) = check.apply(doubleCross.cross("212", "jvm").suffix)
-      val Right(("212_js", 1)) = check.apply(doubleCross.cross("212", "js").suffix)
-      val Right(("212_native", 1)) = check.apply(doubleCross.cross("212", "native").suffix)
+      val Right(("210_jvm", 1)) =
+        check.apply(doubleCross.cross("210", "jvm").suffix)
+      val Right(("210_js", 1)) =
+        check.apply(doubleCross.cross("210", "js").suffix)
+      val Right(("211_jvm", 1)) =
+        check.apply(doubleCross.cross("211", "jvm").suffix)
+      val Right(("211_js", 1)) =
+        check.apply(doubleCross.cross("211", "js").suffix)
+      val Right(("212_jvm", 1)) =
+        check.apply(doubleCross.cross("212", "jvm").suffix)
+      val Right(("212_js", 1)) =
+        check.apply(doubleCross.cross("212", "js").suffix)
+      val Right(("212_native", 1)) =
+        check.apply(doubleCross.cross("212", "native").suffix)
     }
 
     'nestedCrosses - {
       val check = new TestEvaluator(nestedCrosses)
 
-      val Right(("210_jvm", 1)) = check.apply(nestedCrosses.cross("210").cross2("jvm").suffix)
-      val Right(("210_js", 1)) = check.apply(nestedCrosses.cross("210").cross2("js").suffix)
-      val Right(("211_jvm", 1)) = check.apply(nestedCrosses.cross("211").cross2("jvm").suffix)
-      val Right(("211_js", 1)) = check.apply(nestedCrosses.cross("211").cross2("js").suffix)
-      val Right(("212_jvm", 1)) = check.apply(nestedCrosses.cross("212").cross2("jvm").suffix)
-      val Right(("212_js", 1)) = check.apply(nestedCrosses.cross("212").cross2("js").suffix)
-      val Right(("212_native", 1)) = check.apply(nestedCrosses.cross("212").cross2("native").suffix)
+      val Right(("210_jvm", 1)) =
+        check.apply(nestedCrosses.cross("210").cross2("jvm").suffix)
+      val Right(("210_js", 1)) =
+        check.apply(nestedCrosses.cross("210").cross2("js").suffix)
+      val Right(("211_jvm", 1)) =
+        check.apply(nestedCrosses.cross("211").cross2("jvm").suffix)
+      val Right(("211_js", 1)) =
+        check.apply(nestedCrosses.cross("211").cross2("js").suffix)
+      val Right(("212_jvm", 1)) =
+        check.apply(nestedCrosses.cross("212").cross2("jvm").suffix)
+      val Right(("212_js", 1)) =
+        check.apply(nestedCrosses.cross("212").cross2("js").suffix)
+      val Right(("212_native", 1)) =
+        check.apply(nestedCrosses.cross("212").cross2("native").suffix)
     }
   }
 }

--- a/main/test/src/mill/eval/EvaluationTests.scala
+++ b/main/test/src/mill/eval/EvaluationTests.scala
@@ -1,6 +1,5 @@
 package mill.eval
 
-
 import mill.util.TestUtil.{Test, test}
 import mill.define.{Discover, Graph, Target, Task}
 import mill.{Module, T}
@@ -11,13 +10,14 @@ import utest.framework.TestPath
 
 import ammonite.ops._
 
-object EvaluationTests extends TestSuite{
+object EvaluationTests extends TestSuite {
   class Checker[T <: TestUtil.BaseModule](module: T)(implicit tp: TestPath) {
     // Make sure data is persisted even if we re-create the evaluator each time
 
     def evaluator = new TestEvaluator(module).evaluator
 
-    def apply(target: Task[_], expValue: Any,
+    def apply(target: Task[_],
+              expValue: Any,
               expEvaled: Agg[Task[_]],
               // How many "other" tasks were evaluated other than those listed above.
               // Pass in -1 to skip the check entirely
@@ -39,7 +39,7 @@ object EvaluationTests extends TestSuite{
       )
 
       // Second time the value is already cached, so no evaluation needed
-      if (secondRunNoOp){
+      if (secondRunNoOp) {
         val evaled2 = evaluator.evaluate(Agg(target))
         val expecteSecondRunEvaluated = Agg()
         assert(
@@ -50,8 +50,7 @@ object EvaluationTests extends TestSuite{
     }
   }
 
-
-  val tests = Tests{
+  val tests = Tests {
     object graphs extends TestGraphs()
     import graphs._
     import TestGraphs._
@@ -137,7 +136,10 @@ object EvaluationTests extends TestSuite{
         import bigSingleTerminal._
         val check = new Checker(bigSingleTerminal)
 
-        check(j, expValue = 0, expEvaled = Agg(a, b, e, f, i, j), extraEvaled = 22)
+        check(j,
+              expValue = 0,
+              expEvaled = Agg(a, b, e, f, i, j),
+              extraEvaled = 22)
 
         j.counter += 1
         check(j, expValue = 1, expEvaled = Agg(j), extraEvaled = 3)
@@ -170,7 +172,6 @@ object EvaluationTests extends TestSuite{
         val filtered3 = evaled3.evaluated.filter(_.isInstanceOf[Target[_]])
         assert(filtered3 == Agg(change, right))
 
-
       }
       'triangleTask - {
 
@@ -193,7 +194,11 @@ object EvaluationTests extends TestSuite{
         import multiTerminalBoundary._
 
         val checker = new Checker(multiTerminalBoundary)
-        checker(task2, 4, Agg(right, left), extraEvaled = -1, secondRunNoOp = false)
+        checker(task2,
+                4,
+                Agg(right, left),
+                extraEvaled = -1,
+                secondRunNoOp = false)
         checker(task2, 4, Agg(), extraEvaled = -1, secondRunNoOp = false)
       }
 
@@ -206,11 +211,11 @@ object EvaluationTests extends TestSuite{
         val checker = new Checker(canOverrideSuper)
         checker(foo, Seq("base", "object"), Agg(foo), extraEvaled = -1)
 
-
-        val public = ammonite.ops.read(checker.evaluator.outPath / 'foo / "meta.json")
+        val public =
+          ammonite.ops.read(checker.evaluator.outPath / 'foo / "meta.json")
         val overriden = ammonite.ops.read(
           checker.evaluator.outPath / 'foo /
-            'overriden / "mill" / "util" / "TestGraphs" / "BaseModule" / "foo"  / "meta.json"
+            'overriden / "mill" / "util" / "TestGraphs" / "BaseModule" / "foo" / "meta.json"
         )
         assert(
           public.contains("base"),
@@ -235,10 +240,11 @@ object EvaluationTests extends TestSuite{
           secondRunNoOp = false
         )
 
-        val public = ammonite.ops.read(checker.evaluator.outPath / 'cmd / "meta.json")
+        val public =
+          ammonite.ops.read(checker.evaluator.outPath / 'cmd / "meta.json")
         val overriden = ammonite.ops.read(
           checker.evaluator.outPath / 'cmd /
-          'overriden / "mill" / "util" / "TestGraphs" / "BaseModule"/ "cmd"  / "meta.json"
+            'overriden / "mill" / "util" / "TestGraphs" / "BaseModule" / "cmd" / "meta.json"
         )
         assert(
           public.contains("base1"),
@@ -283,15 +289,15 @@ object EvaluationTests extends TestSuite{
         // up    middle -- down
         //                /
         //           right
-        object build extends TestUtil.BaseModule{
+        object build extends TestUtil.BaseModule {
           var leftCount = 0
           var rightCount = 0
           var middleCount = 0
-          def up = T{ test.anon() }
-          def left = T.task{ leftCount += 1; up() + 1 }
-          def middle = T.task{ middleCount += 1; 100 }
-          def right = T{ rightCount += 1; 10000 }
-          def down = T{ left() + middle() + right() }
+          def up = T { test.anon() }
+          def left = T.task { leftCount += 1; up() + 1 }
+          def middle = T.task { middleCount += 1; 100 }
+          def right = T { rightCount += 1; 10000 }
+          def down = T { left() + middle() + right() }
         }
 
         import build._
@@ -309,7 +315,10 @@ object EvaluationTests extends TestSuite{
         // cached target
         val check = new Checker(build)
         assert(leftCount == 0, rightCount == 0)
-        check(down, expValue = 10101, expEvaled = Agg(up, right, down), extraEvaled = 8)
+        check(down,
+              expValue = 10101,
+              expEvaled = Agg(up, right, down),
+              extraEvaled = 8)
         assert(leftCount == 1, middleCount == 1, rightCount == 1)
 
         // If the upstream `up` doesn't change, the entire block of tasks
@@ -322,19 +331,38 @@ object EvaluationTests extends TestSuite{
         // because tasks have no cached value that can be used. `right`, which
         // is a cached Target, does not recompute
         up.inputs(0).asInstanceOf[Test].counter += 1
-        check(down, expValue = 10102, expEvaled = Agg(up, down), extraEvaled = 6)
+        check(down,
+              expValue = 10102,
+              expEvaled = Agg(up, down),
+              extraEvaled = 6)
         assert(leftCount == 2, middleCount == 2, rightCount == 1)
 
         // Running the tasks themselves results in them being recomputed every
         // single time, even if nothing changes
-        check(left, expValue = 2, expEvaled = Agg(), extraEvaled = 1, secondRunNoOp = false)
+        check(left,
+              expValue = 2,
+              expEvaled = Agg(),
+              extraEvaled = 1,
+              secondRunNoOp = false)
         assert(leftCount == 3, middleCount == 2, rightCount == 1)
-        check(left, expValue = 2, expEvaled = Agg(), extraEvaled = 1, secondRunNoOp = false)
+        check(left,
+              expValue = 2,
+              expEvaled = Agg(),
+              extraEvaled = 1,
+              secondRunNoOp = false)
         assert(leftCount == 4, middleCount == 2, rightCount == 1)
 
-        check(middle, expValue = 100, expEvaled = Agg(), extraEvaled = 2, secondRunNoOp = false)
+        check(middle,
+              expValue = 100,
+              expEvaled = Agg(),
+              extraEvaled = 2,
+              secondRunNoOp = false)
         assert(leftCount == 4, middleCount == 3, rightCount == 1)
-        check(middle, expValue = 100, expEvaled = Agg(), extraEvaled = 2, secondRunNoOp = false)
+        check(middle,
+              expValue = 100,
+              expEvaled = Agg(),
+              extraEvaled = 2,
+              secondRunNoOp = false)
         assert(leftCount == 4, middleCount == 4, rightCount == 1)
       }
     }

--- a/main/test/src/mill/eval/FailureTests.scala
+++ b/main/test/src/mill/eval/FailureTests.scala
@@ -6,10 +6,9 @@ import mill.eval.Result.OuterStack
 import utest._
 import utest.framework.TestPath
 
+object FailureTests extends TestSuite {
 
-object FailureTests extends TestSuite{
-
-  val tests = Tests{
+  val tests = Tests {
     val graphs = new mill.util.TestGraphs()
     import graphs._
 
@@ -37,10 +36,8 @@ object FailureTests extends TestSuite{
         expectedRawValues = Seq(Result.Success(0))
       )
 
-
       val ex = new IndexOutOfBoundsException()
       singleton.single.exception = Some(ex)
-
 
       check.fail(
         target = singleton.single,
@@ -83,11 +80,13 @@ object FailureTests extends TestSuite{
     'multipleUsesOfDest - {
       object build extends TestUtil.BaseModule {
         // Using `T.ctx(  ).dest` twice in a single task is ok
-        def left = T{ + T.ctx().dest.toString.length + T.ctx().dest.toString.length }
+        def left = T {
+          +T.ctx().dest.toString.length + T.ctx().dest.toString.length
+        }
 
         // Using `T.ctx(  ).dest` once in two different tasks is not ok
-        val task = T.task{ T.ctx().dest.toString.length  }
-        def right = T{ task() + left() + T.ctx().dest.toString().length }
+        val task = T.task { T.ctx().dest.toString.length }
+        def right = T { task() + left() + T.ctx().dest.toString().length }
       }
 
       val check = new TestEvaluator(build)
@@ -97,4 +96,3 @@ object FailureTests extends TestSuite{
     }
   }
 }
-

--- a/main/test/src/mill/eval/ModuleTests.scala
+++ b/main/test/src/mill/eval/ModuleTests.scala
@@ -7,16 +7,16 @@ import mill.define.Discover
 
 import utest._
 
-object ModuleTests extends TestSuite{
+object ModuleTests extends TestSuite {
   object ExternalModule extends mill.define.ExternalModule {
-    def x = T{13}
-    object inner extends mill.Module{
-      def y = T{17}
+    def x = T { 13 }
+    object inner extends mill.Module {
+      def y = T { 17 }
     }
     lazy val millDiscover = Discover[this.type]
   }
-  object Build extends TestUtil.BaseModule{
-    def z = T{ ExternalModule.x() + ExternalModule.inner.y() }
+  object Build extends TestUtil.BaseModule {
+    def z = T { ExternalModule.x() + ExternalModule.inner.y() }
   }
   val tests = Tests {
     rm(TestEvaluator.externalOutPath)
@@ -26,20 +26,23 @@ object ModuleTests extends TestSuite{
       assert(
         zresult == Right((30, 1)),
         read(check.evaluator.outPath / 'z / "meta.json").contains("30"),
-        read(TestEvaluator.externalOutPath / 'mill / 'eval / 'ModuleTests / 'ExternalModule / 'x / "meta.json").contains("13"),
-        read(TestEvaluator.externalOutPath / 'mill / 'eval / 'ModuleTests / 'ExternalModule / 'inner / 'y / "meta.json").contains("17")
+        read(
+          TestEvaluator.externalOutPath / 'mill / 'eval / 'ModuleTests / 'ExternalModule / 'x / "meta.json")
+          .contains("13"),
+        read(
+          TestEvaluator.externalOutPath / 'mill / 'eval / 'ModuleTests / 'ExternalModule / 'inner / 'y / "meta.json")
+          .contains("17")
       )
     }
     'externalModuleMustBeGlobalStatic - {
 
-
       object Build extends mill.define.ExternalModule {
 
-        def z = T{ ExternalModule.x() + ExternalModule.inner.y() }
+        def z = T { ExternalModule.x() + ExternalModule.inner.y() }
         lazy val millDiscover = Discover[this.type]
       }
 
-      intercept[java.lang.AssertionError]{ Build }
+      intercept[java.lang.AssertionError] { Build }
     }
   }
 }

--- a/main/test/src/mill/eval/TarjanTests.scala
+++ b/main/test/src/mill/eval/TarjanTests.scala
@@ -2,26 +2,25 @@ package mill.eval
 
 import utest._
 
-object TarjanTests extends TestSuite{
+object TarjanTests extends TestSuite {
   def check(input: Seq[Seq[Int]], expected: Seq[Seq[Int]]) = {
     val result = Tarjans(input).map(_.sorted)
     val sortedExpected = expected.map(_.sorted)
     assert(result == sortedExpected)
   }
-  val tests = Tests{
+  val tests = Tests {
     //
     'empty - check(Seq(), Seq())
 
     // (0)
     'singleton - check(Seq(Seq()), Seq(Seq(0)))
 
-
     // (0)-.
     //  ^._/
     'selfCycle - check(Seq(Seq(0)), Seq(Seq(0)))
 
     // (0) <-> (1)
-    'simpleCycle- check(Seq(Seq(1), Seq(0)), Seq(Seq(1, 0)))
+    'simpleCycle - check(Seq(Seq(1), Seq(0)), Seq(Seq(1, 0)))
 
     // (0)  (1)  (2)
     'multipleSingletons - check(
@@ -30,13 +29,13 @@ object TarjanTests extends TestSuite{
     )
 
     // (0) -> (1) -> (2)
-    'straightLineNoCycles- check(
+    'straightLineNoCycles - check(
       Seq(Seq(1), Seq(2), Seq()),
       Seq(Seq(2), Seq(1), Seq(0))
     )
 
     // (0) <- (1) <- (2)
-    'straightLineNoCyclesReversed- check(
+    'straightLineNoCyclesReversed - check(
       Seq(Seq(), Seq(0), Seq(1)),
       Seq(Seq(0), Seq(1), Seq(2))
     )
@@ -83,7 +82,16 @@ object TarjanTests extends TestSuite{
     //      v            /
     //     (9) <--------'
     'combinedCycles - check(
-      Seq(Seq(1), Seq(0), Seq(0, 1), Seq(2, 4, 7, 9), Seq(3), Seq(4, 8), Seq(9), Seq(6), Seq(), Seq()),
+      Seq(Seq(1),
+          Seq(0),
+          Seq(0, 1),
+          Seq(2, 4, 7, 9),
+          Seq(3),
+          Seq(4, 8),
+          Seq(9),
+          Seq(6),
+          Seq(),
+          Seq()),
       Seq(Seq(0, 1), Seq(2), Seq(9), Seq(6), Seq(7), Seq(3, 4), Seq(8), Seq(5))
     )
 

--- a/main/test/src/mill/eval/TaskTests.scala
+++ b/main/test/src/mill/eval/TaskTests.scala
@@ -5,50 +5,50 @@ import ammonite.ops._
 import mill.T
 
 import mill.util.TestEvaluator
-object TaskTests extends TestSuite{
-  val tests = Tests{
-    object build extends mill.util.TestUtil.BaseModule{
+object TaskTests extends TestSuite {
+  val tests = Tests {
+    object build extends mill.util.TestUtil.BaseModule {
       var count = 0
       // Explicitly instantiate `Function1` objects to make sure we get
       // different instances each time
-      def staticWorker = T.worker{
+      def staticWorker = T.worker {
         new Function1[Int, Int] {
           def apply(v1: Int) = v1 + 1
         }
       }
-      def noisyWorker = T.worker{
+      def noisyWorker = T.worker {
         new Function1[Int, Int] {
           def apply(v1: Int) = input() + 1
         }
       }
-      def input = T.input{
+      def input = T.input {
         count += 1
         count
       }
-      def task = T.task{
+      def task = T.task {
         count += 1
         count
       }
-      def taskInput = T{ input() }
-      def taskNoInput = T{ task() }
+      def taskInput = T { input() }
+      def taskNoInput = T { task() }
 
-      def persistent = T.persistent{
+      def persistent = T.persistent {
         input() // force re-computation
         mkdir(T.ctx().dest)
-        write.append(T.ctx().dest/'count, "hello\n")
-        read.lines(T.ctx().dest/'count).length
+        write.append(T.ctx().dest / 'count, "hello\n")
+        read.lines(T.ctx().dest / 'count).length
       }
-      def nonPersistent = T{
+      def nonPersistent = T {
         input() // force re-computation
         mkdir(T.ctx().dest)
-        write.append(T.ctx().dest/'count, "hello\n")
-        read.lines(T.ctx().dest/'count).length
+        write.append(T.ctx().dest / 'count, "hello\n")
+        read.lines(T.ctx().dest / 'count).length
       }
 
-      def staticWorkerDownstream = T{
+      def staticWorkerDownstream = T {
         staticWorker().apply(1)
       }
-      def noisyWorkerDownstream = T{
+      def noisyWorkerDownstream = T {
         noisyWorker().apply(1)
       }
     }

--- a/main/test/src/mill/main/ClientServerTests.scala
+++ b/main/test/src/mill/main/ClientServerTests.scala
@@ -6,7 +6,7 @@ import mill.main.client.{Util, Locks}
 
 import scala.collection.JavaConverters._
 import utest._
-class EchoServer extends MillServerMain[Int]{
+class EchoServer extends MillServerMain[Int] {
   def main0(args: Array[String],
             stateCache: Option[Int],
             mainInteractive: Boolean,
@@ -18,14 +18,14 @@ class EchoServer extends MillServerMain[Int]{
 
     val reader = new BufferedReader(new InputStreamReader(stdin))
     val str = reader.readLine()
-    if (args.nonEmpty){
+    if (args.nonEmpty) {
       stdout.println(str + args(0))
     }
-    env.toSeq.sortBy(_._1).foreach{
+    env.toSeq.sortBy(_._1).foreach {
       case (key, value) => stdout.println(s"$key=$value")
     }
     stdout.flush()
-    if (args.nonEmpty){
+    if (args.nonEmpty) {
       stderr.println(str.toUpperCase + args(0))
     }
     stderr.flush()
@@ -33,7 +33,7 @@ class EchoServer extends MillServerMain[Int]{
   }
 }
 
-object ClientServerTests extends TestSuite{
+object ClientServerTests extends TestSuite {
   def initStreams() = {
     val in = new ByteArrayInputStream("hello\n".getBytes())
     val out = new ByteArrayOutputStream()
@@ -47,20 +47,22 @@ object ClientServerTests extends TestSuite{
     (tmpDir, locks)
   }
 
-  def spawnEchoServer(tmpDir : Path, locks: Locks): Unit = {
-    new Thread(() => new Server(
-      tmpDir.toString,
-      new EchoServer(),
-      () => (),
-      1000,
-      locks
-    ).run()).start()
+  def spawnEchoServer(tmpDir: Path, locks: Locks): Unit = {
+    new Thread(
+      () =>
+        new Server(
+          tmpDir.toString,
+          new EchoServer(),
+          () => (),
+          1000,
+          locks
+        ).run()).start()
   }
 
-  def runClientAux(tmpDir : Path, locks: Locks)
-                  (env : Map[String, String], args: Array[String]) = {
+  def runClientAux(tmpDir: Path, locks: Locks)(env: Map[String, String],
+                                               args: Array[String]) = {
     val (in, out, err) = initStreams()
-    Server.lockBlock(locks.clientLock){
+    Server.lockBlock(locks.clientLock) {
       mill.main.client.MillClientMain.run(
         tmpDir.toString,
         () => spawnEchoServer(tmpDir, locks),
@@ -76,11 +78,12 @@ object ClientServerTests extends TestSuite{
     }
   }
 
-  def tests = Tests{
+  def tests = Tests {
     'hello - {
-      if (!Util.isWindows){
+      if (!Util.isWindows) {
         val (tmpDir, locks) = init()
-        def runClient(s: String) = runClientAux(tmpDir, locks)(Map.empty, Array(s))
+        def runClient(s: String) =
+          runClientAux(tmpDir, locks)(Map.empty, Array(s))
 
         // Make sure the simple "have the client start a server and
         // exchange one message" workflow works from end to end.
@@ -133,10 +136,11 @@ object ClientServerTests extends TestSuite{
       }
 
       'envVars - {
-        if (!Util.isWindows){
+        if (!Util.isWindows) {
           val (tmpDir, locks) = init()
 
-          def runClient(env : Map[String, String]) = runClientAux(tmpDir, locks)(env, Array())
+          def runClient(env: Map[String, String]) =
+            runClientAux(tmpDir, locks)(env, Array())
 
           // Make sure the simple "have the client start a server and
           // exchange one message" workflow works from end to end.
@@ -147,7 +151,7 @@ object ClientServerTests extends TestSuite{
             locks.processLock.probe()
           )
 
-          def longString(s : String) = Array.fill(1000)(s).mkString
+          def longString(s: String) = Array.fill(1000)(s).mkString
           val b1000 = longString("b")
           val c1000 = longString("c")
           val a1000 = longString("a")
@@ -157,7 +161,6 @@ object ClientServerTests extends TestSuite{
             "b" -> b1000,
             "c" -> c1000
           )
-
 
           val (out1, err1) = runClient(env)
           val expected = s"a=$a1000\nb=$b1000\nc=$c1000\n"

--- a/main/test/src/mill/main/JavaCompileJarTests.scala
+++ b/main/test/src/mill/main/JavaCompileJarTests.scala
@@ -7,7 +7,7 @@ import utest._
 object JavaCompileJarTests extends ScriptTestSuite(fork = false) {
   def workspaceSlug = "java-compile-jar"
   def scriptSourcePath = pwd / 'main / 'test / 'resources / 'examples / 'javac
-  val tests = Tests{
+  val tests = Tests {
     initWorkspace()
     'test - {
       if (!ammonite.util.Util.java9OrAbove) {
@@ -31,7 +31,7 @@ object JavaCompileJarTests extends ScriptTestSuite(fork = false) {
         )
 
         // If we update resources, classFiles are unchanged but jar changes
-        for(scalaFile <- ls.rec(workspacePath).filter(_.ext == "txt")){
+        for (scalaFile <- ls.rec(workspacePath).filter(_.ext == "txt")) {
           write.append(scalaFile, "\n")
         }
 
@@ -48,14 +48,14 @@ object JavaCompileJarTests extends ScriptTestSuite(fork = false) {
 
         // We can intentionally break the code, have the targets break, then
         // fix the code and have them recover.
-        for(scalaFile <- ls.rec(workspacePath).filter(_.ext == "java")){
+        for (scalaFile <- ls.rec(workspacePath).filter(_.ext == "java")) {
           write.append(scalaFile, "\n}")
         }
 
         assert(!eval("classFiles"))
         assert(!eval("jar"))
 
-        for(scalaFile <- ls.rec(workspacePath).filter(_.ext == "java")){
+        for (scalaFile <- ls.rec(workspacePath).filter(_.ext == "java")) {
           write.over(scalaFile, read(scalaFile).dropRight(2))
         }
 
@@ -65,4 +65,3 @@ object JavaCompileJarTests extends ScriptTestSuite(fork = false) {
     }
   }
 }
-

--- a/main/test/src/mill/main/MainTests.scala
+++ b/main/test/src/mill/main/MainTests.scala
@@ -4,34 +4,53 @@ import mill.define.{Discover, Segment, Task}
 import mill.util.TestGraphs._
 
 import utest._
-object MainTests extends TestSuite{
+object MainTests extends TestSuite {
 
   def check[T <: mill.define.BaseModule](module: T)(
-                                         selectorString: String,
-                                         expected0: Either[String, Seq[T => Task[_]]])= {
+      selectorString: String,
+      expected0: Either[String, Seq[T => Task[_]]]) = {
 
     val expected = expected0.map(_.map(_(module)))
-    val resolved = for{
-      selectors <- mill.util.ParseArgs(Seq(selectorString), multiSelect = false).map(_._1.head)
-      val crossSelectors = selectors._2.value.map{case Segment.Cross(x) => x.toList.map(_.toString) case _ => Nil}
+    val resolved = for {
+      selectors <- mill.util
+        .ParseArgs(Seq(selectorString), multiSelect = false)
+        .map(_._1.head)
+      val crossSelectors = selectors._2.value.map {
+        case Segment.Cross(x) => x.toList.map(_.toString)
+        case _                => Nil
+      }
       task <- mill.main.ResolveTasks.resolve(
-        selectors._2.value.toList, module, module.millDiscover, Nil, crossSelectors.toList, Nil
+        selectors._2.value.toList,
+        module,
+        module.millDiscover,
+        Nil,
+        crossSelectors.toList,
+        Nil
       )
     } yield task
     assert(resolved == expected)
   }
-  val tests = Tests{
+  val tests = Tests {
     val graphs = new mill.util.TestGraphs()
     import graphs._
     'single - {
       val check = MainTests.check(singleton) _
       'pos - check("single", Right(Seq(_.single)))
       'neg1 - check("sngle", Left("Cannot resolve sngle. Did you mean single?"))
-      'neg2 - check("snigle", Left("Cannot resolve snigle. Did you mean single?"))
-      'neg3 - check("nsiigle", Left("Cannot resolve nsiigle. Did you mean single?"))
-      'neg4 - check("ansiigle", Left("Cannot resolve ansiigle. Try `mill resolve _` to see what's available."))
-      'neg5 - check("doesntExist", Left("Cannot resolve doesntExist. Try `mill resolve _` to see what's available."))
-      'neg6 - check("single.doesntExist", Left("Task single is not a module and has no children."))
+      'neg2 - check("snigle",
+                    Left("Cannot resolve snigle. Did you mean single?"))
+      'neg3 - check("nsiigle",
+                    Left("Cannot resolve nsiigle. Did you mean single?"))
+      'neg4 - check(
+        "ansiigle",
+        Left(
+          "Cannot resolve ansiigle. Try `mill resolve _` to see what's available."))
+      'neg5 - check(
+        "doesntExist",
+        Left(
+          "Cannot resolve doesntExist. Try `mill resolve _` to see what's available."))
+      'neg6 - check("single.doesntExist",
+                    Left("Task single is not a module and has no children."))
       'neg7 - check("", Left("Selector cannot be empty"))
     }
     'nested - {
@@ -41,7 +60,8 @@ object MainTests extends TestSuite{
       'pos3 - check("classInstance.single", Right(Seq(_.classInstance.single)))
       'neg1 - check(
         "doesntExist",
-        Left("Cannot resolve doesntExist. Try `mill resolve _` to see what's available.")
+        Left(
+          "Cannot resolve doesntExist. Try `mill resolve _` to see what's available.")
       )
       'neg2 - check(
         "single.doesntExist",
@@ -49,7 +69,8 @@ object MainTests extends TestSuite{
       )
       'neg3 - check(
         "nested.doesntExist",
-        Left("Cannot resolve nested.doesntExist. Try `mill resolve nested._` to see what's available.")
+        Left(
+          "Cannot resolve nested.doesntExist. Try `mill resolve nested._` to see what's available.")
       )
       'neg3 - check(
         "nested.singel",
@@ -57,42 +78,49 @@ object MainTests extends TestSuite{
       )
       'neg4 - check(
         "classInstance.doesntExist",
-        Left("Cannot resolve classInstance.doesntExist. Try `mill resolve classInstance._` to see what's available.")
+        Left(
+          "Cannot resolve classInstance.doesntExist. Try `mill resolve classInstance._` to see what's available.")
       )
       'wildcard - check(
         "_.single",
-        Right(Seq(
-          _.classInstance.single,
-          _.nested.single
-        ))
+        Right(
+          Seq(
+            _.classInstance.single,
+            _.nested.single
+          ))
       )
       'wildcardNeg - check(
         "_._.single",
-        Left("Cannot resolve _._.single. Try `mill resolve _` to see what's available")
+        Left(
+          "Cannot resolve _._.single. Try `mill resolve _` to see what's available")
       )
       'wildcardNeg2 - check(
         "_._.__",
-        Left("Cannot resolve _._.__. Try `mill resolve _` to see what's available")
+        Left(
+          "Cannot resolve _._.__. Try `mill resolve _` to see what's available")
       )
       'wildcardNeg3 - check(
         "nested._.foobar",
-        Left("Cannot resolve nested._.foobar. Try `mill resolve nested._` to see what's available")
+        Left(
+          "Cannot resolve nested._.foobar. Try `mill resolve nested._` to see what's available")
       )
       'wildcard2 - check(
         "__.single",
-        Right(Seq(
-          _.single,
-          _.classInstance.single,
-          _.nested.single
-        ))
+        Right(
+          Seq(
+            _.single,
+            _.classInstance.single,
+            _.nested.single
+          ))
       )
 
       'wildcard3 - check(
         "_.__.single",
-        Right(Seq(
-          _.classInstance.single,
-          _.nested.single
-        ))
+        Right(
+          Seq(
+            _.classInstance.single,
+            _.nested.single
+          ))
       )
 
     }
@@ -103,11 +131,13 @@ object MainTests extends TestSuite{
         'pos2 - check("cross[211].suffix", Right(Seq(_.cross("211").suffix)))
         'neg1 - check(
           "cross[210].doesntExist",
-          Left("Cannot resolve cross[210].doesntExist. Try `mill resolve cross[210]._` to see what's available.")
+          Left(
+            "Cannot resolve cross[210].doesntExist. Try `mill resolve cross[210]._` to see what's available.")
         )
         'neg2 - check(
           "cross[doesntExist].doesntExist",
-          Left("Cannot resolve cross[doesntExist]. Try `mill resolve cross[__]` to see what's available.")
+          Left(
+            "Cannot resolve cross[doesntExist]. Try `mill resolve cross[__]` to see what's available.")
         )
         'neg3 - check(
           "cross[221].doesntExist",
@@ -115,23 +145,26 @@ object MainTests extends TestSuite{
         )
         'neg4 - check(
           "cross[doesntExist].suffix",
-          Left("Cannot resolve cross[doesntExist]. Try `mill resolve cross[__]` to see what's available.")
+          Left(
+            "Cannot resolve cross[doesntExist]. Try `mill resolve cross[__]` to see what's available.")
         )
         'wildcard - check(
           "cross[_].suffix",
-          Right(Seq(
-            _.cross("210").suffix,
-            _.cross("211").suffix,
-            _.cross("212").suffix
-          ))
+          Right(
+            Seq(
+              _.cross("210").suffix,
+              _.cross("211").suffix,
+              _.cross("212").suffix
+            ))
         )
         'wildcard2 - check(
           "cross[__].suffix",
-          Right(Seq(
-            _.cross("210").suffix,
-            _.cross("211").suffix,
-            _.cross("212").suffix
-          ))
+          Right(
+            Seq(
+              _.cross("210").suffix,
+              _.cross("211").suffix,
+              _.cross("212").suffix
+            ))
         )
       }
       'double - {
@@ -154,10 +187,8 @@ object MainTests extends TestSuite{
             Right(Seq(
               _.cross("210", "jvm").suffix,
               _.cross("210", "js").suffix,
-
               _.cross("211", "jvm").suffix,
               _.cross("211", "js").suffix,
-
               _.cross("212", "jvm").suffix,
               _.cross("212", "js").suffix,
               _.cross("212", "native").suffix
@@ -165,28 +196,28 @@ object MainTests extends TestSuite{
           )
           'first - check(
             "cross[_,jvm].suffix",
-            Right(Seq(
-              _.cross("210", "jvm").suffix,
-              _.cross("211", "jvm").suffix,
-              _.cross("212", "jvm").suffix
-            ))
+            Right(
+              Seq(
+                _.cross("210", "jvm").suffix,
+                _.cross("211", "jvm").suffix,
+                _.cross("212", "jvm").suffix
+              ))
           )
           'second - check(
             "cross[210,_].suffix",
-            Right(Seq(
-              _.cross("210", "jvm").suffix,
-              _.cross("210", "js").suffix
-            ))
+            Right(
+              Seq(
+                _.cross("210", "jvm").suffix,
+                _.cross("210", "js").suffix
+              ))
           )
           'both - check(
             "cross[_,_].suffix",
             Right(Seq(
               _.cross("210", "jvm").suffix,
               _.cross("210", "js").suffix,
-
               _.cross("211", "jvm").suffix,
               _.cross("211", "js").suffix,
-
               _.cross("212", "jvm").suffix,
               _.cross("212", "js").suffix,
               _.cross("212", "native").suffix
@@ -197,10 +228,8 @@ object MainTests extends TestSuite{
             Right(Seq(
               _.cross("210", "jvm").suffix,
               _.cross("210", "js").suffix,
-
               _.cross("211", "jvm").suffix,
               _.cross("211", "js").suffix,
-
               _.cross("212", "jvm").suffix,
               _.cross("212", "js").suffix,
               _.cross("212", "native").suffix
@@ -221,19 +250,21 @@ object MainTests extends TestSuite{
         'wildcard - {
           'first - check(
             "cross[_].cross2[jvm].suffix",
-            Right(Seq(
-              _.cross("210").cross2("jvm").suffix,
-              _.cross("211").cross2("jvm").suffix,
-              _.cross("212").cross2("jvm").suffix
-            ))
+            Right(
+              Seq(
+                _.cross("210").cross2("jvm").suffix,
+                _.cross("211").cross2("jvm").suffix,
+                _.cross("212").cross2("jvm").suffix
+              ))
           )
           'second - check(
             "cross[210].cross2[_].suffix",
-            Right(Seq(
-              _.cross("210").cross2("jvm").suffix,
-              _.cross("210").cross2("js").suffix,
-              _.cross("210").cross2("native").suffix
-            ))
+            Right(
+              Seq(
+                _.cross("210").cross2("jvm").suffix,
+                _.cross("210").cross2("js").suffix,
+                _.cross("210").cross2("native").suffix
+              ))
           )
           'both - check(
             "cross[_].cross2[_].suffix",
@@ -241,11 +272,9 @@ object MainTests extends TestSuite{
               _.cross("210").cross2("jvm").suffix,
               _.cross("210").cross2("js").suffix,
               _.cross("210").cross2("native").suffix,
-
               _.cross("211").cross2("jvm").suffix,
               _.cross("211").cross2("js").suffix,
               _.cross("211").cross2("native").suffix,
-
               _.cross("212").cross2("jvm").suffix,
               _.cross("212").cross2("js").suffix,
               _.cross("212").cross2("native").suffix

--- a/main/test/src/mill/util/ParseArgsTest.scala
+++ b/main/test/src/mill/util/ParseArgsTest.scala
@@ -146,9 +146,9 @@ object ParseArgsTest extends TestSuite {
                 multiSelect: Boolean) = {
         val Right((selectors0, args)) = ParseArgs(input, multiSelect)
 
-        val selectors = selectors0.map{
+        val selectors = selectors0.map {
           case (Some(v1), v2) => (Some(v1.value), v2.value)
-          case (None, v2) => (None, v2.value)
+          case (None, v2)     => (None, v2.value)
         }
         assert(
           selectors == expectedSelectors,
@@ -157,7 +157,9 @@ object ParseArgsTest extends TestSuite {
       }
 
       'rejectEmpty {
-        assert(ParseArgs(Seq.empty, multiSelect = false) == Left("Selector cannot be empty"))
+        assert(
+          ParseArgs(Seq.empty, multiSelect = false) == Left(
+            "Selector cannot be empty"))
       }
       'singleSelector - check(
         input = Seq("core.compile"),
@@ -170,7 +172,8 @@ object ParseArgsTest extends TestSuite {
       'externalSelector - check(
         input = Seq("foo.bar/core.compile"),
         expectedSelectors = List(
-          Some(List(Label("foo"), Label("bar"))) -> List(Label("core"), Label("compile"))
+          Some(List(Label("foo"), Label("bar"))) -> List(Label("core"),
+                                                         Label("compile"))
         ),
         expectedArgs = Seq.empty,
         multiSelect = false
@@ -186,7 +189,9 @@ object ParseArgsTest extends TestSuite {
       'singleSelectorWithCross - check(
         input = Seq("bridges[2.12.4,jvm].compile"),
         expectedSelectors = List(
-          None -> List(Label("bridges"), Cross(Seq("2.12.4", "jvm")), Label("compile"))
+          None -> List(Label("bridges"),
+                       Cross(Seq("2.12.4", "jvm")),
+                       Label("compile"))
         ),
         expectedArgs = Seq.empty,
         multiSelect = false
@@ -212,8 +217,12 @@ object ParseArgsTest extends TestSuite {
       'multiSelectorsBraceExpansionWithCross - check(
         input = Seq("bridges[2.12.4,jvm].{test,jar}"),
         expectedSelectors = List(
-          None -> List(Label("bridges"), Cross(Seq("2.12.4", "jvm")), Label("test")),
-          None -> List(Label("bridges"), Cross(Seq("2.12.4", "jvm")), Label("jar"))
+          None -> List(Label("bridges"),
+                       Cross(Seq("2.12.4", "jvm")),
+                       Label("test")),
+          None -> List(Label("bridges"),
+                       Cross(Seq("2.12.4", "jvm")),
+                       Label("jar"))
         ),
         expectedArgs = Seq.empty,
         multiSelect = true
@@ -229,7 +238,8 @@ object ParseArgsTest extends TestSuite {
         multiSelect = true
       )
       'multiSelectorsBraceExpansionWithoutAll - {
-        val res = ParseArgs(Seq("{core,application}.compile"), multiSelect = false)
+        val res =
+          ParseArgs(Seq("{core,application}.compile"), multiSelect = false)
         val expected = Right(
           List(
             None -> Segments(Label("core"), Label("compile")),

--- a/main/test/src/mill/util/ScriptTestSuite.scala
+++ b/main/test/src/mill/util/ScriptTestSuite.scala
@@ -5,7 +5,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, PrintStream}
 import ammonite.ops._
 import utest._
 
-abstract class ScriptTestSuite(fork: Boolean) extends TestSuite{
+abstract class ScriptTestSuite(fork: Boolean) extends TestSuite {
   def workspaceSlug: String
   def scriptSourcePath: Path
   def buildPath: RelPath = "build.sc"
@@ -16,24 +16,28 @@ abstract class ScriptTestSuite(fork: Boolean) extends TestSuite{
   val stdIn = new ByteArrayInputStream(Array())
   lazy val runner = new mill.main.MainRunner(
     ammonite.main.Cli.Config(wd = wd),
-    stdOutErr, stdOutErr, stdIn, None, Map.empty,
+    stdOutErr,
+    stdOutErr,
+    stdIn,
+    None,
+    Map.empty,
     b => ()
   )
   def eval(s: String*) = {
-    if (!fork) runner.runScript(workspacePath / buildPath , s.toList)
-    else{
+    if (!fork) runner.runScript(workspacePath / buildPath, s.toList)
+    else {
       try {
         %(home / "mill-release", "-i", s)(wd)
         true
-      }catch{case e: Throwable => false}
+      } catch { case e: Throwable => false }
     }
   }
   def meta(s: String) = {
-    val (List(selector), args) = ParseArgs.apply(Seq(s), multiSelect = false).right.get
+    val (List(selector), args) =
+      ParseArgs.apply(Seq(s), multiSelect = false).right.get
 
     read(wd / "out" / selector._2.value.flatMap(_.pathSegments) / "meta.json")
   }
-
 
   def initWorkspace() = {
     rm(workspacePath)

--- a/main/test/src/mill/util/TestEvaluator.scala
+++ b/main/test/src/mill/util/TestEvaluator.scala
@@ -9,27 +9,34 @@ import utest.assert
 import utest.framework.TestPath
 
 import language.experimental.macros
-object TestEvaluator{
+object TestEvaluator {
   val externalOutPath = pwd / 'target / 'external
 
-
-  def static[T <: TestUtil.BaseModule](module: T)
-                                     (implicit fullName: sourcecode.FullName) = {
+  def static[T <: TestUtil.BaseModule](module: T)(
+      implicit fullName: sourcecode.FullName) = {
     new TestEvaluator[T](module)(fullName, TestPath(Nil))
   }
 }
 
-class TestEvaluator[T <: TestUtil.BaseModule](module: T)
-                                            (implicit fullName: sourcecode.FullName,
-                                             tp: TestPath){
-  val outPath =  TestUtil.getOutPath()
+class TestEvaluator[T <: TestUtil.BaseModule](module: T)(
+    implicit fullName: sourcecode.FullName,
+    tp: TestPath) {
+  val outPath = TestUtil.getOutPath()
 
 //  val logger = DummyLogger
   val logger = new PrintLogger(
     true,
-    ammonite.util.Colors.Default, System.out, System.out, System.err, System.in
- )
-  val evaluator = new Evaluator(Ctx.defaultHome, outPath, TestEvaluator.externalOutPath, module, logger)
+    ammonite.util.Colors.Default,
+    System.out,
+    System.out,
+    System.err,
+    System.in
+  )
+  val evaluator = new Evaluator(Ctx.defaultHome,
+                                outPath,
+                                TestEvaluator.externalOutPath,
+                                module,
+                                logger)
 
   def apply[T](t: Task[T]): Either[Result.Failing[T], (T, Int)] = {
     val evaluated = evaluator.evaluate(Agg(t))
@@ -40,27 +47,33 @@ class TestEvaluator[T <: TestUtil.BaseModule](module: T)
           evaluated.rawValues.head.asInstanceOf[Result.Success[T]].value,
           evaluated.evaluated.collect {
             case t: Target[_]
-              if module.millInternal.targets.contains(t)
-              && !t.isInstanceOf[Input[_]]
-              && !t.ctx.external => t
+                if module.millInternal.targets.contains(t)
+                  && !t.isInstanceOf[Input[_]]
+                  && !t.ctx.external =>
+              t
             case t: mill.define.Command[_] => t
           }.size
         ))
     } else {
       Left(
-        evaluated.failing.lookupKey(evaluated.failing.keys().next).items.next()
+        evaluated.failing
+          .lookupKey(evaluated.failing.keys().next)
+          .items
+          .next()
           .asInstanceOf[Result.Failing[T]]
       )
     }
   }
 
-  def fail(target: Target[_], expectedFailCount: Int, expectedRawValues: Seq[Result[_]]) = {
+  def fail(target: Target[_],
+           expectedFailCount: Int,
+           expectedRawValues: Seq[Result[_]]) = {
 
     val res = evaluator.evaluate(Agg(target))
 
-    val cleaned = res.rawValues.map{
+    val cleaned = res.rawValues.map {
       case Result.Exception(ex, _) => Result.Exception(ex, new OuterStack(Nil))
-      case x => x
+      case x                       => x
     }
 
     assert(
@@ -71,7 +84,8 @@ class TestEvaluator[T <: TestUtil.BaseModule](module: T)
   }
 
   def check(targets: Agg[Task[_]], expected: Agg[Task[_]]) = {
-    val evaluated = evaluator.evaluate(targets)
+    val evaluated = evaluator
+      .evaluate(targets)
       .evaluated
       .flatMap(_.asTarget)
       .filter(module.millInternal.targets.contains)

--- a/main/test/src/mill/util/TestGraphs.scala
+++ b/main/test/src/mill/util/TestGraphs.scala
@@ -14,14 +14,14 @@ import mill.{Module, T}
   * The immutable graphs, used for testing discovery & target resolution,
   * live in the companion object.
   */
-class TestGraphs(){
+class TestGraphs() {
   // single
   object singleton extends TestUtil.BaseModule {
     val single = test()
   }
 
   // up---down
-  object pair extends TestUtil.BaseModule{
+  object pair extends TestUtil.BaseModule {
     val up = test()
     val down = test(up)
   }
@@ -55,21 +55,20 @@ class TestGraphs(){
   }
 
   object defCachedDiamond extends TestUtil.BaseModule {
-    def up = T{ test() }
-    def left = T{ test(up) }
-    def right = T{ test(up) }
-    def down = T{ test(left, right) }
+    def up = T { test() }
+    def left = T { test(up) }
+    def right = T { test(up) }
+    def down = T { test(left, right) }
   }
 
-
-  object borkedCachedDiamond2 extends TestUtil.BaseModule  {
+  object borkedCachedDiamond2 extends TestUtil.BaseModule {
     def up = test()
     def left = test(up)
     def right = test(up)
     def down = test(left, right)
   }
 
-  object borkedCachedDiamond3 extends TestUtil.BaseModule  {
+  object borkedCachedDiamond3 extends TestUtil.BaseModule {
     def up = test()
     def left = test(up)
     def right = test(up)
@@ -113,59 +112,56 @@ class TestGraphs(){
   //               _/
   // change - task2
   object separateGroups extends TestUtil.BaseModule {
-    val task1 = T.task{ 1 }
-    def left = T{ task1() }
+    val task1 = T.task { 1 }
+    def left = T { task1() }
     val change = test()
-    val task2 = T.task{ change() }
-    def right = T{ task1() + task2() + left() + 1 }
+    val task2 = T.task { change() }
+    def right = T { task1() + task2() + left() + 1 }
 
   }
 }
 
-
-object TestGraphs{
+object TestGraphs {
   //      _ left _
   //     /        \
   // task -------- right
   object triangleTask extends TestUtil.BaseModule {
-    val task = T.task{ 1 }
-    def left = T{ task() }
-    def right = T{ task() + left() + 1 }
+    val task = T.task { 1 }
+    def left = T { task() }
+    def right = T { task() + left() + 1 }
   }
-
 
   //      _ left
   //     /
   // task -------- right
   object multiTerminalGroup extends TestUtil.BaseModule {
-    val task = T.task{ 1 }
-    def left = T{ task() }
-    def right = T{ task() }
+    val task = T.task { 1 }
+    def left = T { task() }
+    def right = T { task() }
   }
 
   //       _ left _____________
   //      /        \           \
   // task1 -------- right ----- task2
   object multiTerminalBoundary extends TestUtil.BaseModule {
-    val task1 = T.task{ 1 }
-    def left = T{ task1() }
-    def right = T{ task1() + left() + 1 }
-    val task2 = T.task{ left() + right() }
+    val task1 = T.task { 1 }
+    def left = T { task1() }
+    def right = T { task1() + left() + 1 }
+    val task2 = T.task { left() + right() }
   }
 
-
-  trait CanNest extends Module{
-    def single = T{ 1 }
-    def invisible: Any = T{ 2 }
-    def invisible2: mill.define.Task[Int] = T{ 3 }
-    def invisible3: mill.define.Task[_] = T{ 4 }
+  trait CanNest extends Module {
+    def single = T { 1 }
+    def invisible: Any = T { 2 }
+    def invisible2: mill.define.Task[Int] = T { 3 }
+    def invisible3: mill.define.Task[_] = T { 4 }
   }
   object nestedModule extends TestUtil.BaseModule {
-    def single = T{ 5 }
-    def invisible: Any = T{ 6 }
-    object nested extends Module{
-      def single = T{ 7 }
-      def invisible: Any = T{ 8 }
+    def single = T { 5 }
+    def invisible: Any = T { 6 }
+    object nested extends Module {
+      def single = T { 7 }
+      def invisible: Any = T { 8 }
 
     }
     object classInstance extends CanNest
@@ -173,89 +169,91 @@ object TestGraphs{
   }
 
   trait BaseModule extends Module {
-    def foo = T{ Seq("base") }
-    def cmd(i: Int) = T.command{ Seq("base" + i) }
+    def foo = T { Seq("base") }
+    def cmd(i: Int) = T.command { Seq("base" + i) }
   }
 
   object canOverrideSuper extends TestUtil.BaseModule with BaseModule {
-    override def foo = T{ super.foo() ++ Seq("object") }
-    override def cmd(i: Int) = T.command{ super.cmd(i)() ++ Seq("object" + i) }
+    override def foo = T { super.foo() ++ Seq("object") }
+    override def cmd(i: Int) = T.command { super.cmd(i)() ++ Seq("object" + i) }
     override lazy val millDiscover: Discover[this.type] = Discover[this.type]
   }
 
-  trait TraitWithModule extends Module{ outer =>
-    object TraitModule extends Module{
-      def testFrameworks = T{ Seq("mill.UTestFramework") }
-      def test() = T.command{ ()/*donothing*/ }
+  trait TraitWithModule extends Module { outer =>
+    object TraitModule extends Module {
+      def testFrameworks = T { Seq("mill.UTestFramework") }
+      def test() = T.command { () /*donothing*/ }
     }
   }
 
-
   // Make sure nested objects inherited from traits work
-  object TraitWithModuleObject extends TestUtil.BaseModule with TraitWithModule{
+  object TraitWithModuleObject
+      extends TestUtil.BaseModule
+      with TraitWithModule {
     override lazy val millDiscover: Discover[this.type] = Discover[this.type]
   }
 
-  object nullTasks extends  TestUtil.BaseModule{
+  object nullTasks extends TestUtil.BaseModule {
     val nullString: String = null
-    def nullTask1 = T.task{ nullString }
-    def nullTask2 = T.task{ nullTask1() }
+    def nullTask1 = T.task { nullString }
+    def nullTask2 = T.task { nullTask1() }
 
-    def nullTarget1 = T{ nullString }
-    def nullTarget2 = T{ nullTarget1() }
-    def nullTarget3 = T{ nullTask1() }
-    def nullTarget4 = T{ nullTask2() }
+    def nullTarget1 = T { nullString }
+    def nullTarget2 = T { nullTarget1() }
+    def nullTarget3 = T { nullTask1() }
+    def nullTarget4 = T { nullTask2() }
 
-    def nullCommand1() = T.command{ nullString }
-    def nullCommand2() = T.command{ nullTarget1() }
-    def nullCommand3() = T.command{ nullTask1() }
-    def nullCommand4() = T.command{ nullTask2() }
+    def nullCommand1() = T.command { nullString }
+    def nullCommand2() = T.command { nullTarget1() }
+    def nullCommand3() = T.command { nullTask1() }
+    def nullCommand4() = T.command { nullTask2() }
 
     override lazy val millDiscover: Discover[this.type] = Discover[this.type]
   }
 
   object singleCross extends TestUtil.BaseModule {
     object cross extends mill.Cross[Cross]("210", "211", "212")
-    class Cross(scalaVersion: String) extends Module{
-      def suffix = T{ scalaVersion }
+    class Cross(scalaVersion: String) extends Module {
+      def suffix = T { scalaVersion }
     }
   }
   object crossResolved extends TestUtil.BaseModule {
-    trait MyModule extends Module{
+    trait MyModule extends Module {
       def crossVersion: String
-      implicit object resolver extends mill.define.Cross.Resolver[MyModule]{
-        def resolve[V <: MyModule](c: Cross[V]): V = c.itemMap(List(crossVersion))
+      implicit object resolver extends mill.define.Cross.Resolver[MyModule] {
+        def resolve[V <: MyModule](c: Cross[V]): V =
+          c.itemMap(List(crossVersion))
       }
     }
 
     object foo extends mill.Cross[FooModule]("2.10", "2.11", "2.12")
-    class FooModule(val crossVersion: String) extends MyModule{
-      def suffix = T{ crossVersion }
+    class FooModule(val crossVersion: String) extends MyModule {
+      def suffix = T { crossVersion }
     }
 
     object bar extends mill.Cross[BarModule]("2.10", "2.11", "2.12")
-    class BarModule(val crossVersion: String) extends MyModule{
-      def longSuffix = T{ "_" + foo().suffix() }
+    class BarModule(val crossVersion: String) extends MyModule {
+      def longSuffix = T { "_" + foo().suffix() }
     }
   }
   object doubleCross extends TestUtil.BaseModule {
-    val crossMatrix = for{
+    val crossMatrix = for {
       scalaVersion <- Seq("210", "211", "212")
       platform <- Seq("jvm", "js", "native")
       if !(platform == "native" && scalaVersion != "212")
     } yield (scalaVersion, platform)
-    object cross extends mill.Cross[Cross](crossMatrix:_*)
-    class Cross(scalaVersion: String, platform: String) extends Module{
-      def suffix = T{ scalaVersion + "_" + platform }
+    object cross extends mill.Cross[Cross](crossMatrix: _*)
+    class Cross(scalaVersion: String, platform: String) extends Module {
+      def suffix = T { scalaVersion + "_" + platform }
     }
   }
 
   object nestedCrosses extends TestUtil.BaseModule {
     object cross extends mill.Cross[Cross]("210", "211", "212")
-    class Cross(scalaVersion: String) extends mill.Module{
+    class Cross(scalaVersion: String) extends mill.Module {
       object cross2 extends mill.Cross[Cross]("jvm", "js", "native")
-      class Cross(platform: String) extends mill.Module{
-        def suffix = T{ scalaVersion + "_" + platform }
+      class Cross(platform: String) extends mill.Module {
+        def suffix = T { scalaVersion + "_" + platform }
       }
     }
   }

--- a/main/test/src/mill/util/TestUtil.scala
+++ b/main/test/src/mill/util/TestUtil.scala
@@ -12,8 +12,7 @@ import utest.framework.TestPath
 import scala.collection.mutable
 
 object TestUtil {
-  def getOutPath()(implicit fullName: sourcecode.FullName,
-                   tp: TestPath) = {
+  def getOutPath()(implicit fullName: sourcecode.FullName, tp: TestPath) = {
     pwd / 'target / 'workspace / (fullName.value.split('.') ++ tp.value)
   }
   def getOutPathStatic()(implicit fullName: sourcecode.FullName) = {
@@ -31,49 +30,49 @@ object TestUtil {
                    millModuleLine0: sourcecode.Line,
                    millName0: sourcecode.Name,
                    overrides: Overrides)
-    extends mill.define.BaseModule(getSrcPathBase() / millModuleEnclosing0.value.split("\\.| |#")){
+      extends mill.define.BaseModule(
+        getSrcPathBase() / millModuleEnclosing0.value.split("\\.| |#")) {
     lazy val millDiscover: Discover[this.type] = Discover[this.type]
   }
 
-  object test{
+  object test {
 
     def anon(inputs: Task[Int]*) = new Test(inputs)
-    def apply(inputs: Task[Int]*)
-            (implicit ctx: mill.define.Ctx)= {
+    def apply(inputs: Task[Int]*)(implicit ctx: mill.define.Ctx) = {
       new TestTarget(inputs, pure = inputs.nonEmpty)
     }
   }
 
-  class Test(val inputs: Seq[Task[Int]]) extends Task[Int]{
+  class Test(val inputs: Seq[Task[Int]]) extends Task[Int] {
     var counter = 0
     var failure = Option.empty[String]
     var exception = Option.empty[Throwable]
     override def evaluate(args: Ctx) = {
       failure.map(Result.Failure(_)) orElse
-      exception.map(Result.Exception(_, new OuterStack(Nil))) getOrElse
-      Result.Success(counter + args.args.map(_.asInstanceOf[Int]).sum)
+        exception.map(Result.Exception(_, new OuterStack(Nil))) getOrElse
+        Result.Success(counter + args.args.map(_.asInstanceOf[Int]).sum)
     }
     override def sideHash = counter + failure.hashCode() + exception.hashCode()
   }
+
   /**
     * A dummy target that takes any number of inputs, and whose output can be
     * controlled externally, so you can construct arbitrary dataflow graphs and
     * test how changes propagate.
     */
-  class TestTarget(inputs: Seq[Task[Int]],
-                   val pure: Boolean)
-                  (implicit ctx0: mill.define.Ctx)
-    extends Test(inputs) with Target[Int]{
+  class TestTarget(inputs: Seq[Task[Int]], val pure: Boolean)(
+      implicit ctx0: mill.define.Ctx)
+      extends Test(inputs)
+      with Target[Int] {
     val ctx = ctx0.copy(segments = ctx0.segments ++ Seq(ctx0.segment))
     val readWrite = upickle.default.readwriter[Int]
-
 
   }
   def checkTopological(targets: Agg[Task[_]]) = {
     val seen = mutable.Set.empty[Task[_]]
-    for(t <- targets.indexed.reverseIterator){
+    for (t <- targets.indexed.reverseIterator) {
       seen.add(t)
-      for(upstream <- t.inputs){
+      for (upstream <- t.inputs) {
         assert(!seen(upstream))
       }
     }

--- a/moduledefs/src/mill/moduledefs/AutoOverridePlugin.scala
+++ b/moduledefs/src/mill/moduledefs/AutoOverridePlugin.scala
@@ -8,7 +8,8 @@ import scala.tools.nsc.plugins.{Plugin, PluginComponent}
 
 class AutoOverridePlugin(val global: Global) extends Plugin {
   import global._
-  override def init(options: List[String],  error: String => Unit): Boolean = true
+  override def init(options: List[String], error: String => Unit): Boolean =
+    true
 
   val name = "auto-override-plugin"
   val description = "automatically inserts `override` keywords for you"
@@ -37,14 +38,13 @@ class AutoOverridePlugin(val global: Global) extends Plugin {
 
         def apply(unit: global.CompilationUnit): Unit = {
           object AutoOverrider extends global.Transformer {
-            override def transform(tree: global.Tree) = tree match{
+            override def transform(tree: global.Tree) = tree match {
               case d: DefDef
-                if d.symbol.overrideChain.count(!_.isAbstract) > 1
-                && !d.mods.isOverride
-                && isCacher(d.symbol.owner) =>
-
-                  d.symbol.flags = d.symbol.flags | Flags.OVERRIDE
-                  copyDefDef(d)(mods = d.mods | Flags.OVERRIDE)
+                  if d.symbol.overrideChain.count(!_.isAbstract) > 1
+                    && !d.mods.isOverride
+                    && isCacher(d.symbol.owner) =>
+                d.symbol.flags = d.symbol.flags | Flags.OVERRIDE
+                copyDefDef(d)(mods = d.mods | Flags.OVERRIDE)
               case _ => super.transform(tree)
 
             }

--- a/moduledefs/src/mill/moduledefs/Cacher.scala
+++ b/moduledefs/src/mill/moduledefs/Cacher.scala
@@ -3,19 +3,18 @@ package mill.moduledefs
 import scala.collection.mutable
 import scala.reflect.macros.blackbox.Context
 
+trait Cacher {
+  private[this] lazy val cacherLazyMap =
+    mutable.Map.empty[sourcecode.Enclosing, Any]
 
-trait Cacher{
-  private[this] lazy val cacherLazyMap = mutable.Map.empty[sourcecode.Enclosing, Any]
-
-  protected[this] def cachedTarget[T](t: => T)
-                                     (implicit c: sourcecode.Enclosing): T = synchronized{
+  protected[this] def cachedTarget[T](t: => T)(
+      implicit c: sourcecode.Enclosing): T = synchronized {
     cacherLazyMap.getOrElseUpdate(c, t).asInstanceOf[T]
   }
 }
 
-object Cacher{
-  def impl0[T: c.WeakTypeTag](c: Context)
-                                   (t: c.Expr[T]): c.Expr[T] = {
+object Cacher {
+  def impl0[T: c.WeakTypeTag](c: Context)(t: c.Expr[T]): c.Expr[T] = {
     c.Expr[T](wrapCached[T](c)(t.tree))
   }
   def wrapCached[R: c.WeakTypeTag](c: Context)(t: c.Tree) = {
@@ -24,12 +23,15 @@ object Cacher{
     val owner = c.internal.enclosingOwner
     val ownerIsCacherClass =
       owner.owner.isClass &&
-        owner.owner.asClass.baseClasses.exists(_.fullName == "mill.moduledefs.Cacher")
+        owner.owner.asClass.baseClasses
+          .exists(_.fullName == "mill.moduledefs.Cacher")
 
-    if (ownerIsCacherClass && owner.isMethod) q"this.cachedTarget[${weakTypeTag[R]}]($t)"
-    else c.abort(
-      c.enclosingPosition,
-      "T{} members must be defs defined in a Cacher class/trait/object body"
-    )
+    if (ownerIsCacherClass && owner.isMethod)
+      q"this.cachedTarget[${weakTypeTag[R]}]($t)"
+    else
+      c.abort(
+        c.enclosingPosition,
+        "T{} members must be defs defined in a Cacher class/trait/object body"
+      )
   }
 }

--- a/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/0.6/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -8,7 +8,12 @@ import mill.eval.Result
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
-import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker, Semantics, ModuleKind => ScalaJSModuleKind}
+import org.scalajs.core.tools.linker.{
+  ModuleInitializer,
+  StandardLinker,
+  Semantics,
+  ModuleKind => ScalaJSModuleKind
+}
 import org.scalajs.core.tools.logging.ScalaConsoleLogger
 import org.scalajs.jsenv._
 import org.scalajs.jsenv.nodejs._
@@ -22,30 +27,38 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
            fullOpt: Boolean,
            moduleKind: ModuleKind) = {
     val semantics = fullOpt match {
-        case true => Semantics.Defaults.optimized
-        case false => Semantics.Defaults
+      case true  => Semantics.Defaults.optimized
+      case false => Semantics.Defaults
     }
     val scalaJSModuleKind = moduleKind match {
-      case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
+      case ModuleKind.NoModule       => ScalaJSModuleKind.NoModule
       case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
     }
-    val config = StandardLinker.Config()
+    val config = StandardLinker
+      .Config()
       .withOptimizer(fullOpt)
       .withClosureCompilerIfAvailable(fullOpt)
       .withSemantics(semantics)
       .withModuleKind(scalaJSModuleKind)
     val linker = StandardLinker(config)
     val sourceSJSIRs = sources.map(new FileVirtualScalaJSIRFile(_))
-    val jars = libraries.map(jar => IRContainer.Jar(new FileVirtualBinaryFile(jar) with VirtualJarFile))
+    val jars = libraries.map(jar =>
+      IRContainer.Jar(new FileVirtualBinaryFile(jar) with VirtualJarFile))
     val jarSJSIRs = jars.flatMap(_.jar.sjsirFiles)
     val destFile = AtomicWritableFileVirtualJSFile(dest)
     val logger = new ScalaConsoleLogger
-    val initializer = Option(main).map { cls => ModuleInitializer.mainMethodWithArgs(cls, "main") }
+    val initializer = Option(main).map { cls =>
+      ModuleInitializer.mainMethodWithArgs(cls, "main")
+    }
     try {
-      linker.link(sourceSJSIRs ++ jarSJSIRs, initializer.toSeq, destFile, logger)
+      linker.link(sourceSJSIRs ++ jarSJSIRs,
+                  initializer.toSeq,
+                  destFile,
+                  logger)
       Result.Success(dest)
-    }catch {case e: org.scalajs.core.tools.linker.LinkingException =>
-      Result.Failure(e.getMessage)
+    } catch {
+      case e: org.scalajs.core.tools.linker.LinkingException =>
+        Result.Failure(e.getMessage)
     }
   }
 
@@ -78,7 +91,8 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
 
   def nodeJSEnv(config: NodeJSConfig): NodeJSEnv = {
     new NodeJSEnv(
-      NodeJSEnv.Config()
+      NodeJSEnv
+        .Config()
         .withExecutable(config.executable)
         .withArgs(config.args)
         .withEnv(config.env)

--- a/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
+++ b/scalajslib/jsbridges/1.0/src/mill/scalajslib/bridge/ScalaJSBridge.scala
@@ -6,7 +6,12 @@ import java.io.File
 
 import mill.eval.Result
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.linker.{ModuleInitializer, Semantics, StandardLinker, ModuleKind => ScalaJSModuleKind}
+import org.scalajs.core.tools.linker.{
+  ModuleInitializer,
+  Semantics,
+  StandardLinker,
+  ModuleKind => ScalaJSModuleKind
+}
 import org.scalajs.core.tools.logging.ScalaConsoleLogger
 import org.scalajs.jsenv.ConsoleJSConsole
 import org.scalajs.jsenv.nodejs._
@@ -20,14 +25,15 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
            fullOpt: Boolean,
            moduleKind: ModuleKind) = {
     val semantics = fullOpt match {
-        case true => Semantics.Defaults.optimized
-        case false => Semantics.Defaults
+      case true  => Semantics.Defaults.optimized
+      case false => Semantics.Defaults
     }
     val scalaJSModuleKind = moduleKind match {
-      case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
+      case ModuleKind.NoModule       => ScalaJSModuleKind.NoModule
       case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
     }
-    val config = StandardLinker.Config()
+    val config = StandardLinker
+      .Config()
       .withOptimizer(fullOpt)
       .withClosureCompilerIfAvailable(fullOpt)
       .withSemantics(semantics)
@@ -39,13 +45,16 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
     val libraryIRs = cache.cached(irContainers)
     val destFile = AtomicWritableFileVirtualJSFile(dest)
     val logger = new ScalaConsoleLogger
-    val initializer = Option(main).map { cls => ModuleInitializer.mainMethodWithArgs(cls, "main") }
+    val initializer = Option(main).map { cls =>
+      ModuleInitializer.mainMethodWithArgs(cls, "main")
+    }
 
     try {
       linker.link(sourceIRs ++ libraryIRs, initializer.toSeq, destFile, logger)
       Result.Success(dest)
-    }catch {case e: org.scalajs.core.tools.linker.LinkingException =>
-      Result.Failure(e.getMessage)
+    } catch {
+      case e: org.scalajs.core.tools.linker.LinkingException =>
+        Result.Failure(e.getMessage)
     }
   }
 
@@ -76,7 +85,8 @@ class ScalaJSBridge extends mill.scalajslib.ScalaJSBridge {
 
   def nodeJSEnv(config: NodeJSConfig): NodeJSEnv = {
     new NodeJSEnv(
-      NodeJSEnv.Config()
+      NodeJSEnv
+        .Config()
         .withExecutable(config.executable)
         .withArgs(config.args)
         .withEnv(config.env)

--- a/scalajslib/src/mill/scalajslib/ScalaJSBridge.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSBridge.scala
@@ -15,7 +15,7 @@ object FastOpt extends OptimizeMode
 object FullOpt extends OptimizeMode
 
 sealed trait ModuleKind
-object ModuleKind{
+object ModuleKind {
   object NoModule extends ModuleKind
   object CommonJSModule extends ModuleKind
 }
@@ -23,8 +23,7 @@ object ModuleKind{
 class ScalaJSWorker {
   private var scalaInstanceCache = Option.empty[(Long, ScalaJSBridge)]
 
-  private def bridge(toolsClasspath: Agg[Path])
-                    (implicit ctx: Ctx.Home) = {
+  private def bridge(toolsClasspath: Agg[Path])(implicit ctx: Ctx.Home) = {
     val classloaderSig =
       toolsClasspath.map(p => p.toString().hashCode + p.mtime.toMillis).sum
     scalaInstanceCache match {
@@ -50,28 +49,29 @@ class ScalaJSWorker {
            dest: File,
            main: Option[String],
            fullOpt: Boolean,
-           moduleKind: ModuleKind)
-          (implicit ctx: Ctx.Home): Result[Path] = {
-    bridge(toolsClasspath).link(
-      sources.items.map(_.toIO).toArray,
-      libraries.items.map(_.toIO).toArray,
-      dest,
-      main.orNull,
-      fullOpt,
-      moduleKind
-    ).map(Path(_))
+           moduleKind: ModuleKind)(implicit ctx: Ctx.Home): Result[Path] = {
+    bridge(toolsClasspath)
+      .link(
+        sources.items.map(_.toIO).toArray,
+        libraries.items.map(_.toIO).toArray,
+        dest,
+        main.orNull,
+        fullOpt,
+        moduleKind
+      )
+      .map(Path(_))
   }
 
-  def run(toolsClasspath: Agg[Path], config: NodeJSConfig, linkedFile: File)
-         (implicit ctx: Ctx.Home): Unit = {
+  def run(toolsClasspath: Agg[Path], config: NodeJSConfig, linkedFile: File)(
+      implicit ctx: Ctx.Home): Unit = {
     bridge(toolsClasspath).run(config, linkedFile)
   }
 
   def getFramework(toolsClasspath: Agg[Path],
                    config: NodeJSConfig,
                    frameworkName: String,
-                   linkedFile: File)
-                  (implicit ctx: Ctx.Home): (() => Unit, sbt.testing.Framework) = {
+                   linkedFile: File)(
+      implicit ctx: Ctx.Home): (() => Unit, sbt.testing.Framework) = {
     bridge(toolsClasspath).getFramework(config, frameworkName, linkedFile)
   }
 

--- a/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/HelloJSWorldTests.scala
@@ -6,19 +6,26 @@ import ammonite.ops._
 import mill._
 import mill.define.Discover
 import mill.eval.{Evaluator, Result}
-import mill.scalalib.{CrossScalaModule, DepSyntax, Lib, PublishModule, TestRunner}
+import mill.scalalib.{
+  CrossScalaModule,
+  DepSyntax,
+  Lib,
+  PublishModule,
+  TestRunner
+}
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import mill.util.{TestEvaluator, TestUtil}
 import utest._
 
-
 import scala.collection.JavaConverters._
 
-
 object HelloJSWorldTests extends TestSuite {
-  val workspacePath =  TestUtil.getOutPathStatic() / "hello-js-world"
+  val workspacePath = TestUtil.getOutPathStatic() / "hello-js-world"
 
-  trait HelloJSWorldModule extends CrossScalaModule with ScalaJSModule with PublishModule {
+  trait HelloJSWorldModule
+      extends CrossScalaModule
+      with ScalaJSModule
+      with PublishModule {
     override def millSourcePath = workspacePath
     def publishVersion = "0.0.1-SNAPSHOT"
     override def mainClass = Some("Main")
@@ -30,8 +37,9 @@ object HelloJSWorldTests extends TestSuite {
       scalaJS <- Seq("0.6.22", "1.0.0-M2")
     } yield (scala, scalaJS)
 
-    object helloJsWorld extends Cross[BuildModule](matrix:_*)
-    class BuildModule(val crossScalaVersion: String, sjsVersion0: String) extends HelloJSWorldModule {
+    object helloJsWorld extends Cross[BuildModule](matrix: _*)
+    class BuildModule(val crossScalaVersion: String, sjsVersion0: String)
+        extends HelloJSWorldModule {
       override def artifactName = "hello-js-world"
       def scalaJSVersion = sjsVersion0
       def pomSettings = PomSettings(
@@ -45,11 +53,11 @@ object HelloJSWorldTests extends TestSuite {
       )
     }
 
-    object buildUTest extends Cross[BuildModuleUtest](matrix:_*)
+    object buildUTest extends Cross[BuildModuleUtest](matrix: _*)
     class BuildModuleUtest(crossScalaVersion: String, sjsVersion0: String)
-      extends BuildModule(crossScalaVersion, sjsVersion0) {
+        extends BuildModule(crossScalaVersion, sjsVersion0) {
       object test extends super.Tests {
-        override def sources = T.sources{ millSourcePath / 'src / 'utest }
+        override def sources = T.sources { millSourcePath / 'src / 'utest }
         def testFrameworks = Seq("utest.runner.Framework")
         override def ivyDeps = Agg(
           ivy"com.lihaoyi::utest::0.6.3"
@@ -57,11 +65,11 @@ object HelloJSWorldTests extends TestSuite {
       }
     }
 
-    object buildScalaTest extends Cross[BuildModuleScalaTest](matrix:_*)
+    object buildScalaTest extends Cross[BuildModuleScalaTest](matrix: _*)
     class BuildModuleScalaTest(crossScalaVersion: String, sjsVersion0: String)
-      extends BuildModule(crossScalaVersion, sjsVersion0) {
+        extends BuildModule(crossScalaVersion, sjsVersion0) {
       object test extends super.Tests {
-        override def sources = T.sources{ millSourcePath / 'src / 'scalatest }
+        override def sources = T.sources { millSourcePath / 'src / 'scalatest }
         def testFrameworks = Seq("org.scalatest.tools.Framework")
         override def ivyDeps = Agg(
           ivy"org.scalatest::scalatest::3.0.4"
@@ -75,16 +83,16 @@ object HelloJSWorldTests extends TestSuite {
 
   val helloWorldEvaluator = TestEvaluator.static(HelloJSWorld)
 
-
   val mainObject = helloWorldEvaluator.outPath / 'src / "Main.scala"
 
   def tests: Tests = Tests {
     prepareWorkspace()
     'compile - {
       def testCompileFromScratch(scalaVersion: String,
-                          scalaJSVersion: String): Unit = {
+                                 scalaJSVersion: String): Unit = {
         val Right((result, evalCount)) =
-          helloWorldEvaluator(HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion).compile)
+          helloWorldEvaluator(
+            HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion).compile)
 
         val outPath = result.classes.path
         val outputFiles = ls.rec(outPath)
@@ -96,13 +104,15 @@ object HelloJSWorldTests extends TestSuite {
 
         // don't recompile if nothing changed
         val Right((_, unchangedEvalCount)) =
-          helloWorldEvaluator(HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion).compile)
+          helloWorldEvaluator(
+            HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion).compile)
         assert(unchangedEvalCount == 0)
       }
 
       'fromScratch_2124_0622 - testCompileFromScratch("2.12.4", "0.6.22")
       'fromScratch_2123_0622 - testCompileFromScratch("2.12.3", "0.6.22")
-      'fromScratch_2118_0622 - TestUtil.disableInJava9OrAbove(testCompileFromScratch("2.11.8", "0.6.22"))
+      'fromScratch_2118_0622 - TestUtil.disableInJava9OrAbove(
+        testCompileFromScratch("2.11.8", "0.6.22"))
       'fromScratch_2124_100M2 - testCompileFromScratch("2.12.4", "1.0.0-M2")
     }
 
@@ -110,8 +120,10 @@ object HelloJSWorldTests extends TestSuite {
                 scalaJSVersion: String,
                 mode: OptimizeMode): Unit = {
       val task = mode match {
-        case FullOpt => HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion).fullOpt
-        case FastOpt => HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion).fastOpt
+        case FullOpt =>
+          HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion).fullOpt
+        case FastOpt =>
+          HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion).fastOpt
       }
       val Right((result, evalCount)) = helloWorldEvaluator(task)
       val output = ScalaJsUtils.runJS(result.path)
@@ -119,20 +131,29 @@ object HelloJSWorldTests extends TestSuite {
     }
 
     'fullOpt - {
-      'run_2124_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "0.6.22", FullOpt))
-      'run_2123_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.3", "0.6.22", FullOpt))
-      'run_2118_0622 - TestUtil.disableInJava9OrAbove(testRun("2.11.8", "0.6.22", FullOpt))
-      'run_2124_100M2 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "1.0.0-M2", FullOpt))
+      'run_2124_0622 - TestUtil.disableInJava9OrAbove(
+        testRun("2.12.4", "0.6.22", FullOpt))
+      'run_2123_0622 - TestUtil.disableInJava9OrAbove(
+        testRun("2.12.3", "0.6.22", FullOpt))
+      'run_2118_0622 - TestUtil.disableInJava9OrAbove(
+        testRun("2.11.8", "0.6.22", FullOpt))
+      'run_2124_100M2 - TestUtil.disableInJava9OrAbove(
+        testRun("2.12.4", "1.0.0-M2", FullOpt))
     }
     'fastOpt - {
-      'run_2124_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "0.6.22", FastOpt))
-      'run_2123_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.3", "0.6.22", FastOpt))
-      'run_2118_0622 - TestUtil.disableInJava9OrAbove(testRun("2.11.8", "0.6.22", FastOpt))
-      'run_2124_100M2 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "1.0.0-M2", FastOpt))
+      'run_2124_0622 - TestUtil.disableInJava9OrAbove(
+        testRun("2.12.4", "0.6.22", FastOpt))
+      'run_2123_0622 - TestUtil.disableInJava9OrAbove(
+        testRun("2.12.3", "0.6.22", FastOpt))
+      'run_2118_0622 - TestUtil.disableInJava9OrAbove(
+        testRun("2.11.8", "0.6.22", FastOpt))
+      'run_2124_100M2 - TestUtil.disableInJava9OrAbove(
+        testRun("2.12.4", "1.0.0-M2", FastOpt))
     }
     'jar - {
       'containsSJSIRs - {
-        val Right((result, evalCount)) = helloWorldEvaluator(HelloJSWorld.helloJsWorld("2.12.4", "0.6.22").jar)
+        val Right((result, evalCount)) =
+          helloWorldEvaluator(HelloJSWorld.helloJsWorld("2.12.4", "0.6.22").jar)
         val jar = result.path
         val entries = new JarFile(jar.toIO).entries().asScala.map(_.getName)
         assert(entries.contains("Main$.sjsir"))
@@ -142,14 +163,22 @@ object HelloJSWorldTests extends TestSuite {
       def testArtifactId(scalaVersion: String,
                          scalaJSVersion: String,
                          artifactId: String): Unit = {
-        val Right((result, evalCount)) = helloWorldEvaluator(HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion).artifactMetadata)
+        val Right((result, evalCount)) = helloWorldEvaluator(
+          HelloJSWorld
+            .helloJsWorld(scalaVersion, scalaJSVersion)
+            .artifactMetadata)
         assert(result.id == artifactId)
       }
-      'artifactId_0622 - testArtifactId("2.12.4", "0.6.22", "hello-js-world_sjs0.6_2.12")
-      'artifactId_100M2 - testArtifactId("2.12.4", "1.0.0-M2", "hello-js-world_sjs1.0.0-M2_2.12")
+      'artifactId_0622 - testArtifactId("2.12.4",
+                                        "0.6.22",
+                                        "hello-js-world_sjs0.6_2.12")
+      'artifactId_100M2 - testArtifactId("2.12.4",
+                                         "1.0.0-M2",
+                                         "hello-js-world_sjs1.0.0-M2_2.12")
     }
     'test - {
-      def runTests(testTask: define.Command[(String, Seq[TestRunner.Result])]): Map[String, Map[String, TestRunner.Result]] = {
+      def runTests(testTask: define.Command[(String, Seq[TestRunner.Result])])
+        : Map[String, Map[String, TestRunner.Result]] = {
         val Left(Result.Failure(_, Some(res))) = helloWorldEvaluator(testTask)
 
         val (doneMsg, testResults) = res
@@ -159,7 +188,8 @@ object HelloJSWorldTests extends TestSuite {
       }
 
       def checkUtest(scalaVersion: String, scalaJSVersion: String) = {
-        val resultMap = runTests(HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion).test.test())
+        val resultMap = runTests(
+          HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion).test.test())
 
         val mainTests = resultMap("MainTests")
         val argParserTests = resultMap("ArgsParserTests")
@@ -168,7 +198,6 @@ object HelloJSWorldTests extends TestSuite {
           mainTests.size == 2,
           mainTests("MainTests.vmName.containJs").status == "Success",
           mainTests("MainTests.vmName.containScala").status == "Success",
-
           argParserTests.size == 2,
           argParserTests("ArgsParserTests.one").status == "Success",
           argParserTests("ArgsParserTests.two").status == "Failure"
@@ -176,7 +205,8 @@ object HelloJSWorldTests extends TestSuite {
       }
 
       def checkScalaTest(scalaVersion: String, scalaJSVersion: String) = {
-        val resultMap = runTests(HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion).test.test())
+        val resultMap = runTests(
+          HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion).test.test())
 
         val mainSpec = resultMap("MainSpec")
         val argParserSpec = resultMap("ArgsParserSpec")
@@ -185,19 +215,21 @@ object HelloJSWorldTests extends TestSuite {
           mainSpec.size == 2,
           mainSpec("vmName should contain js").status == "Success",
           mainSpec("vmName should contain Scala").status == "Success",
-
           argParserSpec.size == 2,
           argParserSpec("parse should one").status == "Success",
           argParserSpec("parse should two").status == "Failure"
         )
       }
 
-      'utest_2118_0622 - TestUtil.disableInJava9OrAbove(checkUtest("2.11.8", "0.6.22"))
+      'utest_2118_0622 - TestUtil.disableInJava9OrAbove(
+        checkUtest("2.11.8", "0.6.22"))
       'utest_2124_0622 - checkUtest("2.12.4", "0.6.22")
-      'utest_2118_100M2 - TestUtil.disableInJava9OrAbove(checkUtest("2.11.8", "1.0.0-M2"))
+      'utest_2118_100M2 - TestUtil.disableInJava9OrAbove(
+        checkUtest("2.11.8", "1.0.0-M2"))
       'utest_2124_100M2 - checkUtest("2.12.4", "1.0.0-M2")
 
-      'scalaTest_2118_0622 - TestUtil.disableInJava9OrAbove(checkScalaTest("2.11.8", "0.6.22"))
+      'scalaTest_2118_0622 - TestUtil.disableInJava9OrAbove(
+        checkScalaTest("2.11.8", "0.6.22"))
       'scalaTest_2124_0622 - checkScalaTest("2.12.4", "0.6.22")
 //      No scalatest artifact for scala.js 1.0.0-M2 published yet
 //      'scalaTest_2118_100M2 - checkScalaTest("2.11.8", "1.0.0-M2")
@@ -222,9 +254,11 @@ object HelloJSWorldTests extends TestSuite {
     }
 
     'run - {
-      'run_2118_0622  - TestUtil.disableInJava9OrAbove(checkRun("2.11.8", "0.6.22"))
-      'run_2124_0622  - checkRun("2.12.4", "0.6.22")
-      'run_2118_100M2 - TestUtil.disableInJava9OrAbove(checkRun("2.11.8", "1.0.0-M2"))
+      'run_2118_0622 - TestUtil.disableInJava9OrAbove(
+        checkRun("2.11.8", "0.6.22"))
+      'run_2124_0622 - checkRun("2.12.4", "0.6.22")
+      'run_2118_100M2 - TestUtil.disableInJava9OrAbove(
+        checkRun("2.11.8", "1.0.0-M2"))
       'run_2124_100M2 - checkRun("2.12.4", "1.0.0-M2")
     }
   }

--- a/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/MultiModuleTests.scala
@@ -9,7 +9,7 @@ import mill.scalalib._
 import utest._
 
 object MultiModuleTests extends TestSuite {
-  val workspacePath =  TestUtil.getOutPathStatic() / "multi-module"
+  val workspacePath = TestUtil.getOutPathStatic() / "multi-module"
   val sourcePath = pwd / 'scalajslib / 'test / 'resources / "multi-module"
 
   object MultiModule extends TestUtil.BaseModule {
@@ -58,7 +58,8 @@ object MultiModuleTests extends TestSuite {
     'fullOpt - TestUtil.disableInJava9OrAbove(checkOpt(FullOpt))
 
     'test - {
-      val Right(((_, testResults), evalCount)) = evaluator(MultiModule.client.test.test())
+      val Right(((_, testResults), evalCount)) =
+        evaluator(MultiModule.client.test.test())
 
       assert(
         evalCount > 0,
@@ -69,7 +70,7 @@ object MultiModuleTests extends TestSuite {
 
     'run - {
       val command = MultiModule.client.run()
-      
+
       val Right((_, evalCount)) = evaluator(command)
 
       val paths = Evaluator.resolveDestPaths(

--- a/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
+++ b/scalajslib/test/src/mill/scalajslib/NodeJSConfigTests.scala
@@ -8,9 +8,8 @@ import mill.scalalib.{CrossScalaModule, DepSyntax}
 import mill.util.{TestEvaluator, TestUtil}
 import utest._
 
-
 object NodeJSConfigTests extends TestSuite {
-  val workspacePath =  TestUtil.getOutPathStatic() / "hello-js-world"
+  val workspacePath = TestUtil.getOutPathStatic() / "hello-js-world"
   val scalaVersion = "2.12.4"
   val scalaJSVersion = "0.6.22"
   val utestVersion = "0.6.3"
@@ -30,18 +29,19 @@ object NodeJSConfigTests extends TestSuite {
       nodeArgs <- Seq(nodeArgsEmpty, nodeArgs2G)
     } yield (scala, nodeArgs)
 
-    object helloJsWorld extends Cross[BuildModule](matrix:_*)
-    class BuildModule(val crossScalaVersion: String, nodeArgs: List[String]) extends HelloJSWorldModule {
+    object helloJsWorld extends Cross[BuildModule](matrix: _*)
+    class BuildModule(val crossScalaVersion: String, nodeArgs: List[String])
+        extends HelloJSWorldModule {
       override def artifactName = "hello-js-world"
       def scalaJSVersion = NodeJSConfigTests.scalaJSVersion
       override def nodeJSConfig = T { NodeJSConfig(args = nodeArgs) }
     }
 
-    object buildUTest extends Cross[BuildModuleUtest](matrix:_*)
+    object buildUTest extends Cross[BuildModuleUtest](matrix: _*)
     class BuildModuleUtest(crossScalaVersion: String, nodeArgs: List[String])
-      extends BuildModule(crossScalaVersion, nodeArgs) {
+        extends BuildModule(crossScalaVersion, nodeArgs) {
       object test extends super.Tests {
-        override def sources = T.sources{ millSourcePath / 'src / 'utest }
+        override def sources = T.sources { millSourcePath / 'src / 'utest }
         def testFrameworks = Seq("utest.runner.Framework")
         override def ivyDeps = Agg(
           ivy"com.lihaoyi::utest::$utestVersion"
@@ -62,7 +62,9 @@ object NodeJSConfigTests extends TestSuite {
   def tests: Tests = Tests {
     prepareWorkspace()
 
-    def checkLog(command: define.Command[_], nodeArgs: List[String], notNodeArgs: List[String]) = {
+    def checkLog(command: define.Command[_],
+                 nodeArgs: List[String],
+                 notNodeArgs: List[String]) = {
       helloWorldEvaluator(command)
       val paths = Evaluator.resolveDestPaths(
         helloWorldEvaluator.outPath,
@@ -78,7 +80,9 @@ object NodeJSConfigTests extends TestSuite {
     'test - {
 
       def checkUtest(nodeArgs: List[String], notNodeArgs: List[String]) = {
-        checkLog(HelloJSWorld.buildUTest(scalaVersion, nodeArgs).test.test(), nodeArgs, notNodeArgs)
+        checkLog(HelloJSWorld.buildUTest(scalaVersion, nodeArgs).test.test(),
+                 nodeArgs,
+                 notNodeArgs)
       }
 
       'test - checkUtest(nodeArgsEmpty, nodeArgs2G)
@@ -86,7 +90,9 @@ object NodeJSConfigTests extends TestSuite {
     }
 
     def checkRun(nodeArgs: List[String], notNodeArgs: List[String]): Unit = {
-      checkLog(HelloJSWorld.helloJsWorld(scalaVersion, nodeArgs).run(), nodeArgs, notNodeArgs)
+      checkLog(HelloJSWorld.helloJsWorld(scalaVersion, nodeArgs).run(),
+               nodeArgs,
+               notNodeArgs)
     }
 
     'run - {

--- a/scalalib/src/mill/scalalib/Dep.scala
+++ b/scalalib/src/mill/scalalib/Dep.scala
@@ -5,24 +5,34 @@ sealed trait Dep {
   def configure(attributes: coursier.Attributes): Dep
   def force: Boolean
   def forceVersion(): Dep = this match {
-    case dep : Dep.Java => dep.copy(force = true)
-    case dep : Dep.Scala => dep.copy(force = true)
-    case dep : Dep.Point => dep.copy(force = true)
+    case dep: Dep.Java  => dep.copy(force = true)
+    case dep: Dep.Scala => dep.copy(force = true)
+    case dep: Dep.Point => dep.copy(force = true)
   }
   def exclude(exclusions: (String, String)*): Dep = this match {
-    case dep : Dep.Java => dep.copy(dep = dep.dep.copy(exclusions = dep.dep.exclusions ++ exclusions))
-    case dep : Dep.Scala => dep.copy(dep = dep.dep.copy(exclusions = dep.dep.exclusions ++ exclusions))
-    case dep : Dep.Point => dep.copy(dep = dep.dep.copy(exclusions = dep.dep.exclusions ++ exclusions))
+    case dep: Dep.Java =>
+      dep.copy(
+        dep = dep.dep.copy(exclusions = dep.dep.exclusions ++ exclusions))
+    case dep: Dep.Scala =>
+      dep.copy(
+        dep = dep.dep.copy(exclusions = dep.dep.exclusions ++ exclusions))
+    case dep: Dep.Point =>
+      dep.copy(
+        dep = dep.dep.copy(exclusions = dep.dep.exclusions ++ exclusions))
   }
-  def excludeOrg(organizations: String*): Dep = exclude(organizations.map(_ -> "*"): _*)
+  def excludeOrg(organizations: String*): Dep =
+    exclude(organizations.map(_ -> "*"): _*)
   def excludeName(names: String*): Dep = exclude(names.map("*" -> _): _*)
   def withConfiguration(configuration: String): Dep = this match {
-    case dep : Dep.Java => dep.copy(dep = dep.dep.copy(configuration = configuration))
-    case dep : Dep.Scala => dep.copy(dep = dep.dep.copy(configuration = configuration))
-    case dep : Dep.Point => dep.copy(dep = dep.dep.copy(configuration = configuration))
+    case dep: Dep.Java =>
+      dep.copy(dep = dep.dep.copy(configuration = configuration))
+    case dep: Dep.Scala =>
+      dep.copy(dep = dep.dep.copy(configuration = configuration))
+    case dep: Dep.Point =>
+      dep.copy(dep = dep.dep.copy(configuration = configuration))
   }
 }
-object Dep{
+object Dep {
 
   val DefaultConfiguration = "default(compile)"
 
@@ -32,53 +42,94 @@ object Dep{
     val attributes = parts.tail.foldLeft(coursier.Attributes()) { (as, s) =>
       s.split('=') match {
         case Array("classifier", v) => as.copy(classifier = v)
-        case Array(k, v) => throw new Exception(s"Unrecognized attribute: [$s]")
-        case _ => throw new Exception(s"Unable to parse attribute specifier: [$s]")
+        case Array(k, v)            => throw new Exception(s"Unrecognized attribute: [$s]")
+        case _ =>
+          throw new Exception(s"Unable to parse attribute specifier: [$s]")
       }
     }
     (module.split(':') match {
-      case Array(a, b, c) => Dep.Java(a, b, c, cross = false, force = false)
+      case Array(a, b, c)     => Dep.Java(a, b, c, cross = false, force = false)
       case Array(a, b, "", c) => Dep.Java(a, b, c, cross = true, force = false)
-      case Array(a, "", b, c) => Dep.Scala(a, b, c, cross = false, force = false)
-      case Array(a, "", b, "", c) => Dep.Scala(a, b, c, cross = true, force = false)
-      case Array(a, "", "", b, c) => Dep.Point(a, b, c, cross = false, force = false)
-      case Array(a, "", "", b, "", c) => Dep.Point(a, b, c, cross = true, force = false)
+      case Array(a, "", b, c) =>
+        Dep.Scala(a, b, c, cross = false, force = false)
+      case Array(a, "", b, "", c) =>
+        Dep.Scala(a, b, c, cross = true, force = false)
+      case Array(a, "", "", b, c) =>
+        Dep.Point(a, b, c, cross = false, force = false)
+      case Array(a, "", "", b, "", c) =>
+        Dep.Point(a, b, c, cross = true, force = false)
       case _ => throw new Exception(s"Unable to parse signature: [$signature]")
     }).configure(attributes = attributes)
   }
   def apply(org: String, name: String, version: String, cross: Boolean): Dep = {
-    this(coursier.Dependency(coursier.Module(org, name), version, DefaultConfiguration), cross)
+    this(coursier.Dependency(coursier.Module(org, name),
+                             version,
+                             DefaultConfiguration),
+         cross)
   }
-  case class Java(dep: coursier.Dependency, cross: Boolean, force: Boolean) extends Dep {
-    def configure(attributes: coursier.Attributes): Dep = copy(dep = dep.copy(attributes = attributes))
+  case class Java(dep: coursier.Dependency, cross: Boolean, force: Boolean)
+      extends Dep {
+    def configure(attributes: coursier.Attributes): Dep =
+      copy(dep = dep.copy(attributes = attributes))
   }
-  object Java{
+  object Java {
     implicit def rw: RW[Java] = macroRW
-    def apply(org: String, name: String, version: String, cross: Boolean, force: Boolean): Dep = {
-      Java(coursier.Dependency(coursier.Module(org, name), version, DefaultConfiguration), cross, force)
+    def apply(org: String,
+              name: String,
+              version: String,
+              cross: Boolean,
+              force: Boolean): Dep = {
+      Java(coursier.Dependency(coursier.Module(org, name),
+                               version,
+                               DefaultConfiguration),
+           cross,
+           force)
     }
   }
-  implicit def default(dep: coursier.Dependency): Dep = new Java(dep, false, false)
+  implicit def default(dep: coursier.Dependency): Dep =
+    new Java(dep, false, false)
   def apply(dep: coursier.Dependency, cross: Boolean) = Scala(dep, cross, false)
-  case class Scala(dep: coursier.Dependency, cross: Boolean, force: Boolean) extends Dep {
-    def configure(attributes: coursier.Attributes): Dep = copy(dep = dep.copy(attributes = attributes))
+  case class Scala(dep: coursier.Dependency, cross: Boolean, force: Boolean)
+      extends Dep {
+    def configure(attributes: coursier.Attributes): Dep =
+      copy(dep = dep.copy(attributes = attributes))
   }
-  object Scala{
+  object Scala {
     implicit def rw: RW[Scala] = macroRW
-    def apply(org: String, name: String, version: String, cross: Boolean, force: Boolean): Dep = {
-      Scala(coursier.Dependency(coursier.Module(org, name), version, DefaultConfiguration), cross, force)
+    def apply(org: String,
+              name: String,
+              version: String,
+              cross: Boolean,
+              force: Boolean): Dep = {
+      Scala(coursier.Dependency(coursier.Module(org, name),
+                                version,
+                                DefaultConfiguration),
+            cross,
+            force)
     }
   }
-  case class Point(dep: coursier.Dependency, cross: Boolean, force: Boolean) extends Dep {
-    def configure(attributes: coursier.Attributes): Dep = copy(dep = dep.copy(attributes = attributes))
+  case class Point(dep: coursier.Dependency, cross: Boolean, force: Boolean)
+      extends Dep {
+    def configure(attributes: coursier.Attributes): Dep =
+      copy(dep = dep.copy(attributes = attributes))
   }
-  object Point{
+  object Point {
     implicit def rw: RW[Point] = macroRW
-    def apply(org: String, name: String, version: String, cross: Boolean, force: Boolean): Dep = {
-      Point(coursier.Dependency(coursier.Module(org, name), version, DefaultConfiguration), cross, force)
+    def apply(org: String,
+              name: String,
+              version: String,
+              cross: Boolean,
+              force: Boolean): Dep = {
+      Point(coursier.Dependency(coursier.Module(org, name),
+                                version,
+                                DefaultConfiguration),
+            cross,
+            force)
     }
   }
   implicit def rw = RW.merge[Dep](
-    Java.rw, Scala.rw, Point.rw
+    Java.rw,
+    Scala.rw,
+    Point.rw
   )
 }

--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -12,10 +12,9 @@ import mill.{T, scalalib}
 
 import scala.util.Try
 
-
 object GenIdea extends ExternalModule {
 
-  def idea(ev: Evaluator[Any]) = T.command{
+  def idea(ev: Evaluator[Any]) = T.command {
     mill.scalalib.GenIdeaImpl(
       implicitly,
       ev.rootModule,
@@ -33,98 +32,115 @@ object GenIdeaImpl {
             discover: Discover[_]): Unit = {
     val pp = new scala.xml.PrettyPrinter(999, 4)
 
-    val jdkInfo = extractCurrentJdk(pwd / ".idea" / "misc.xml").getOrElse(("JDK_1_8", "1.8 (1)"))
+    val jdkInfo = extractCurrentJdk(pwd / ".idea" / "misc.xml")
+      .getOrElse(("JDK_1_8", "1.8 (1)"))
 
-    rm! pwd/".idea"/"libraries"
-    rm! pwd/".idea"/"scala_compiler.xml"
-    rm! pwd/".idea_modules"
+    rm ! pwd / ".idea" / "libraries"
+    rm ! pwd / ".idea" / "scala_compiler.xml"
+    rm ! pwd / ".idea_modules"
 
+    val evaluator =
+      new Evaluator(ctx.home, pwd / 'out, pwd / 'out, rootModule, ctx.log)
 
-    val evaluator = new Evaluator(ctx.home, pwd / 'out, pwd / 'out, rootModule, ctx.log)
-
-    for((relPath, xml) <- xmlFileLayout(evaluator, rootModule, jdkInfo)){
-      write.over(pwd/relPath, pp.format(xml))
+    for ((relPath, xml) <- xmlFileLayout(evaluator, rootModule, jdkInfo)) {
+      write.over(pwd / relPath, pp.format(xml))
     }
   }
 
-  def extractCurrentJdk(ideaPath: Path): Option[(String,String)] = {
+  def extractCurrentJdk(ideaPath: Path): Option[(String, String)] = {
     import scala.xml.XML
     Try {
       val xml = XML.loadFile(ideaPath.toString)
       (xml \\ "component")
-        .filter(x => x.attribute("project-jdk-type").map(_.text).contains("JavaSDK"))
-        .map { n => (n.attribute("languageLevel"), n.attribute("project-jdk-name")) }
-        .collectFirst{ case (Some(lang), Some(jdk)) => (lang.text, jdk.text) }
+        .filter(x =>
+          x.attribute("project-jdk-type").map(_.text).contains("JavaSDK"))
+        .map { n =>
+          (n.attribute("languageLevel"), n.attribute("project-jdk-name"))
+        }
+        .collectFirst { case (Some(lang), Some(jdk)) => (lang.text, jdk.text) }
     }.getOrElse(None)
   }
 
-  def xmlFileLayout[T](evaluator: Evaluator[T],
-                       rootModule: mill.Module,
-                       jdkInfo: (String,String),
-                       fetchMillModules: Boolean = true): Seq[(RelPath, scala.xml.Node)] = {
+  def xmlFileLayout[T](
+      evaluator: Evaluator[T],
+      rootModule: mill.Module,
+      jdkInfo: (String, String),
+      fetchMillModules: Boolean = true): Seq[(RelPath, scala.xml.Node)] = {
 
-    val modules = rootModule.millInternal.segmentsToModules.values
-      .collect{ case x: scalalib.JavaModule => (x.millModuleSegments, x)}
-      .toSeq
+    val modules = rootModule.millInternal.segmentsToModules.values.collect {
+      case x: scalalib.JavaModule => (x.millModuleSegments, x)
+    }.toSeq
 
     val buildLibraryPaths =
       if (!fetchMillModules) Nil
-      else sys.props.get("MILL_BUILD_LIBRARIES") match {
-        case Some(found) => found.split(',').map(Path(_)).distinct.toList
-        case None =>
-          val repos = modules.foldLeft(Set.empty[Repository]) { _ ++ _._2.repositories }
-          val artifactNames = Seq("moduledefs", "core", "scalalib", "scalajslib")
-          val Result.Success(res) = scalalib.Lib.resolveDependencies(
-            repos.toList,
-            Lib.depToDependency(_, "2.12.4", ""),
-            for(name <- artifactNames)
-            yield ivy"com.lihaoyi::mill-$name:${sys.props("MILL_VERSION")}"
-          )
-          res.items.toList.map(_.path)
+      else
+        sys.props.get("MILL_BUILD_LIBRARIES") match {
+          case Some(found) => found.split(',').map(Path(_)).distinct.toList
+          case None =>
+            val repos = modules.foldLeft(Set.empty[Repository]) {
+              _ ++ _._2.repositories
+            }
+            val artifactNames =
+              Seq("moduledefs", "core", "scalalib", "scalajslib")
+            val Result.Success(res) = scalalib.Lib.resolveDependencies(
+              repos.toList,
+              Lib.depToDependency(_, "2.12.4", ""),
+              for (name <- artifactNames)
+                yield ivy"com.lihaoyi::mill-$name:${sys.props("MILL_VERSION")}"
+            )
+            res.items.toList.map(_.path)
+        }
+
+    val buildDepsPaths = Try(
+      evaluator.rootModule.getClass.getClassLoader
+        .asInstanceOf[SpecialClassLoader])
+      .map {
+        _.allJars
+          .map(url => Path(url.getFile))
+          .filter(_.toIO.exists)
       }
+      .getOrElse(Seq())
 
-    val buildDepsPaths = Try(evaluator
-      .rootModule
-      .getClass
-      .getClassLoader
-      .asInstanceOf[SpecialClassLoader]
-    ).map {
-       _.allJars
-        .map(url => Path(url.getFile))
-        .filter(_.toIO.exists)
-    }.getOrElse(Seq())
-
-    val resolved = for((path, mod) <- modules) yield {
-      val scalaLibraryIvyDeps = mod match{
+    val resolved = for ((path, mod) <- modules) yield {
+      val scalaLibraryIvyDeps = mod match {
         case x: ScalaModule => x.scalaLibraryIvyDeps
-        case _ => T.task{Nil}
+        case _              => T.task { Nil }
       }
-      val allIvyDeps = T.task{mod.transitiveIvyDeps() ++ scalaLibraryIvyDeps() ++ mod.compileIvyDeps()}
-      val externalDependencies = T.task{
+      val allIvyDeps = T.task {
+        mod.transitiveIvyDeps() ++ scalaLibraryIvyDeps() ++ mod.compileIvyDeps()
+      }
+      val externalDependencies = T.task {
         mod.resolveDeps(allIvyDeps)() ++
-        Task.traverse(mod.transitiveModuleDeps)(_.unmanagedClasspath)().flatten
+          Task
+            .traverse(mod.transitiveModuleDeps)(_.unmanagedClasspath)()
+            .flatten
       }
 
-      val externalSources = T.task{
+      val externalSources = T.task {
         mod.resolveDeps(allIvyDeps, sources = true)()
       }
 
-      val (scalacPluginsIvyDeps, scalacOptions) = mod match{
-        case mod: ScalaModule => T.task{mod.scalacPluginIvyDeps()} -> T.task{mod.scalacOptions()}
+      val (scalacPluginsIvyDeps, scalacOptions) = mod match {
+        case mod: ScalaModule =>
+          T.task { mod.scalacPluginIvyDeps() } -> T.task { mod.scalacOptions() }
         case _ => T.task(Loose.Agg[Dep]()) -> T.task(Seq())
       }
-      val scalacPluginDependencies = T.task{
+      val scalacPluginDependencies = T.task {
         mod.resolveDeps(scalacPluginsIvyDeps)()
       }
 
-      val resolvedCp: Loose.Agg[PathRef] = evalOrElse(evaluator, externalDependencies, Loose.Agg.empty)
-      val resolvedSrcs: Loose.Agg[PathRef] = evalOrElse(evaluator, externalSources, Loose.Agg.empty)
-      val resolvedSp: Loose.Agg[PathRef] = evalOrElse(evaluator, scalacPluginDependencies, Loose.Agg.empty)
+      val resolvedCp: Loose.Agg[PathRef] =
+        evalOrElse(evaluator, externalDependencies, Loose.Agg.empty)
+      val resolvedSrcs: Loose.Agg[PathRef] =
+        evalOrElse(evaluator, externalSources, Loose.Agg.empty)
+      val resolvedSp: Loose.Agg[PathRef] =
+        evalOrElse(evaluator, scalacPluginDependencies, Loose.Agg.empty)
       val scalacOpts: Seq[String] = evalOrElse(evaluator, scalacOptions, Seq())
 
       (
         path,
-        resolvedCp.map(_.path).filter(_.ext == "jar") ++ resolvedSrcs.map(_.path),
+        resolvedCp.map(_.path).filter(_.ext == "jar") ++ resolvedSrcs.map(
+          _.path),
         mod,
         resolvedSp.map(_.path).filter(_.ext == "jar"),
         scalacOpts
@@ -138,37 +154,38 @@ object GenIdeaImpl {
       if (allResolved.isEmpty) 0
       else {
         val minResolvedLength = allResolved.map(_.segments.length).min
-        allResolved.map(_.segments.take(minResolvedLength))
+        allResolved
+          .map(_.segments.take(minResolvedLength))
           .transpose
           .takeWhile(_.distinct.length == 1)
           .length
       }
 
     // only resort to full long path names if the jar name is a duplicate
-    val pathShortLibNameDuplicate = allResolved
-      .distinct
-      .map{p => p.segments.last -> p}
+    val pathShortLibNameDuplicate = allResolved.distinct
+      .map { p =>
+        p.segments.last -> p
+      }
       .groupBy(_._1)
       .filter(_._2.size > 1)
       .keySet
 
-    val pathToLibName = allResolved
-      .map{p =>
-        if (pathShortLibNameDuplicate(p.segments.last))
-          (p, p.segments.drop(commonPrefix).mkString("_"))
-        else
-          (p, p.segments.last)
-      }
-      .toMap
+    val pathToLibName = allResolved.map { p =>
+      if (pathShortLibNameDuplicate(p.segments.last))
+        (p, p.segments.drop(commonPrefix).mkString("_"))
+      else
+        (p, p.segments.last)
+    }.toMap
 
-    sealed trait ResolvedLibrary { def path : Path }
-    case class CoursierResolved(path : Path, pom : Path, sources : Option[Path])
-      extends ResolvedLibrary
-    case class OtherResolved(path : Path) extends ResolvedLibrary
+    sealed trait ResolvedLibrary { def path: Path }
+    case class CoursierResolved(path: Path, pom: Path, sources: Option[Path])
+        extends ResolvedLibrary
+    case class OtherResolved(path: Path) extends ResolvedLibrary
 
     // Tries to group jars with their poms and sources.
-    def toResolvedJar(path : Path) : Option[ResolvedLibrary] = {
-      val inCoursierCache = path.startsWith(Path(CoursierPaths.cacheDirectory()))
+    def toResolvedJar(path: Path): Option[ResolvedLibrary] = {
+      val inCoursierCache =
+        path.startsWith(Path(CoursierPaths.cacheDirectory()))
       val isSource = path.segments.last.endsWith("sources.jar")
       val isPom = path.ext == "pom"
       if (inCoursierCache && (isSource || isPom)) {
@@ -185,7 +202,7 @@ object GenIdeaImpl {
 
     // Hack so that Intellij does not complain about unresolved magic
     // imports in build.sc when in fact they are resolved
-    def sbtLibraryNameFromPom(pom : Path) : String = {
+    def sbtLibraryNameFromPom(pom: Path): String = {
       val xml = scala.xml.XML.loadFile(pom.toIO)
 
       val groupId = (xml \ "groupId").text
@@ -196,7 +213,7 @@ object GenIdeaImpl {
       s"SBT: $groupId:$artifactId:$version:jar"
     }
 
-    def libraryName(resolvedJar: ResolvedLibrary) : String = resolvedJar match {
+    def libraryName(resolvedJar: ResolvedLibrary): String = resolvedJar match {
       case CoursierResolved(path, pom, _) if buildDepsPaths.contains(path) =>
         sbtLibraryNameFromPom(pom)
       case CoursierResolved(path, _, _) =>
@@ -205,9 +222,10 @@ object GenIdeaImpl {
         pathToLibName(path)
     }
 
-    def resolvedLibraries(resolved : Seq[Path]) : Seq[ResolvedLibrary] = resolved
-      .map(toResolvedJar)
-      .collect { case Some(r) => r}
+    def resolvedLibraries(resolved: Seq[Path]): Seq[ResolvedLibrary] =
+      resolved
+        .map(toResolvedJar)
+        .collect { case Some(r) => r }
 
     val compilerSettings = resolved
       .foldLeft(Map[(Loose.Agg[Path], Seq[String]), Vector[JavaModule]]()) {
@@ -216,82 +234,100 @@ object GenIdeaImpl {
           r + (key -> (r.getOrElse(key, Vector()) :+ q._3))
       }
 
-    val allBuildLibraries : Set[ResolvedLibrary] =
+    val allBuildLibraries: Set[ResolvedLibrary] =
       resolvedLibraries(buildLibraryPaths ++ buildDepsPaths).toSet
 
     val fixedFiles = Seq(
-      Tuple2(".idea"/"misc.xml", miscXmlTemplate(jdkInfo)),
-      Tuple2(".idea"/"scala_settings.xml", scalaSettingsTemplate()),
+      Tuple2(".idea" / "misc.xml", miscXmlTemplate(jdkInfo)),
+      Tuple2(".idea" / "scala_settings.xml", scalaSettingsTemplate()),
       Tuple2(
-        ".idea"/"modules.xml",
+        ".idea" / "modules.xml",
         allModulesXmlTemplate(
-          for((path, mod) <- modules)
+          for ((path, mod) <- modules)
             yield moduleName(path)
         )
       ),
       Tuple2(
-        ".idea_modules"/"mill-build.iml",
+        ".idea_modules" / "mill-build.iml",
         rootXmlTemplate(
-          for(lib <- allBuildLibraries)
-          yield libraryName(lib)
+          for (lib <- allBuildLibraries)
+            yield libraryName(lib)
         )
       ),
       Tuple2(
-        ".idea"/"scala_compiler.xml",
+        ".idea" / "scala_compiler.xml",
         scalaCompilerTemplate(compilerSettings)
       )
     )
 
-    val libraries = resolvedLibraries(allResolved).map{ resolved =>
+    val libraries = resolvedLibraries(allResolved).map { resolved =>
       import resolved.path
       val url = "jar://" + path + "!/"
       val name = libraryName(resolved)
       val sources = resolved match {
         case CoursierResolved(_, _, s) => s.map(p => "jar://" + p + "!/")
-        case OtherResolved(_) => None
+        case OtherResolved(_)          => None
       }
-      Tuple2(".idea"/'libraries/s"$name.xml", libraryXmlTemplate(name, url, sources))
+      Tuple2(".idea" / 'libraries / s"$name.xml",
+             libraryXmlTemplate(name, url, sources))
     }
 
-    val moduleFiles = resolved.map{ case (path, resolvedDeps, mod, _, _) =>
-      val Seq(
-        resourcesPathRefs: Seq[PathRef],
-        sourcesPathRef: Seq[PathRef],
-        generatedSourcePathRefs: Seq[PathRef],
-        allSourcesPathRefs: Seq[PathRef]
-      ) = evaluator.evaluate(Agg(mod.resources, mod.sources, mod.generatedSources, mod.allSources)).values
+    val moduleFiles = resolved.map {
+      case (path, resolvedDeps, mod, _, _) =>
+        val Seq(
+          resourcesPathRefs: Seq[PathRef],
+          sourcesPathRef: Seq[PathRef],
+          generatedSourcePathRefs: Seq[PathRef],
+          allSourcesPathRefs: Seq[PathRef]
+        ) = evaluator
+          .evaluate(
+            Agg(mod.resources,
+                mod.sources,
+                mod.generatedSources,
+                mod.allSources))
+          .values
 
-      val generatedSourcePaths = generatedSourcePathRefs.map(_.path)
-      val normalSourcePaths = (allSourcesPathRefs.map(_.path).toSet -- generatedSourcePaths.toSet).toSeq
+        val generatedSourcePaths = generatedSourcePathRefs.map(_.path)
+        val normalSourcePaths = (allSourcesPathRefs
+          .map(_.path)
+          .toSet -- generatedSourcePaths.toSet).toSeq
 
-      val paths = Evaluator.resolveDestPaths(
-        evaluator.outPath,
-        mod.compile.ctx.segments
-      )
-      val scalaVersionOpt = mod match {
-        case x: ScalaModule => Some(evaluator.evaluate(Agg(x.scalaVersion)).values.head.asInstanceOf[String])
-        case _ => None
-      }
-      val generatedSourceOutPath = Evaluator.resolveDestPaths(
-        evaluator.outPath,
-        mod.generatedSources.ctx.segments
-      )
+        val paths = Evaluator.resolveDestPaths(
+          evaluator.outPath,
+          mod.compile.ctx.segments
+        )
+        val scalaVersionOpt = mod match {
+          case x: ScalaModule =>
+            Some(
+              evaluator
+                .evaluate(Agg(x.scalaVersion))
+                .values
+                .head
+                .asInstanceOf[String])
+          case _ => None
+        }
+        val generatedSourceOutPath = Evaluator.resolveDestPaths(
+          evaluator.outPath,
+          mod.generatedSources.ctx.segments
+        )
 
-      val isTest = mod.isInstanceOf[TestModule]
+        val isTest = mod.isInstanceOf[TestModule]
 
-      val elem = moduleXmlTemplate(
-        mod.intellijModulePath,
-        scalaVersionOpt,
-        Strict.Agg.from(resourcesPathRefs.map(_.path)),
-        Strict.Agg.from(normalSourcePaths),
-        Strict.Agg.from(generatedSourcePaths),
-        paths.out,
-        generatedSourceOutPath.dest,
-        Strict.Agg.from(resolvedDeps.map(pathToLibName)),
-        Strict.Agg.from(mod.moduleDeps.map{ m => moduleName(moduleLabels(m))}.distinct),
-        isTest
-      )
-      Tuple2(".idea_modules"/s"${moduleName(path)}.iml", elem)
+        val elem = moduleXmlTemplate(
+          mod.intellijModulePath,
+          scalaVersionOpt,
+          Strict.Agg.from(resourcesPathRefs.map(_.path)),
+          Strict.Agg.from(normalSourcePaths),
+          Strict.Agg.from(generatedSourcePaths),
+          paths.out,
+          generatedSourceOutPath.dest,
+          Strict.Agg.from(resolvedDeps.map(pathToLibName)),
+          Strict.Agg.from(mod.moduleDeps.map { m =>
+            moduleName(moduleLabels(m))
+          }.distinct),
+          isTest
+        )
+        Tuple2(".idea_modules" / s"${moduleName(path)}.iml", elem)
     }
 
     fixedFiles ++ libraries ++ moduleFiles
@@ -299,22 +335,26 @@ object GenIdeaImpl {
 
   def evalOrElse[T](evaluator: Evaluator[_], e: Task[T], default: => T): T = {
     evaluator.evaluate(Agg(e)).values match {
-      case Seq() => default
+      case Seq()     => default
       case Seq(e: T) => e
     }
   }
 
   def relify(p: Path) = {
-    val r = p.relativeTo(pwd/".idea_modules")
+    val r = p.relativeTo(pwd / ".idea_modules")
     (Seq.fill(r.ups)("..") ++ r.segments).mkString("/")
   }
 
-  def moduleName(p: Segments) = p.value.foldLeft(StringBuilder.newBuilder) {
-    case (sb, Segment.Label(s)) if sb.isEmpty => sb.append(s)
-    case (sb, Segment.Cross(s)) if sb.isEmpty => sb.append(s.mkString("-"))
-    case (sb, Segment.Label(s)) => sb.append(".").append(s)
-    case (sb, Segment.Cross(s)) => sb.append("-").append(s.mkString("-"))
-  }.mkString.toLowerCase()
+  def moduleName(p: Segments) =
+    p.value
+      .foldLeft(StringBuilder.newBuilder) {
+        case (sb, Segment.Label(s)) if sb.isEmpty => sb.append(s)
+        case (sb, Segment.Cross(s)) if sb.isEmpty => sb.append(s.mkString("-"))
+        case (sb, Segment.Label(s))               => sb.append(".").append(s)
+        case (sb, Segment.Cross(s))               => sb.append("-").append(s.mkString("-"))
+      }
+      .mkString
+      .toLowerCase()
 
   def scalaSettingsTemplate() = {
 
@@ -324,7 +364,7 @@ object GenIdeaImpl {
       </component>
     </project>
   }
-  def miscXmlTemplate(jdkInfo: (String,String)) = {
+  def miscXmlTemplate(jdkInfo: (String, String)) = {
     <project version="4">
       <component name="ProjectRootManager" version="2" languageLevel={jdkInfo._1} project-jdk-name={jdkInfo._2} project-jdk-type="JavaSDK">
         <output url="file://$PROJECT_DIR$/target/idea_output"/>
@@ -394,8 +434,7 @@ object GenIdeaImpl {
                         generatedSourceOutputPath: Path,
                         libNames: Strict.Agg[String],
                         depNames: Strict.Agg[String],
-                        isTest: Boolean
-                       ) = {
+                        isTest: Boolean) = {
     <module type="JAVA_MODULE" version="4">
       <component name="NewModuleRootManager">
         {
@@ -445,7 +484,8 @@ object GenIdeaImpl {
       </component>
     </module>
   }
-  def scalaCompilerTemplate(settings: Map[(Loose.Agg[Path], Seq[String]), Seq[JavaModule]]) = {
+  def scalaCompilerTemplate(
+      settings: Map[(Loose.Agg[Path], Seq[String]), Seq[JavaModule]]) = {
 
     <project version="4">
       <component name="ScalaCompilerConfiguration">

--- a/scalalib/src/mill/scalalib/Lib.scala
+++ b/scalalib/src/mill/scalalib/Lib.scala
@@ -19,49 +19,56 @@ import sbt.testing._
 import scala.collection.mutable
 
 object CompilationResult {
-  implicit val jsonFormatter: upickle.default.ReadWriter[CompilationResult] = upickle.default.macroRW
+  implicit val jsonFormatter: upickle.default.ReadWriter[CompilationResult] =
+    upickle.default.macroRW
 }
 
 // analysisFile is represented by Path, so we won't break caches after file changes
 case class CompilationResult(analysisFile: Path, classes: PathRef)
 
-object Lib{
+object Lib {
   def compileJava(sources: Array[java.io.File],
                   classpath: Array[java.io.File],
                   javaOpts: Seq[String],
-                  upstreamCompileOutput: Seq[CompilationResult])
-                 (implicit ctx: mill.util.Ctx) = {
+                  upstreamCompileOutput: Seq[CompilationResult])(
+      implicit ctx: mill.util.Ctx) = {
     val javac = ToolProvider.getSystemJavaCompiler()
     if (javac == null) {
       throw new Exception(
         "Your Java installation is not a JDK, so it can't compile Java code;" +
-        " Please install the JDK version of Java")
+          " Please install the JDK version of Java")
     }
 
     rm(ctx.dest / 'classes)
     mkdir(ctx.dest / 'classes)
     val cpArgs =
-      if(classpath.isEmpty) Seq()
+      if (classpath.isEmpty) Seq()
       else Seq("-cp", classpath.mkString(File.pathSeparator))
 
     val args = Seq("-d", ctx.dest / 'classes) ++ cpArgs ++ javaOpts ++ sources
 
     javac.run(
-      ctx.log.inStream, ctx.log.outputStream, ctx.log.errorStream,
-      args.map(_.toString):_*
+      ctx.log.inStream,
+      ctx.log.outputStream,
+      ctx.log.errorStream,
+      args.map(_.toString): _*
     )
-    if (ls(ctx.dest / 'classes).isEmpty) mill.eval.Result.Failure("Compilation Failed")
-    else mill.eval.Result.Success(CompilationResult(ctx.dest / 'zinc, PathRef(ctx.dest / 'classes)))
+    if (ls(ctx.dest / 'classes).isEmpty)
+      mill.eval.Result.Failure("Compilation Failed")
+    else
+      mill.eval.Result.Success(
+        CompilationResult(ctx.dest / 'zinc, PathRef(ctx.dest / 'classes)))
   }
 
   private val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
-  private val MinorSnapshotVersion = raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
+  private val MinorSnapshotVersion =
+    raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
 
   def scalaBinaryVersion(scalaVersion: String) = {
     scalaVersion match {
-      case ReleaseVersion(major, minor, _) => s"$major.$minor"
+      case ReleaseVersion(major, minor, _)       => s"$major.$minor"
       case MinorSnapshotVersion(major, minor, _) => s"$major.$minor"
-      case _ => scalaVersion
+      case _                                     => scalaVersion
     }
   }
 
@@ -71,7 +78,6 @@ object Lib{
       .getOrElse(throw new Exception("Cannot find " + s))
       .toIO
   }
-
 
   def depToDependencyJava(dep: Dep, platformSuffix: String = ""): Dependency = {
     dep match {
@@ -85,7 +91,9 @@ object Lib{
         )
     }
   }
-  def depToDependency(dep: Dep, scalaVersion: String, platformSuffix: String = ""): Dependency =
+  def depToDependency(dep: Dep,
+                      scalaVersion: String,
+                      platformSuffix: String = ""): Dependency =
     dep match {
       case d: Dep.Java => depToDependencyJava(dep)
       case Dep.Scala(dep, cross, force) =>
@@ -93,8 +101,8 @@ object Lib{
           module = dep.module.copy(
             name =
               dep.module.name +
-              (if (!cross) "" else platformSuffix) +
-              "_" + scalaBinaryVersion(scalaVersion)
+                (if (!cross) "" else platformSuffix) +
+                "_" + scalaBinaryVersion(scalaVersion)
           )
         )
       case Dep.Point(dep, cross, force) =>
@@ -102,17 +110,17 @@ object Lib{
           module = dep.module.copy(
             name =
               dep.module.name +
-              (if (!cross) "" else platformSuffix) +
-              "_" + scalaVersion
+                (if (!cross) "" else platformSuffix) +
+                "_" + scalaVersion
           )
         )
     }
 
-
-  def resolveDependenciesMetadata(repositories: Seq[Repository],
-                                  depToDependency: Dep => coursier.Dependency,
-                                  deps: TraversableOnce[Dep],
-                                  mapDependencies: Option[Dependency => Dependency] = None) = {
+  def resolveDependenciesMetadata(
+      repositories: Seq[Repository],
+      depToDependency: Dep => coursier.Dependency,
+      deps: TraversableOnce[Dep],
+      mapDependencies: Option[Dependency => Dependency] = None) = {
     val depSeq = deps.toSeq
     mill.modules.Jvm.resolveDependenciesMetadata(
       repositories,
@@ -121,6 +129,7 @@ object Lib{
       mapDependencies
     )
   }
+
   /**
     * Resolve dependencies using Coursier.
     *
@@ -132,7 +141,8 @@ object Lib{
                           depToDependency: Dep => coursier.Dependency,
                           deps: TraversableOnce[Dep],
                           sources: Boolean = false,
-                          mapDependencies: Option[Dependency => Dependency] = None): Result[Agg[PathRef]] = {
+                          mapDependencies: Option[Dependency => Dependency] =
+                            None): Result[Agg[PathRef]] = {
     val depSeq = deps.toSeq
     mill.modules.Jvm.resolveDependencies(
       repositories,
@@ -151,20 +161,32 @@ object Lib{
   )
   def compilerBridgeIvyDep(scalaVersion: String) =
     Dep.Point(
-      coursier.Dependency(coursier.Module("com.lihaoyi", "mill-bridge"), "0.1", transitive = false),
+      coursier.Dependency(coursier.Module("com.lihaoyi", "mill-bridge"),
+                          "0.1",
+                          transitive = false),
       cross = false,
       force = false
     )
 
   def listClassFiles(base: Path): Iterator[String] = {
-    if (base.isDir) ls.rec(base).toIterator.filter(_.ext == "class").map(_.relativeTo(base).toString)
+    if (base.isDir)
+      ls.rec(base)
+        .toIterator
+        .filter(_.ext == "class")
+        .map(_.relativeTo(base).toString)
     else {
       val zip = new ZipInputStream(new FileInputStream(base.toIO))
-      Iterator.continually(zip.getNextEntry).takeWhile(_ != null).map(_.getName).filter(_.endsWith(".class"))
+      Iterator
+        .continually(zip.getNextEntry)
+        .takeWhile(_ != null)
+        .map(_.getName)
+        .filter(_.endsWith(".class"))
     }
   }
 
-  def discoverTests(cl: ClassLoader, framework: Framework, classpath: Agg[Path]) = {
+  def discoverTests(cl: ClassLoader,
+                    framework: Framework,
+                    classpath: Agg[Path]) = {
 
     val fingerprints = framework.fingerprints()
 
@@ -172,40 +194,52 @@ object Lib{
       // Don't blow up if there are no classfiles representing
       // the tests to run Instead just don't run anything
       if (!exists(base)) Nil
-      else listClassFiles(base).flatMap { path =>
-        val cls = cl.loadClass(path.stripSuffix(".class").replace('/', '.'))
-        val publicConstructorCount =
-          cls.getConstructors.count(c => c.getParameterCount == 0 && Modifier.isPublic(c.getModifiers))
+      else
+        listClassFiles(base).flatMap { path =>
+          val cls = cl.loadClass(path.stripSuffix(".class").replace('/', '.'))
+          val publicConstructorCount =
+            cls.getConstructors.count(c =>
+              c.getParameterCount == 0 && Modifier.isPublic(c.getModifiers))
 
-        if (Modifier.isAbstract(cls.getModifiers) || cls.isInterface || publicConstructorCount > 1) {
-          None
-        } else {
-          (cls.getName.endsWith("$"), publicConstructorCount == 0) match{
-            case (true, true) => matchFingerprints(cl, cls, fingerprints, isModule = true)
-            case (false, false) => matchFingerprints(cl, cls, fingerprints, isModule = false)
-            case _ => None
+          if (Modifier.isAbstract(cls.getModifiers) || cls.isInterface || publicConstructorCount > 1) {
+            None
+          } else {
+            (cls.getName.endsWith("$"), publicConstructorCount == 0) match {
+              case (true, true) =>
+                matchFingerprints(cl, cls, fingerprints, isModule = true)
+              case (false, false) =>
+                matchFingerprints(cl, cls, fingerprints, isModule = false)
+              case _ => None
+            }
           }
         }
-      }
     }
 
     testClasses
   }
-  def matchFingerprints(cl: ClassLoader, cls: Class[_], fingerprints: Array[Fingerprint], isModule: Boolean) = {
-    fingerprints.find {
-      case f: SubclassFingerprint =>
-        f.isModule == isModule &&
-        cl.loadClass(f.superclassName()).isAssignableFrom(cls)
+  def matchFingerprints(cl: ClassLoader,
+                        cls: Class[_],
+                        fingerprints: Array[Fingerprint],
+                        isModule: Boolean) = {
+    fingerprints
+      .find {
+        case f: SubclassFingerprint =>
+          f.isModule == isModule &&
+            cl.loadClass(f.superclassName()).isAssignableFrom(cls)
 
-      case f: AnnotatedFingerprint =>
-        val annotationCls = cl.loadClass(f.annotationName()).asInstanceOf[Class[Annotation]]
-        f.isModule == isModule &&
-        (
-          cls.isAnnotationPresent(annotationCls) ||
-          cls.getDeclaredMethods.exists(_.isAnnotationPresent(annotationCls))
-        )
+        case f: AnnotatedFingerprint =>
+          val annotationCls =
+            cl.loadClass(f.annotationName()).asInstanceOf[Class[Annotation]]
+          f.isModule == isModule &&
+          (
+            cls.isAnnotationPresent(annotationCls) ||
+            cls.getDeclaredMethods.exists(_.isAnnotationPresent(annotationCls))
+          )
 
-    }.map { f => (cls, f) }
+      }
+      .map { f =>
+        (cls, f)
+      }
   }
 
 }

--- a/scalalib/src/mill/scalalib/MiscModule.scala
+++ b/scalalib/src/mill/scalalib/MiscModule.scala
@@ -6,97 +6,105 @@ import mill.define.Cross.Resolver
 import mill.define.{Cross, Task}
 import mill.eval.{PathRef, Result}
 import mill.util.Loose.Agg
-object CrossModuleBase{
+object CrossModuleBase {
   def scalaVersionPaths(scalaVersion: String, f: String => Path) = {
-    for(segments <- scalaVersion.split('.').inits.filter(_.nonEmpty))
-    yield PathRef(f(segments.mkString(".")))
+    for (segments <- scalaVersion.split('.').inits.filter(_.nonEmpty))
+      yield PathRef(f(segments.mkString(".")))
   }
 }
 trait CrossModuleBase extends ScalaModule {
   def crossScalaVersion: String
-  def scalaVersion = T{ crossScalaVersion }
+  def scalaVersion = T { crossScalaVersion }
 
   override def millSourcePath = super.millSourcePath / ammonite.ops.up
-  implicit def crossSbtModuleResolver: Resolver[CrossModuleBase] = new Resolver[CrossModuleBase]{
-    def resolve[V <: CrossModuleBase](c: Cross[V]): V = {
-      crossScalaVersion.split('.')
-        .inits
-        .takeWhile(_.length > 1)
-        .flatMap( prefix =>
-          c.items.map(_._2).find(_.crossScalaVersion.split('.').startsWith(prefix))
-        )
-        .collectFirst{case x => x}
-        .getOrElse(
-          throw new Exception(
-            s"Unable to find compatible cross version between $crossScalaVersion and "+
-              c.items.map(_._2.crossScalaVersion).mkString(",")
+  implicit def crossSbtModuleResolver: Resolver[CrossModuleBase] =
+    new Resolver[CrossModuleBase] {
+      def resolve[V <: CrossModuleBase](c: Cross[V]): V = {
+        crossScalaVersion
+          .split('.')
+          .inits
+          .takeWhile(_.length > 1)
+          .flatMap(
+            prefix =>
+              c.items
+                .map(_._2)
+                .find(_.crossScalaVersion.split('.').startsWith(prefix)))
+          .collectFirst { case x => x }
+          .getOrElse(
+            throw new Exception(
+              s"Unable to find compatible cross version between $crossScalaVersion and " +
+                c.items.map(_._2.crossScalaVersion).mkString(",")
+            )
           )
-        )
+      }
     }
-  }
 }
 
-trait CrossScalaModule extends ScalaModule with CrossModuleBase{ outer =>
-    override def sources = T.sources{
+trait CrossScalaModule extends ScalaModule with CrossModuleBase { outer =>
+  override def sources = T.sources {
     super.sources() ++
-    CrossModuleBase.scalaVersionPaths(crossScalaVersion, s => millSourcePath / s"src-$s" )
+      CrossModuleBase.scalaVersionPaths(crossScalaVersion,
+                                        s => millSourcePath / s"src-$s")
   }
 
   trait Tests extends super.Tests {
-    override def sources = T.sources{
+    override def sources = T.sources {
       super.sources() ++
-      CrossModuleBase.scalaVersionPaths(crossScalaVersion, s => millSourcePath / s"src-$s" )
+        CrossModuleBase.scalaVersionPaths(crossScalaVersion,
+                                          s => millSourcePath / s"src-$s")
     }
   }
 }
 
-trait MavenTests extends TestModule{
+trait MavenTests extends TestModule {
   override def sources = T.sources(
     millSourcePath / 'src / 'test / 'scala,
     millSourcePath / 'src / 'test / 'java
   )
-  override def resources = T.sources{ millSourcePath / 'src / 'test / 'resources }
+  override def resources = T.sources {
+    millSourcePath / 'src / 'test / 'resources
+  }
 }
-trait MavenModule extends JavaModule{outer =>
+trait MavenModule extends JavaModule { outer =>
 
   override def sources = T.sources(
     millSourcePath / 'src / 'main / 'scala,
     millSourcePath / 'src / 'main / 'java
   )
-  override def resources = T.sources{ millSourcePath / 'src / 'main / 'resources }
+  override def resources = T.sources {
+    millSourcePath / 'src / 'main / 'resources
+  }
   trait Tests extends super.Tests with MavenTests {
     override def millSourcePath = outer.millSourcePath
     override def intellijModulePath = outer.millSourcePath / 'src / 'test
   }
 }
 
-trait SbtModule extends MavenModule with ScalaModule{ outer =>
+trait SbtModule extends MavenModule with ScalaModule { outer =>
   trait Tests extends super.Tests with MavenTests {
     override def millSourcePath = outer.millSourcePath
     override def intellijModulePath = outer.millSourcePath / 'src / 'test
   }
 }
 
-trait CrossSbtModule extends SbtModule with CrossModuleBase{ outer =>
+trait CrossSbtModule extends SbtModule with CrossModuleBase { outer =>
 
-  override def sources = T.sources{
+  override def sources = T.sources {
     super.sources() ++
-    CrossModuleBase.scalaVersionPaths(
-      crossScalaVersion,
-      s => millSourcePath / 'src / 'main / s"scala-$s"
-    )
+      CrossModuleBase.scalaVersionPaths(
+        crossScalaVersion,
+        s => millSourcePath / 'src / 'main / s"scala-$s"
+      )
 
   }
   trait Tests extends super.Tests {
     override def millSourcePath = outer.millSourcePath
-    override def sources = T.sources{
+    override def sources = T.sources {
       super.sources() ++
-      CrossModuleBase.scalaVersionPaths(
-        crossScalaVersion,
-        s => millSourcePath / 'src / 'test / s"scala-$s"
-      )
+        CrossModuleBase.scalaVersionPaths(
+          crossScalaVersion,
+          s => millSourcePath / 'src / 'test / s"scala-$s"
+        )
     }
   }
 }
-
-

--- a/scalalib/src/mill/scalalib/ScalaWorkerApi.scala
+++ b/scalalib/src/mill/scalalib/ScalaWorkerApi.scala
@@ -1,6 +1,5 @@
 package mill.scalalib
 
-
 import ammonite.ops.Path
 import coursier.Cache
 import coursier.maven.MavenRepository
@@ -11,36 +10,44 @@ import mill.scalalib.Lib.resolveDependencies
 import mill.util.Loose
 import mill.util.JsonFormatters._
 
-object ScalaWorkerModule extends mill.define.ExternalModule with ScalaWorkerModule{
+object ScalaWorkerModule
+    extends mill.define.ExternalModule
+    with ScalaWorkerModule {
   lazy val millDiscover = Discover[this.type]
 }
-trait ScalaWorkerModule extends mill.Module{
+trait ScalaWorkerModule extends mill.Module {
   def repositories = Seq(
     Cache.ivy2Local,
     MavenRepository("https://repo1.maven.org/maven2"),
     MavenRepository("https://oss.sonatype.org/content/repositories/releases")
   )
 
-  def classpath = T{
-    mill.modules.Util.millProjectModule("MILL_SCALA_WORKER", "mill-scalalib-worker", repositories)
+  def classpath = T {
+    mill.modules.Util.millProjectModule("MILL_SCALA_WORKER",
+                                        "mill-scalalib-worker",
+                                        repositories)
   }
 
-  def scalalibClasspath = T{
-    mill.modules.Util.millProjectModule("MILL_SCALA_LIB", "mill-scalalib", repositories)
+  def scalalibClasspath = T {
+    mill.modules.Util
+      .millProjectModule("MILL_SCALA_LIB", "mill-scalalib", repositories)
   }
 
-  def worker: Worker[ScalaWorkerApi] = T.worker{
+  def worker: Worker[ScalaWorkerApi] = T.worker {
     val cl = mill.util.ClassLoader.create(
       classpath().map(_.path.toNIO.toUri.toURL).toVector,
       getClass.getClassLoader
     )
     val cls = cl.loadClass("mill.scalalib.worker.ScalaWorker")
-    val instance = cls.getConstructor(classOf[mill.util.Ctx], classOf[Array[String]])
-      .newInstance(T.ctx(), compilerInterfaceClasspath().map(_.path.toString).toArray[String])
+    val instance = cls
+      .getConstructor(classOf[mill.util.Ctx], classOf[Array[String]])
+      .newInstance(
+        T.ctx(),
+        compilerInterfaceClasspath().map(_.path.toString).toArray[String])
     instance.asInstanceOf[ScalaWorkerApi]
   }
 
-  def compilerInterfaceClasspath = T{
+  def compilerInterfaceClasspath = T {
     resolveDependencies(
       repositories,
       Lib.depToDependency(_, "2.12.4", ""),
@@ -60,10 +67,9 @@ trait ScalaWorkerApi {
                    scalacOptions: Seq[String],
                    scalacPluginClasspath: Agg[Path],
                    javacOptions: Seq[String],
-                   upstreamCompileOutput: Seq[CompilationResult])
-                  (implicit ctx: mill.util.Ctx): mill.eval.Result[CompilationResult]
+                   upstreamCompileOutput: Seq[CompilationResult])(
+      implicit ctx: mill.util.Ctx): mill.eval.Result[CompilationResult]
 
-
-  def discoverMainClasses(compilationResult: CompilationResult)
-                         (implicit ctx: mill.util.Ctx): Seq[String]
+  def discoverMainClasses(compilationResult: CompilationResult)(
+      implicit ctx: mill.util.Ctx): Seq[String]
 }

--- a/scalalib/src/mill/scalalib/TestRunner.scala
+++ b/scalalib/src/mill/scalalib/TestRunner.scala
@@ -11,9 +11,8 @@ import sbt.testing._
 import scala.collection.mutable
 object TestRunner {
 
-
   def main(args: Array[String]): Unit = {
-    try{
+    try {
       var i = 0
       def readArray() = {
         val count = args(i).toInt
@@ -31,7 +30,7 @@ object TestRunner {
       val ctx = new Ctx.Log with Ctx.Home {
         val log = PrintLogger(
           colored == "true",
-          if(colored == "true") Colors.Default
+          if (colored == "true") Colors.Default
           else Colors.BlackWhite,
           System.out,
           System.err,
@@ -52,9 +51,10 @@ object TestRunner {
       // that flag causes writing the results to disk to fail
       Thread.interrupted()
       ammonite.ops.write(Path(outputPath), upickle.default.write(result))
-    }catch{case e: Throwable =>
-      println(e)
-      e.printStackTrace()
+    } catch {
+      case e: Throwable =>
+        println(e)
+        e.printStackTrace()
     }
     // Tests are over, kill the JVM whether or not anyone's threads are still running
     // Always return 0, even if tests fail. The caller can pick up the detailed test
@@ -65,73 +65,87 @@ object TestRunner {
   def runTests(frameworkInstances: ClassLoader => Seq[sbt.testing.Framework],
                entireClasspath: Agg[Path],
                testClassfilePath: Agg[Path],
-               args: Seq[String])
-              (implicit ctx: Ctx.Log with Ctx.Home): (String, Seq[mill.scalalib.TestRunner.Result]) = {
-    Jvm.inprocess(entireClasspath, classLoaderOverrideSbtTesting = true, isolated = true, cl => {
-      val frameworks = frameworkInstances(cl)
+               args: Seq[String])(implicit ctx: Ctx.Log with Ctx.Home)
+    : (String, Seq[mill.scalalib.TestRunner.Result]) = {
+    Jvm.inprocess(
+      entireClasspath,
+      classLoaderOverrideSbtTesting = true,
+      isolated = true,
+      cl => {
+        val frameworks = frameworkInstances(cl)
 
-      val events = mutable.Buffer.empty[Event]
+        val events = mutable.Buffer.empty[Event]
 
-      val doneMessages = frameworks.map{ framework =>
-        val runner = framework.runner(args.toArray, args.toArray, cl)
+        val doneMessages = frameworks.map {
+          framework =>
+            val runner = framework.runner(args.toArray, args.toArray, cl)
 
-        val testClasses = discoverTests(cl, framework, testClassfilePath)
+            val testClasses = discoverTests(cl, framework, testClassfilePath)
 
-        val tasks = runner.tasks(
-          for ((cls, fingerprint) <- testClasses.toArray)
-            yield new TaskDef(cls.getName.stripSuffix("$"), fingerprint, true, Array(new SuiteSelector))
-        )
+            val tasks = runner.tasks(
+              for ((cls, fingerprint) <- testClasses.toArray)
+                yield
+                  new TaskDef(cls.getName.stripSuffix("$"),
+                              fingerprint,
+                              true,
+                              Array(new SuiteSelector))
+            )
 
-        val taskQueue = tasks.to[mutable.Queue]
-        while (taskQueue.nonEmpty){
-          val next = taskQueue.dequeue().execute(
-            new EventHandler {
-              def handle(event: Event) = events.append(event)
-            },
-            Array(
-              new Logger {
-                def debug(msg: String) = ctx.log.outputStream.println(msg)
+            val taskQueue = tasks.to[mutable.Queue]
+            while (taskQueue.nonEmpty) {
+              val next = taskQueue
+                .dequeue()
+                .execute(
+                  new EventHandler {
+                    def handle(event: Event) = events.append(event)
+                  },
+                  Array(new Logger {
+                    def debug(msg: String) = ctx.log.outputStream.println(msg)
 
-                def error(msg: String) = ctx.log.outputStream.println(msg)
+                    def error(msg: String) = ctx.log.outputStream.println(msg)
 
-                def ansiCodesSupported() = true
+                    def ansiCodesSupported() = true
 
-                def warn(msg: String) = ctx.log.outputStream.println(msg)
+                    def warn(msg: String) = ctx.log.outputStream.println(msg)
 
-                def trace(t: Throwable) = t.printStackTrace(ctx.log.outputStream)
+                    def trace(t: Throwable) =
+                      t.printStackTrace(ctx.log.outputStream)
 
-                def info(msg: String) = ctx.log.outputStream.println(msg)
-              })
-          )
-          taskQueue.enqueue(next:_*)
+                    def info(msg: String) = ctx.log.outputStream.println(msg)
+                  })
+                )
+              taskQueue.enqueue(next: _*)
+            }
+            runner.done()
         }
-        runner.done()
-      }
 
-      val results = for(e <- events) yield {
-        val ex = if (e.throwable().isDefined) Some(e.throwable().get) else None
-        mill.scalalib.TestRunner.Result(
-          e.fullyQualifiedName(),
-          e.selector() match{
-            case s: NestedSuiteSelector => s.suiteId()
-            case s: NestedTestSelector => s.suiteId() + "." + s.testName()
-            case s: SuiteSelector => s.toString
-            case s: TestSelector => s.testName()
-            case s: TestWildcardSelector => s.testWildcard()
-          },
-          e.duration(),
-          e.status().toString,
-          ex.map(_.getClass.getName),
-          ex.map(_.getMessage),
-          ex.map(_.getStackTrace)
-        )
-      }
+        val results = for (e <- events) yield {
+          val ex =
+            if (e.throwable().isDefined) Some(e.throwable().get) else None
+          mill.scalalib.TestRunner.Result(
+            e.fullyQualifiedName(),
+            e.selector() match {
+              case s: NestedSuiteSelector  => s.suiteId()
+              case s: NestedTestSelector   => s.suiteId() + "." + s.testName()
+              case s: SuiteSelector        => s.toString
+              case s: TestSelector         => s.testName()
+              case s: TestWildcardSelector => s.testWildcard()
+            },
+            e.duration(),
+            e.status().toString,
+            ex.map(_.getClass.getName),
+            ex.map(_.getMessage),
+            ex.map(_.getStackTrace)
+          )
+        }
 
-      (doneMessages.mkString("\n"), results)
-    })
+        (doneMessages.mkString("\n"), results)
+      }
+    )
   }
 
-  def frameworks(frameworkNames: Seq[String])(cl: ClassLoader): Seq[sbt.testing.Framework] = {
+  def frameworks(frameworkNames: Seq[String])(
+      cl: ClassLoader): Seq[sbt.testing.Framework] = {
     frameworkNames.map { name =>
       cl.loadClass(name).newInstance().asInstanceOf[sbt.testing.Framework]
     }
@@ -145,7 +159,8 @@ object TestRunner {
                     exceptionMsg: Option[String] = None,
                     exceptionTrace: Option[Seq[StackTraceElement]] = None)
 
-  object Result{
-    implicit def resultRW: upickle.default.ReadWriter[Result] = upickle.default.macroRW[Result]
+  object Result {
+    implicit def resultRW: upickle.default.ReadWriter[Result] =
+      upickle.default.macroRW[Result]
   }
 }

--- a/scalalib/src/mill/scalalib/package.scala
+++ b/scalalib/src/mill/scalalib/package.scala
@@ -1,11 +1,13 @@
 package mill
 
 package object scalalib {
-  implicit class DepSyntax(ctx: StringContext){
-    def ivy(args: Any*) = Dep.parse{
+  implicit class DepSyntax(ctx: StringContext) {
+    def ivy(args: Any*) = Dep.parse {
       (
-      ctx.parts.take(args.length).zip(args).flatMap{case (p, a) => Seq(p, a)} ++
-        ctx.parts.drop(args.length)
+        ctx.parts.take(args.length).zip(args).flatMap {
+          case (p, a) => Seq(p, a)
+        } ++
+          ctx.parts.drop(args.length)
       ).mkString
     }
   }

--- a/scalalib/src/mill/scalalib/publish/JsonFormatters.scala
+++ b/scalalib/src/mill/scalalib/publish/JsonFormatters.scala
@@ -6,6 +6,7 @@ trait JsonFormatters {
   implicit lazy val artifactFormat: RW[Artifact] = upickle.default.macroRW
   implicit lazy val developerFormat: RW[Developer] = upickle.default.macroRW
   implicit lazy val licenseFormat: RW[License] = upickle.default.macroRW
-  implicit lazy val versionControlFormat: RW[VersionControl] = upickle.default.macroRW
+  implicit lazy val versionControlFormat: RW[VersionControl] =
+    upickle.default.macroRW
   implicit lazy val pomSettingsFormat: RW[PomSettings] = upickle.default.macroRW
 }

--- a/scalalib/src/mill/scalalib/publish/Licence.scala
+++ b/scalalib/src/mill/scalalib/publish/Licence.scala
@@ -1,12 +1,12 @@
 package mill.scalalib.publish
 
 case class License(
-  id: String,
-  name: String,
-  url: String,
-  isOsiApproved: Boolean,
-  isFsfLibre: Boolean,
-  distribution: String
+    id: String,
+    name: String,
+    url: String,
+    isOsiApproved: Boolean,
+    isFsfLibre: Boolean,
+    distribution: String
 )
 
 object License {
@@ -25,7 +25,7 @@ object License {
     "io.circe" %% "circe-parser"
   ).map(_ % circeVersion)
 
-  import io.circe._, io.circe.generic.auto._, io.circe.parser._, io.circe.syntax._ 
+  import io.circe._, io.circe.generic.auto._, io.circe.parser._, io.circe.syntax._
   import java.nio.file._
   import System.{lineSeparator => nl}
   case class License(
@@ -67,379 +67,797 @@ object License {
 
   val output = licences.map(license => license.syntax(identPadding, namePadding)).mkString(nl)
   Files.write(Paths.get("out.scala"), output.getBytes("utf-8"))
-  */
-  val `0BSD`                                 = spdx("BSD Zero Clause License",                                          "0BSD",                                 false, false)
-  val AAL                                    = spdx("Attribution Assurance License",                                    "AAL",                                  true,  false)
-  val Abstyles                               = spdx("Abstyles License",                                                 "Abstyles",                             false, false)
-  val `Adobe-2006`                           = spdx("Adobe Systems Incorporated Source Code License Agreement",         "Adobe-2006",                           false, false)
-  val `Adobe-Glyph`                          = spdx("Adobe Glyph List License",                                         "Adobe-Glyph",                          false, false)
-  val ADSL                                   = spdx("Amazon Digital Services License",                                  "ADSL",                                 false, false)
-  val `AFL-1.1`                              = spdx("Academic Free License v1.1",                                       "AFL-1.1",                              true,  true)
-  val `AFL-1.2`                              = spdx("Academic Free License v1.2",                                       "AFL-1.2",                              true,  true)
-  val `AFL-2.0`                              = spdx("Academic Free License v2.0",                                       "AFL-2.0",                              true,  true)
-  val `AFL-2.1`                              = spdx("Academic Free License v2.1",                                       "AFL-2.1",                              true,  true)
-  val `AFL-3.0`                              = spdx("Academic Free License v3.0",                                       "AFL-3.0",                              true,  true)
-  val Afmparse                               = spdx("Afmparse License",                                                 "Afmparse",                             false, false)
-  val `AGPL-1.0`                             = spdx("Affero General Public License v1.0",                               "AGPL-1.0",                             false, true)
-  val `AGPL-3.0-only`                        = spdx("GNU Affero General Public License v3.0 only",                      "AGPL-3.0-only",                        true,  false)
-  val `AGPL-3.0-or-later`                    = spdx("GNU Affero General Public License v3.0 or later",                  "AGPL-3.0-or-later",                    true,  false)
-  val Aladdin                                = spdx("Aladdin Free Public License",                                      "Aladdin",                              false, false)
-  val AMDPLPA                                = spdx("AMD's plpa_map.c License",                                         "AMDPLPA",                              false, false)
-  val AML                                    = spdx("Apple MIT License",                                                "AML",                                  false, false)
-  val AMPAS                                  = spdx("Academy of Motion Picture Arts and Sciences BSD",                  "AMPAS",                                false, false)
-  val `ANTLR-PD`                             = spdx("ANTLR Software Rights Notice",                                     "ANTLR-PD",                             false, false)
-  val `Apache-1.0`                           = spdx("Apache License 1.0",                                               "Apache-1.0",                           false, true)
-  val `Apache-1.1`                           = spdx("Apache License 1.1",                                               "Apache-1.1",                           true,  true)
-  val `Apache-2.0`                           = spdx("Apache License 2.0",                                               "Apache-2.0",                           true,  true)
-  val APAFML                                 = spdx("Adobe Postscript AFM License",                                     "APAFML",                               false, false)
-  val `APL-1.0`                              = spdx("Adaptive Public License 1.0",                                      "APL-1.0",                              true,  false)
-  val `APSL-1.0`                             = spdx("Apple Public Source License 1.0",                                  "APSL-1.0",                             true,  false)
-  val `APSL-1.1`                             = spdx("Apple Public Source License 1.1",                                  "APSL-1.1",                             true,  false)
-  val `APSL-1.2`                             = spdx("Apple Public Source License 1.2",                                  "APSL-1.2",                             true,  false)
-  val `APSL-2.0`                             = spdx("Apple Public Source License 2.0",                                  "APSL-2.0",                             true,  true)
-  val `Artistic-1.0-cl8`                     = spdx("Artistic License 1.0 w/clause 8",                                  "Artistic-1.0-cl8",                     true,  false)
-  val `Artistic-1.0-Perl`                    = spdx("Artistic License 1.0 (Perl)",                                      "Artistic-1.0-Perl",                    true,  false)
-  val `Artistic-1.0`                         = spdx("Artistic License 1.0",                                             "Artistic-1.0",                         true,  false)
-  val `Artistic-2.0`                         = spdx("Artistic License 2.0",                                             "Artistic-2.0",                         true,  true)
-  val Bahyph                                 = spdx("Bahyph License",                                                   "Bahyph",                               false, false)
-  val Barr                                   = spdx("Barr License",                                                     "Barr",                                 false, false)
-  val Beerware                               = spdx("Beerware License",                                                 "Beerware",                             false, false)
-  val `BitTorrent-1.0`                       = spdx("BitTorrent Open Source License v1.0",                              "BitTorrent-1.0",                       false, false)
-  val `BitTorrent-1.1`                       = spdx("BitTorrent Open Source License v1.1",                              "BitTorrent-1.1",                       false, true)
-  val Borceux                                = spdx("Borceux license",                                                  "Borceux",                              false, false)
-  val `BSD-1-Clause`                         = spdx("BSD 1-Clause License",                                             "BSD-1-Clause",                         false, false)
-  val `BSD-2-Clause-FreeBSD`                 = spdx("BSD 2-Clause FreeBSD License",                                     "BSD-2-Clause-FreeBSD",                 false, true)
-  val `BSD-2-Clause-NetBSD`                  = spdx("BSD 2-Clause NetBSD License",                                      "BSD-2-Clause-NetBSD",                  false, false)
-  val `BSD-2-Clause-Patent`                  = spdx("BSD-2-Clause Plus Patent License",                                 "BSD-2-Clause-Patent",                  true,  false)
-  val `BSD-2-Clause`                         = spdx("BSD 2-Clause \"Simplified\" License",                              "BSD-2-Clause",                         true,  false)
-  val `BSD-3-Clause-Attribution`             = spdx("BSD with attribution",                                             "BSD-3-Clause-Attribution",             false, false)
-  val `BSD-3-Clause-Clear`                   = spdx("BSD 3-Clause Clear License",                                       "BSD-3-Clause-Clear",                   false, true)
-  val `BSD-3-Clause-LBNL`                    = spdx("Lawrence Berkeley National Labs BSD variant license",              "BSD-3-Clause-LBNL",                    false, false)
-  val `BSD-3-Clause-No-Nuclear-License-2014` = spdx("BSD 3-Clause No Nuclear License 2014",                             "BSD-3-Clause-No-Nuclear-License-2014", false, false)
-  val `BSD-3-Clause-No-Nuclear-License`      = spdx("BSD 3-Clause No Nuclear License",                                  "BSD-3-Clause-No-Nuclear-License",      false, false)
-  val `BSD-3-Clause-No-Nuclear-Warranty`     = spdx("BSD 3-Clause No Nuclear Warranty",                                 "BSD-3-Clause-No-Nuclear-Warranty",     false, false)
-  val `BSD-3-Clause`                         = spdx("BSD 3-Clause \"New\" or \"Revised\" License",                      "BSD-3-Clause",                         true,  true)
-  val `BSD-4-Clause-UC`                      = spdx("BSD-4-Clause (University of California-Specific)",                 "BSD-4-Clause-UC",                      false, false)
-  val `BSD-4-Clause`                         = spdx("BSD 4-Clause \"Original\" or \"Old\" License",                     "BSD-4-Clause",                         false, true)
-  val `BSD-Protection`                       = spdx("BSD Protection License",                                           "BSD-Protection",                       false, false)
-  val `BSD-Source-Code`                      = spdx("BSD Source Code Attribution",                                      "BSD-Source-Code",                      false, false)
-  val `BSL-1.0`                              = spdx("Boost Software License 1.0",                                       "BSL-1.0",                              true,  true)
-  val `bzip2-1.0.5`                          = spdx("bzip2 and libbzip2 License v1.0.5",                                "bzip2-1.0.5",                          false, false)
-  val `bzip2-1.0.6`                          = spdx("bzip2 and libbzip2 License v1.0.6",                                "bzip2-1.0.6",                          false, false)
-  val Caldera                                = spdx("Caldera License",                                                  "Caldera",                              false, false)
-  val `CATOSL-1.1`                           = spdx("Computer Associates Trusted Open Source License 1.1",              "CATOSL-1.1",                           true,  false)
-  val `CC-BY-1.0`                            = spdx("Creative Commons Attribution 1.0",                                 "CC-BY-1.0",                            false, false)
-  val `CC-BY-2.0`                            = spdx("Creative Commons Attribution 2.0",                                 "CC-BY-2.0",                            false, false)
-  val `CC-BY-2.5`                            = spdx("Creative Commons Attribution 2.5",                                 "CC-BY-2.5",                            false, false)
-  val `CC-BY-3.0`                            = spdx("Creative Commons Attribution 3.0",                                 "CC-BY-3.0",                            false, false)
-  val `CC-BY-4.0`                            = spdx("Creative Commons Attribution 4.0",                                 "CC-BY-4.0",                            false, true)
-  val `CC-BY-NC-1.0`                         = spdx("Creative Commons Attribution Non Commercial 1.0",                  "CC-BY-NC-1.0",                         false, false)
-  val `CC-BY-NC-2.0`                         = spdx("Creative Commons Attribution Non Commercial 2.0",                  "CC-BY-NC-2.0",                         false, false)
-  val `CC-BY-NC-2.5`                         = spdx("Creative Commons Attribution Non Commercial 2.5",                  "CC-BY-NC-2.5",                         false, false)
-  val `CC-BY-NC-3.0`                         = spdx("Creative Commons Attribution Non Commercial 3.0",                  "CC-BY-NC-3.0",                         false, false)
-  val `CC-BY-NC-4.0`                         = spdx("Creative Commons Attribution Non Commercial 4.0",                  "CC-BY-NC-4.0",                         false, false)
-  val `CC-BY-NC-ND-1.0`                      = spdx("Creative Commons Attribution Non Commercial No Derivatives 1.0",   "CC-BY-NC-ND-1.0",                      false, false)
-  val `CC-BY-NC-ND-2.0`                      = spdx("Creative Commons Attribution Non Commercial No Derivatives 2.0",   "CC-BY-NC-ND-2.0",                      false, false)
-  val `CC-BY-NC-ND-2.5`                      = spdx("Creative Commons Attribution Non Commercial No Derivatives 2.5",   "CC-BY-NC-ND-2.5",                      false, false)
-  val `CC-BY-NC-ND-3.0`                      = spdx("Creative Commons Attribution Non Commercial No Derivatives 3.0",   "CC-BY-NC-ND-3.0",                      false, false)
-  val `CC-BY-NC-ND-4.0`                      = spdx("Creative Commons Attribution Non Commercial No Derivatives 4.0",   "CC-BY-NC-ND-4.0",                      false, false)
-  val `CC-BY-NC-SA-1.0`                      = spdx("Creative Commons Attribution Non Commercial Share Alike 1.0",      "CC-BY-NC-SA-1.0",                      false, false)
-  val `CC-BY-NC-SA-2.0`                      = spdx("Creative Commons Attribution Non Commercial Share Alike 2.0",      "CC-BY-NC-SA-2.0",                      false, false)
-  val `CC-BY-NC-SA-2.5`                      = spdx("Creative Commons Attribution Non Commercial Share Alike 2.5",      "CC-BY-NC-SA-2.5",                      false, false)
-  val `CC-BY-NC-SA-3.0`                      = spdx("Creative Commons Attribution Non Commercial Share Alike 3.0",      "CC-BY-NC-SA-3.0",                      false, false)
-  val `CC-BY-NC-SA-4.0`                      = spdx("Creative Commons Attribution Non Commercial Share Alike 4.0",      "CC-BY-NC-SA-4.0",                      false, false)
-  val `CC-BY-ND-1.0`                         = spdx("Creative Commons Attribution No Derivatives 1.0",                  "CC-BY-ND-1.0",                         false, false)
-  val `CC-BY-ND-2.0`                         = spdx("Creative Commons Attribution No Derivatives 2.0",                  "CC-BY-ND-2.0",                         false, false)
-  val `CC-BY-ND-2.5`                         = spdx("Creative Commons Attribution No Derivatives 2.5",                  "CC-BY-ND-2.5",                         false, false)
-  val `CC-BY-ND-3.0`                         = spdx("Creative Commons Attribution No Derivatives 3.0",                  "CC-BY-ND-3.0",                         false, false)
-  val `CC-BY-ND-4.0`                         = spdx("Creative Commons Attribution No Derivatives 4.0",                  "CC-BY-ND-4.0",                         false, false)
-  val `CC-BY-SA-1.0`                         = spdx("Creative Commons Attribution Share Alike 1.0",                     "CC-BY-SA-1.0",                         false, false)
-  val `CC-BY-SA-2.0`                         = spdx("Creative Commons Attribution Share Alike 2.0",                     "CC-BY-SA-2.0",                         false, false)
-  val `CC-BY-SA-2.5`                         = spdx("Creative Commons Attribution Share Alike 2.5",                     "CC-BY-SA-2.5",                         false, false)
-  val `CC-BY-SA-3.0`                         = spdx("Creative Commons Attribution Share Alike 3.0",                     "CC-BY-SA-3.0",                         false, false)
-  val `CC-BY-SA-4.0`                         = spdx("Creative Commons Attribution Share Alike 4.0",                     "CC-BY-SA-4.0",                         false, true)
-  val `CC0-1.0`                              = spdx("Creative Commons Zero v1.0 Universal",                             "CC0-1.0",                              false, true)
-  val `CDDL-1.0`                             = spdx("Common Development and Distribution License 1.0",                  "CDDL-1.0",                             true,  true)
-  val `CDDL-1.1`                             = spdx("Common Development and Distribution License 1.1",                  "CDDL-1.1",                             false, false)
-  val `CDLA-Permissive-1.0`                  = spdx("Community Data License Agreement Permissive 1.0",                  "CDLA-Permissive-1.0",                  false, false)
-  val `CDLA-Sharing-1.0`                     = spdx("Community Data License Agreement Sharing 1.0",                     "CDLA-Sharing-1.0",                     false, false)
-  val `CECILL-1.0`                           = spdx("CeCILL Free Software License Agreement v1.0",                      "CECILL-1.0",                           false, false)
-  val `CECILL-1.1`                           = spdx("CeCILL Free Software License Agreement v1.1",                      "CECILL-1.1",                           false, false)
-  val `CECILL-2.0`                           = spdx("CeCILL Free Software License Agreement v2.0",                      "CECILL-2.0",                           false, true)
-  val `CECILL-2.1`                           = spdx("CeCILL Free Software License Agreement v2.1",                      "CECILL-2.1",                           true,  false)
-  val `CECILL-B`                             = spdx("CeCILL-B Free Software License Agreement",                         "CECILL-B",                             false, true)
-  val `CECILL-C`                             = spdx("CeCILL-C Free Software License Agreement",                         "CECILL-C",                             false, true)
-  val ClArtistic                             = spdx("Clarified Artistic License",                                       "ClArtistic",                           false, true)
-  val `CNRI-Jython`                          = spdx("CNRI Jython License",                                              "CNRI-Jython",                          false, false)
-  val `CNRI-Python-GPL-Compatible`           = spdx("CNRI Python Open Source GPL Compatible License Agreement",         "CNRI-Python-GPL-Compatible",           false, false)
-  val `CNRI-Python`                          = spdx("CNRI Python License",                                              "CNRI-Python",                          true,  false)
-  val `Condor-1.1`                           = spdx("Condor Public License v1.1",                                       "Condor-1.1",                           false, true)
-  val `CPAL-1.0`                             = spdx("Common Public Attribution License 1.0",                            "CPAL-1.0",                             true,  true)
-  val `CPL-1.0`                              = spdx("Common Public License 1.0",                                        "CPL-1.0",                              true,  true)
-  val `CPOL-1.02`                            = spdx("Code Project Open License 1.02",                                   "CPOL-1.02",                            false, false)
-  val Crossword                              = spdx("Crossword License",                                                "Crossword",                            false, false)
-  val CrystalStacker                         = spdx("CrystalStacker License",                                           "CrystalStacker",                       false, false)
-  val `CUA-OPL-1.0`                          = spdx("CUA Office Public License v1.0",                                   "CUA-OPL-1.0",                          true,  false)
-  val Cube                                   = spdx("Cube License",                                                     "Cube",                                 false, false)
-  val curl                                   = spdx("curl License",                                                     "curl",                                 false, false)
-  val `D-FSL-1.0`                            = spdx("Deutsche Freie Software Lizenz",                                   "D-FSL-1.0",                            false, false)
-  val diffmark                               = spdx("diffmark license",                                                 "diffmark",                             false, false)
-  val DOC                                    = spdx("DOC License",                                                      "DOC",                                  false, false)
-  val Dotseqn                                = spdx("Dotseqn License",                                                  "Dotseqn",                              false, false)
-  val DSDP                                   = spdx("DSDP License",                                                     "DSDP",                                 false, false)
-  val dvipdfm                                = spdx("dvipdfm License",                                                  "dvipdfm",                              false, false)
-  val `ECL-1.0`                              = spdx("Educational Community License v1.0",                               "ECL-1.0",                              true,  false)
-  val `ECL-2.0`                              = spdx("Educational Community License v2.0",                               "ECL-2.0",                              true,  true)
-  val `EFL-1.0`                              = spdx("Eiffel Forum License v1.0",                                        "EFL-1.0",                              true,  false)
-  val `EFL-2.0`                              = spdx("Eiffel Forum License v2.0",                                        "EFL-2.0",                              true,  true)
-  val eGenix                                 = spdx("eGenix.com Public License 1.1.0",                                  "eGenix",                               false, false)
-  val Entessa                                = spdx("Entessa Public License v1.0",                                      "Entessa",                              true,  false)
-  val `EPL-1.0`                              = spdx("Eclipse Public License 1.0",                                       "EPL-1.0",                              true,  true)
-  val `EPL-2.0`                              = spdx("Eclipse Public License 2.0",                                       "EPL-2.0",                              true,  true)
-  val `ErlPL-1.1`                            = spdx("Erlang Public License v1.1",                                       "ErlPL-1.1",                            false, false)
-  val EUDatagrid                             = spdx("EU DataGrid Software License",                                     "EUDatagrid",                           true,  true)
-  val `EUPL-1.0`                             = spdx("European Union Public License 1.0",                                "EUPL-1.0",                             false, false)
-  val `EUPL-1.1`                             = spdx("European Union Public License 1.1",                                "EUPL-1.1",                             true,  true)
-  val `EUPL-1.2`                             = spdx("European Union Public License 1.2",                                "EUPL-1.2",                             true,  false)
-  val Eurosym                                = spdx("Eurosym License",                                                  "Eurosym",                              false, false)
-  val Fair                                   = spdx("Fair License",                                                     "Fair",                                 true,  false)
-  val `Frameworx-1.0`                        = spdx("Frameworx Open License 1.0",                                       "Frameworx-1.0",                        true,  false)
-  val FreeImage                              = spdx("FreeImage Public License v1.0",                                    "FreeImage",                            false, false)
-  val FSFAP                                  = spdx("FSF All Permissive License",                                       "FSFAP",                                false, true)
-  val FSFUL                                  = spdx("FSF Unlimited License",                                            "FSFUL",                                false, false)
-  val FSFULLR                                = spdx("FSF Unlimited License (with License Retention)",                   "FSFULLR",                              false, false)
-  val FTL                                    = spdx("Freetype Project License",                                         "FTL",                                  false, true)
-  val `GFDL-1.1-only`                        = spdx("GNU Free Documentation License v1.1 only",                         "GFDL-1.1-only",                        false, false)
-  val `GFDL-1.1-or-later`                    = spdx("GNU Free Documentation License v1.1 or later",                     "GFDL-1.1-or-later",                    false, false)
-  val `GFDL-1.2-only`                        = spdx("GNU Free Documentation License v1.2 only",                         "GFDL-1.2-only",                        false, false)
-  val `GFDL-1.2-or-later`                    = spdx("GNU Free Documentation License v1.2 or later",                     "GFDL-1.2-or-later",                    false, false)
-  val `GFDL-1.3-only`                        = spdx("GNU Free Documentation License v1.3 only",                         "GFDL-1.3-only",                        false, false)
-  val `GFDL-1.3-or-later`                    = spdx("GNU Free Documentation License v1.3 or later",                     "GFDL-1.3-or-later",                    false, false)
-  val Giftware                               = spdx("Giftware License",                                                 "Giftware",                             false, false)
-  val GL2PS                                  = spdx("GL2PS License",                                                    "GL2PS",                                false, false)
-  val Glide                                  = spdx("3dfx Glide License",                                               "Glide",                                false, false)
-  val Glulxe                                 = spdx("Glulxe License",                                                   "Glulxe",                               false, false)
-  val gnuplot                                = spdx("gnuplot License",                                                  "gnuplot",                              false, true)
-  val `GPL-1.0-only`                         = spdx("GNU General Public License v1.0 only",                             "GPL-1.0-only",                         false, false)
-  val `GPL-1.0-or-later`                     = spdx("GNU General Public License v1.0 or later",                         "GPL-1.0-or-later",                     false, false)
-  val `GPL-2.0-only`                         = spdx("GNU General Public License v2.0 only",                             "GPL-2.0-only",                         true,  false)
-  val `GPL-2.0-or-later`                     = spdx("GNU General Public License v2.0 or later",                         "GPL-2.0-or-later",                     true,  false)
-  val `GPL-3.0-only`                         = spdx("GNU General Public License v3.0 only",                             "GPL-3.0-only",                         true,  false)
-  val `GPL-3.0-or-later`                     = spdx("GNU General Public License v3.0 or later",                         "GPL-3.0-or-later",                     true,  false)
-  val `gSOAP-1.3b`                           = spdx("gSOAP Public License v1.3b",                                       "gSOAP-1.3b",                           false, false)
-  val HaskellReport                          = spdx("Haskell Language Report License",                                  "HaskellReport",                        false, false)
-  val HPND                                   = spdx("Historical Permission Notice and Disclaimer",                      "HPND",                                 true,  true)
-  val `IBM-pibs`                             = spdx("IBM PowerPC Initialization and Boot Software",                     "IBM-pibs",                             false, false)
-  val ICU                                    = spdx("ICU License",                                                      "ICU",                                  false, false)
-  val IJG                                    = spdx("Independent JPEG Group License",                                   "IJG",                                  false, true)
-  val ImageMagick                            = spdx("ImageMagick License",                                              "ImageMagick",                          false, false)
-  val iMatix                                 = spdx("iMatix Standard Function Library Agreement",                       "iMatix",                               false, true)
-  val Imlib2                                 = spdx("Imlib2 License",                                                   "Imlib2",                               false, true)
-  val `Info-ZIP`                             = spdx("Info-ZIP License",                                                 "Info-ZIP",                             false, false)
-  val `Intel-ACPI`                           = spdx("Intel ACPI Software License Agreement",                            "Intel-ACPI",                           false, false)
-  val Intel                                  = spdx("Intel Open Source License",                                        "Intel",                                true,  true)
-  val `Interbase-1.0`                        = spdx("Interbase Public License v1.0",                                    "Interbase-1.0",                        false, false)
-  val IPA                                    = spdx("IPA Font License",                                                 "IPA",                                  true,  true)
-  val `IPL-1.0`                              = spdx("IBM Public License v1.0",                                          "IPL-1.0",                              true,  true)
-  val ISC                                    = spdx("ISC License",                                                      "ISC",                                  true,  true)
-  val `JasPer-2.0`                           = spdx("JasPer License",                                                   "JasPer-2.0",                           false, false)
-  val JSON                                   = spdx("JSON License",                                                     "JSON",                                 false, false)
-  val `LAL-1.2`                              = spdx("Licence Art Libre 1.2",                                            "LAL-1.2",                              false, false)
-  val `LAL-1.3`                              = spdx("Licence Art Libre 1.3",                                            "LAL-1.3",                              false, false)
-  val Latex2e                                = spdx("Latex2e License",                                                  "Latex2e",                              false, false)
-  val Leptonica                              = spdx("Leptonica License",                                                "Leptonica",                            false, false)
-  val `LGPL-2.0-only`                        = spdx("GNU Library General Public License v2 only",                       "LGPL-2.0-only",                        true,  false)
-  val `LGPL-2.0-or-later`                    = spdx("GNU Library General Public License v2 or later",                   "LGPL-2.0-or-later",                    true,  false)
-  val `LGPL-2.1-only`                        = spdx("GNU Lesser General Public License v2.1 only",                      "LGPL-2.1-only",                        true,  false)
-  val `LGPL-2.1-or-later`                    = spdx("GNU Lesser General Public License v2.1 or later",                  "LGPL-2.1-or-later",                    true,  false)
-  val `LGPL-3.0-only`                        = spdx("GNU Lesser General Public License v3.0 only",                      "LGPL-3.0-only",                        true,  false)
-  val `LGPL-3.0-or-later`                    = spdx("GNU Lesser General Public License v3.0 or later",                  "LGPL-3.0-or-later",                    true,  false)
-  val LGPLLR                                 = spdx("Lesser General Public License For Linguistic Resources",           "LGPLLR",                               false, false)
-  val Libpng                                 = spdx("libpng License",                                                   "Libpng",                               false, false)
-  val libtiff                                = spdx("libtiff License",                                                  "libtiff",                              false, false)
-  val `LiLiQ-P-1.1`                          = spdx("Licence Libre du Québec – Permissive version 1.1",                 "LiLiQ-P-1.1",                          true,  false)
-  val `LiLiQ-R-1.1`                          = spdx("Licence Libre du Québec – Réciprocité version 1.1",                "LiLiQ-R-1.1",                          true,  false)
-  val `LiLiQ-Rplus-1.1`                      = spdx("Licence Libre du Québec – Réciprocité forte version 1.1",          "LiLiQ-Rplus-1.1",                      true,  false)
-  val `LPL-1.0`                              = spdx("Lucent Public License Version 1.0",                                "LPL-1.0",                              true,  false)
-  val `LPL-1.02`                             = spdx("Lucent Public License v1.02",                                      "LPL-1.02",                             true,  true)
-  val `LPPL-1.0`                             = spdx("LaTeX Project Public License v1.0",                                "LPPL-1.0",                             false, false)
-  val `LPPL-1.1`                             = spdx("LaTeX Project Public License v1.1",                                "LPPL-1.1",                             false, false)
-  val `LPPL-1.2`                             = spdx("LaTeX Project Public License v1.2",                                "LPPL-1.2",                             false, true)
-  val `LPPL-1.3a`                            = spdx("LaTeX Project Public License v1.3a",                               "LPPL-1.3a",                            false, true)
-  val `LPPL-1.3c`                            = spdx("LaTeX Project Public License v1.3c",                               "LPPL-1.3c",                            true,  false)
-  val MakeIndex                              = spdx("MakeIndex License",                                                "MakeIndex",                            false, false)
-  val MirOS                                  = spdx("MirOS License",                                                    "MirOS",                                true,  false)
-  val `MIT-advertising`                      = spdx("Enlightenment License (e16)",                                      "MIT-advertising",                      false, false)
-  val `MIT-CMU`                              = spdx("CMU License",                                                      "MIT-CMU",                              false, false)
-  val `MIT-enna`                             = spdx("enna License",                                                     "MIT-enna",                             false, false)
-  val `MIT-feh`                              = spdx("feh License",                                                      "MIT-feh",                              false, false)
-  val MIT                                    = spdx("MIT License",                                                      "MIT",                                  true,  true)
-  val MITNFA                                 = spdx("MIT +no-false-attribs license",                                    "MITNFA",                               false, false)
-  val Motosoto                               = spdx("Motosoto License",                                                 "Motosoto",                             true,  false)
-  val mpich2                                 = spdx("mpich2 License",                                                   "mpich2",                               false, false)
-  val `MPL-1.0`                              = spdx("Mozilla Public License 1.0",                                       "MPL-1.0",                              true,  false)
-  val `MPL-1.1`                              = spdx("Mozilla Public License 1.1",                                       "MPL-1.1",                              true,  true)
-  val `MPL-2.0-no-copyleft-exception`        = spdx("Mozilla Public License 2.0 (no copyleft exception)",               "MPL-2.0-no-copyleft-exception",        true,  false)
-  val `MPL-2.0`                              = spdx("Mozilla Public License 2.0",                                       "MPL-2.0",                              true,  true)
-  val `MS-PL`                                = spdx("Microsoft Public License",                                         "MS-PL",                                true,  true)
-  val `MS-RL`                                = spdx("Microsoft Reciprocal License",                                     "MS-RL",                                true,  true)
-  val MTLL                                   = spdx("Matrix Template Library License",                                  "MTLL",                                 false, false)
-  val Multics                                = spdx("Multics License",                                                  "Multics",                              true,  false)
-  val Mup                                    = spdx("Mup License",                                                      "Mup",                                  false, false)
-  val `NASA-1.3`                             = spdx("NASA Open Source Agreement 1.3",                                   "NASA-1.3",                             true,  false)
-  val Naumen                                 = spdx("Naumen Public License",                                            "Naumen",                               true,  false)
-  val `NBPL-1.0`                             = spdx("Net Boolean Public License v1",                                    "NBPL-1.0",                             false, false)
-  val NCSA                                   = spdx("University of Illinois/NCSA Open Source License",                  "NCSA",                                 true,  true)
-  val `Net-SNMP`                             = spdx("Net-SNMP License",                                                 "Net-SNMP",                             false, false)
-  val NetCDF                                 = spdx("NetCDF license",                                                   "NetCDF",                               false, false)
-  val Newsletr                               = spdx("Newsletr License",                                                 "Newsletr",                             false, false)
-  val NGPL                                   = spdx("Nethack General Public License",                                   "NGPL",                                 true,  false)
-  val `NLOD-1.0`                             = spdx("Norwegian Licence for Open Government Data",                       "NLOD-1.0",                             false, false)
-  val NLPL                                   = spdx("No Limit Public License",                                          "NLPL",                                 false, false)
-  val Nokia                                  = spdx("Nokia Open Source License",                                        "Nokia",                                true,  true)
-  val NOSL                                   = spdx("Netizen Open Source License",                                      "NOSL",                                 false, true)
-  val Noweb                                  = spdx("Noweb License",                                                    "Noweb",                                false, false)
-  val `NPL-1.0`                              = spdx("Netscape Public License v1.0",                                     "NPL-1.0",                              false, true)
-  val `NPL-1.1`                              = spdx("Netscape Public License v1.1",                                     "NPL-1.1",                              false, true)
-  val `NPOSL-3.0`                            = spdx("Non-Profit Open Software License 3.0",                             "NPOSL-3.0",                            true,  false)
-  val NRL                                    = spdx("NRL License",                                                      "NRL",                                  false, false)
-  val NTP                                    = spdx("NTP License",                                                      "NTP",                                  true,  false)
-  val `OCCT-PL`                              = spdx("Open CASCADE Technology Public License",                           "OCCT-PL",                              false, false)
-  val `OCLC-2.0`                             = spdx("OCLC Research Public License 2.0",                                 "OCLC-2.0",                             true,  false)
-  val `ODbL-1.0`                             = spdx("ODC Open Database License v1.0",                                   "ODbL-1.0",                             false, true)
-  val `OFL-1.0`                              = spdx("SIL Open Font License 1.0",                                        "OFL-1.0",                              false, false)
-  val `OFL-1.1`                              = spdx("SIL Open Font License 1.1",                                        "OFL-1.1",                              true,  true)
-  val OGTSL                                  = spdx("Open Group Test Suite License",                                    "OGTSL",                                true,  false)
-  val `OLDAP-1.1`                            = spdx("Open LDAP Public License v1.1",                                    "OLDAP-1.1",                            false, false)
-  val `OLDAP-1.2`                            = spdx("Open LDAP Public License v1.2",                                    "OLDAP-1.2",                            false, false)
-  val `OLDAP-1.3`                            = spdx("Open LDAP Public License v1.3",                                    "OLDAP-1.3",                            false, false)
-  val `OLDAP-1.4`                            = spdx("Open LDAP Public License v1.4",                                    "OLDAP-1.4",                            false, false)
-  val `OLDAP-2.0.1`                          = spdx("Open LDAP Public License v2.0.1",                                  "OLDAP-2.0.1",                          false, false)
-  val `OLDAP-2.0`                            = spdx("Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",        "OLDAP-2.0",                            false, false)
-  val `OLDAP-2.1`                            = spdx("Open LDAP Public License v2.1",                                    "OLDAP-2.1",                            false, false)
-  val `OLDAP-2.2.1`                          = spdx("Open LDAP Public License v2.2.1",                                  "OLDAP-2.2.1",                          false, false)
-  val `OLDAP-2.2.2`                          = spdx("Open LDAP Public License 2.2.2",                                   "OLDAP-2.2.2",                          false, false)
-  val `OLDAP-2.2`                            = spdx("Open LDAP Public License v2.2",                                    "OLDAP-2.2",                            false, false)
-  val `OLDAP-2.3`                            = spdx("Open LDAP Public License v2.3",                                    "OLDAP-2.3",                            false, true)
-  val `OLDAP-2.4`                            = spdx("Open LDAP Public License v2.4",                                    "OLDAP-2.4",                            false, false)
-  val `OLDAP-2.5`                            = spdx("Open LDAP Public License v2.5",                                    "OLDAP-2.5",                            false, false)
-  val `OLDAP-2.6`                            = spdx("Open LDAP Public License v2.6",                                    "OLDAP-2.6",                            false, false)
-  val `OLDAP-2.7`                            = spdx("Open LDAP Public License v2.7",                                    "OLDAP-2.7",                            false, true)
-  val `OLDAP-2.8`                            = spdx("Open LDAP Public License v2.8",                                    "OLDAP-2.8",                            false, false)
-  val OML                                    = spdx("Open Market License",                                              "OML",                                  false, false)
-  val OpenSSL                                = spdx("OpenSSL License",                                                  "OpenSSL",                              false, true)
-  val `OPL-1.0`                              = spdx("Open Public License v1.0",                                         "OPL-1.0",                              false, false)
-  val `OSET-PL-2.1`                          = spdx("OSET Public License version 2.1",                                  "OSET-PL-2.1",                          true,  false)
-  val `OSL-1.0`                              = spdx("Open Software License 1.0",                                        "OSL-1.0",                              true,  true)
-  val `OSL-1.1`                              = spdx("Open Software License 1.1",                                        "OSL-1.1",                              false, true)
-  val `OSL-2.0`                              = spdx("Open Software License 2.0",                                        "OSL-2.0",                              true,  true)
-  val `OSL-2.1`                              = spdx("Open Software License 2.1",                                        "OSL-2.1",                              true,  true)
-  val `OSL-3.0`                              = spdx("Open Software License 3.0",                                        "OSL-3.0",                              true,  true)
-  val `PDDL-1.0`                             = spdx("ODC Public Domain Dedication & License 1.0",                       "PDDL-1.0",                             false, false)
-  val `PHP-3.0`                              = spdx("PHP License v3.0",                                                 "PHP-3.0",                              true,  false)
-  val `PHP-3.01`                             = spdx("PHP License v3.01",                                                "PHP-3.01",                             false, true)
-  val Plexus                                 = spdx("Plexus Classworlds License",                                       "Plexus",                               false, false)
-  val PostgreSQL                             = spdx("PostgreSQL License",                                               "PostgreSQL",                           true,  false)
-  val psfrag                                 = spdx("psfrag License",                                                   "psfrag",                               false, false)
-  val psutils                                = spdx("psutils License",                                                  "psutils",                              false, false)
-  val `Python-2.0`                           = spdx("Python License 2.0",                                               "Python-2.0",                           true,  true)
-  val Qhull                                  = spdx("Qhull License",                                                    "Qhull",                                false, false)
-  val `QPL-1.0`                              = spdx("Q Public License 1.0",                                             "QPL-1.0",                              true,  true)
-  val Rdisc                                  = spdx("Rdisc License",                                                    "Rdisc",                                false, false)
-  val `RHeCos-1.1`                           = spdx("Red Hat eCos Public License v1.1",                                 "RHeCos-1.1",                           false, false)
-  val `RPL-1.1`                              = spdx("Reciprocal Public License 1.1",                                    "RPL-1.1",                              true,  false)
-  val `RPL-1.5`                              = spdx("Reciprocal Public License 1.5",                                    "RPL-1.5",                              true,  false)
-  val `RPSL-1.0`                             = spdx("RealNetworks Public Source License v1.0",                          "RPSL-1.0",                             true,  true)
-  val `RSA-MD`                               = spdx("RSA Message-Digest License ",                                      "RSA-MD",                               false, false)
-  val RSCPL                                  = spdx("Ricoh Source Code Public License",                                 "RSCPL",                                true,  false)
-  val Ruby                                   = spdx("Ruby License",                                                     "Ruby",                                 false, true)
-  val `SAX-PD`                               = spdx("Sax Public Domain Notice",                                         "SAX-PD",                               false, false)
-  val Saxpath                                = spdx("Saxpath License",                                                  "Saxpath",                              false, false)
-  val SCEA                                   = spdx("SCEA Shared Source License",                                       "SCEA",                                 false, false)
-  val Sendmail                               = spdx("Sendmail License",                                                 "Sendmail",                             false, false)
-  val `SGI-B-1.0`                            = spdx("SGI Free Software License B v1.0",                                 "SGI-B-1.0",                            false, false)
-  val `SGI-B-1.1`                            = spdx("SGI Free Software License B v1.1",                                 "SGI-B-1.1",                            false, false)
-  val `SGI-B-2.0`                            = spdx("SGI Free Software License B v2.0",                                 "SGI-B-2.0",                            false, true)
-  val `SimPL-2.0`                            = spdx("Simple Public License 2.0",                                        "SimPL-2.0",                            true,  false)
-  val `SISSL-1.2`                            = spdx("Sun Industry Standards Source License v1.2",                       "SISSL-1.2",                            false, false)
-  val SISSL                                  = spdx("Sun Industry Standards Source License v1.1",                       "SISSL",                                true,  false)
-  val Sleepycat                              = spdx("Sleepycat License",                                                "Sleepycat",                            true,  true)
-  val SMLNJ                                  = spdx("Standard ML of New Jersey License",                                "SMLNJ",                                false, true)
-  val SMPPL                                  = spdx("Secure Messaging Protocol Public License",                         "SMPPL",                                false, false)
-  val SNIA                                   = spdx("SNIA Public License 1.1",                                          "SNIA",                                 false, false)
-  val `Spencer-86`                           = spdx("Spencer License 86",                                               "Spencer-86",                           false, false)
-  val `Spencer-94`                           = spdx("Spencer License 94",                                               "Spencer-94",                           false, false)
-  val `Spencer-99`                           = spdx("Spencer License 99",                                               "Spencer-99",                           false, false)
-  val `SPL-1.0`                              = spdx("Sun Public License v1.0",                                          "SPL-1.0",                              true,  true)
-  val `SugarCRM-1.1.3`                       = spdx("SugarCRM Public License v1.1.3",                                   "SugarCRM-1.1.3",                       false, false)
-  val SWL                                    = spdx("Scheme Widget Library (SWL) Software License Agreement",           "SWL",                                  false, false)
-  val TCL                                    = spdx("TCL/TK License",                                                   "TCL",                                  false, false)
-  val `TCP-wrappers`                         = spdx("TCP Wrappers License",                                             "TCP-wrappers",                         false, false)
-  val TMate                                  = spdx("TMate Open Source License",                                        "TMate",                                false, false)
-  val `TORQUE-1.1`                           = spdx("TORQUE v2.5+ Software License v1.1",                               "TORQUE-1.1",                           false, false)
-  val TOSL                                   = spdx("Trusster Open Source License",                                     "TOSL",                                 false, false)
-  val `Unicode-DFS-2015`                     = spdx("Unicode License Agreement - Data Files and Software (2015)",       "Unicode-DFS-2015",                     false, false)
-  val `Unicode-DFS-2016`                     = spdx("Unicode License Agreement - Data Files and Software (2016)",       "Unicode-DFS-2016",                     false, false)
-  val `Unicode-TOU`                          = spdx("Unicode Terms of Use",                                             "Unicode-TOU",                          false, false)
-  val Unlicense                              = spdx("The Unlicense",                                                    "Unlicense",                            false, true)
-  val `UPL-1.0`                              = spdx("Universal Permissive License v1.0",                                "UPL-1.0",                              true,  true)
-  val Vim                                    = spdx("Vim License",                                                      "Vim",                                  false, true)
-  val VOSTROM                                = spdx("VOSTROM Public License for Open Source",                           "VOSTROM",                              false, false)
-  val `VSL-1.0`                              = spdx("Vovida Software License v1.0",                                     "VSL-1.0",                              true,  false)
-  val `W3C-19980720`                         = spdx("W3C Software Notice and License (1998-07-20)",                     "W3C-19980720",                         false, false)
-  val `W3C-20150513`                         = spdx("W3C Software Notice and Document License (2015-05-13)",            "W3C-20150513",                         false, false)
-  val W3C                                    = spdx("W3C Software Notice and License (2002-12-31)",                     "W3C",                                  true,  true)
-  val `Watcom-1.0`                           = spdx("Sybase Open Watcom Public License 1.0",                            "Watcom-1.0",                           true,  false)
-  val Wsuipa                                 = spdx("Wsuipa License",                                                   "Wsuipa",                               false, false)
-  val WTFPL                                  = spdx("Do What The F*ck You Want To Public License",                      "WTFPL",                                false, true)
-  val X11                                    = spdx("X11 License",                                                      "X11",                                  false, true)
-  val Xerox                                  = spdx("Xerox License",                                                    "Xerox",                                false, false)
-  val `XFree86-1.1`                          = spdx("XFree86 License 1.1",                                              "XFree86-1.1",                          false, true)
-  val xinetd                                 = spdx("xinetd License",                                                   "xinetd",                               false, true)
-  val Xnet                                   = spdx("X.Net License",                                                    "Xnet",                                 true,  false)
-  val xpp                                    = spdx("XPP License",                                                      "xpp",                                  false, false)
-  val XSkat                                  = spdx("XSkat License",                                                    "XSkat",                                false, false)
-  val `YPL-1.0`                              = spdx("Yahoo! Public License v1.0",                                       "YPL-1.0",                              false, false)
-  val `YPL-1.1`                              = spdx("Yahoo! Public License v1.1",                                       "YPL-1.1",                              false, true)
-  val Zed                                    = spdx("Zed License",                                                      "Zed",                                  false, false)
-  val `Zend-2.0`                             = spdx("Zend License v2.0",                                                "Zend-2.0",                             false, true)
-  val `Zimbra-1.3`                           = spdx("Zimbra Public License v1.3",                                       "Zimbra-1.3",                           false, true)
-  val `Zimbra-1.4`                           = spdx("Zimbra Public License v1.4",                                       "Zimbra-1.4",                           false, false)
-  val `zlib-acknowledgement`                 = spdx("zlib/libpng License with Acknowledgement",                         "zlib-acknowledgement",                 false, false)
-  val Zlib                                   = spdx("zlib License",                                                     "Zlib",                                 true,  true)
-  val `ZPL-1.1`                              = spdx("Zope Public License 1.1",                                          "ZPL-1.1",                              false, false)
-  val `ZPL-2.0`                              = spdx("Zope Public License 2.0",                                          "ZPL-2.0",                              true,  true)
-  val `ZPL-2.1`                              = spdx("Zope Public License 2.1",                                          "ZPL-2.1",                              false, true)
-  val `AGPL-3.0`                             = spdx("GNU Affero General Public License v3.0",                           "AGPL-3.0",                             true,  false)
-  val `eCos-2.0`                             = spdx("eCos license version 2.0",                                         "eCos-2.0",                             false, false)
-  val `GFDL-1.1`                             = spdx("GNU Free Documentation License v1.1",                              "GFDL-1.1",                             false, false)
-  val `GFDL-1.2`                             = spdx("GNU Free Documentation License v1.2",                              "GFDL-1.2",                             false, false)
-  val `GFDL-1.3`                             = spdx("GNU Free Documentation License v1.3",                              "GFDL-1.3",                             false, false)
-  val `GPL-1.0+`                             = spdx("GNU General Public License v1.0 or later",                         "GPL-1.0+",                             false, false)
-  val `GPL-1.0`                              = spdx("GNU General Public License v1.0 only",                             "GPL-1.0",                              false, false)
-  val `GPL-2.0+`                             = spdx("GNU General Public License v2.0 or later",                         "GPL-2.0+",                             true,  false)
-  val `GPL-2.0-with-autoconf-exception`      = spdx("GNU General Public License v2.0 w/Autoconf exception",             "GPL-2.0-with-autoconf-exception",      false, false)
-  val `GPL-2.0-with-bison-exception`         = spdx("GNU General Public License v2.0 w/Bison exception",                "GPL-2.0-with-bison-exception",         false, false)
-  val `GPL-2.0-with-classpath-exception`     = spdx("GNU General Public License v2.0 w/Classpath exception",            "GPL-2.0-with-classpath-exception",     false, false)
-  val `GPL-2.0-with-font-exception`          = spdx("GNU General Public License v2.0 w/Font exception",                 "GPL-2.0-with-font-exception",          false, false)
-  val `GPL-2.0-with-GCC-exception`           = spdx("GNU General Public License v2.0 w/GCC Runtime Library exception",  "GPL-2.0-with-GCC-exception",           false, false)
-  val `GPL-2.0`                              = spdx("GNU General Public License v2.0 only",                             "GPL-2.0",                              true,  false)
-  val `GPL-3.0+`                             = spdx("GNU General Public License v3.0 or later",                         "GPL-3.0+",                             true,  false)
-  val `GPL-3.0-with-autoconf-exception`      = spdx("GNU General Public License v3.0 w/Autoconf exception",             "GPL-3.0-with-autoconf-exception",      false, false)
-  val `GPL-3.0-with-GCC-exception`           = spdx("GNU General Public License v3.0 w/GCC Runtime Library exception",  "GPL-3.0-with-GCC-exception",           true,  false)
-  val `GPL-3.0`                              = spdx("GNU General Public License v3.0 only",                             "GPL-3.0",                              true,  false)
-  val `LGPL-2.0+`                            = spdx("GNU Library General Public License v2 or later",                   "LGPL-2.0+",                            true,  false)
-  val `LGPL-2.0`                             = spdx("GNU Library General Public License v2 only",                       "LGPL-2.0",                             true,  false)
-  val `LGPL-2.1+`                            = spdx("GNU Library General Public License v2 or later",                   "LGPL-2.1+",                            true,  false)
-  val `LGPL-2.1`                             = spdx("GNU Lesser General Public License v2.1 only",                      "LGPL-2.1",                             true,  false)
-  val `LGPL-3.0+`                            = spdx("GNU Lesser General Public License v3.0 or later",                  "LGPL-3.0+",                            true,  false)
-  val `LGPL-3.0`                             = spdx("GNU Lesser General Public License v3.0 only",                      "LGPL-3.0",                             true,  false)
-  val Nunit                                  = spdx("Nunit License",                                                    "Nunit",                                false, false)
-  val `StandardML-NJ`                        = spdx("Standard ML of New Jersey License",                                "StandardML-NJ",                        false, false)
-  val wxWindows                              = spdx("wxWindows Library License",                                        "wxWindows",                            false, false)
+   */
+  val `0BSD` = spdx("BSD Zero Clause License", "0BSD", false, false)
+  val AAL = spdx("Attribution Assurance License", "AAL", true, false)
+  val Abstyles = spdx("Abstyles License", "Abstyles", false, false)
+  val `Adobe-2006` = spdx(
+    "Adobe Systems Incorporated Source Code License Agreement",
+    "Adobe-2006",
+    false,
+    false)
+  val `Adobe-Glyph` =
+    spdx("Adobe Glyph List License", "Adobe-Glyph", false, false)
+  val ADSL = spdx("Amazon Digital Services License", "ADSL", false, false)
+  val `AFL-1.1` = spdx("Academic Free License v1.1", "AFL-1.1", true, true)
+  val `AFL-1.2` = spdx("Academic Free License v1.2", "AFL-1.2", true, true)
+  val `AFL-2.0` = spdx("Academic Free License v2.0", "AFL-2.0", true, true)
+  val `AFL-2.1` = spdx("Academic Free License v2.1", "AFL-2.1", true, true)
+  val `AFL-3.0` = spdx("Academic Free License v3.0", "AFL-3.0", true, true)
+  val Afmparse = spdx("Afmparse License", "Afmparse", false, false)
+  val `AGPL-1.0` =
+    spdx("Affero General Public License v1.0", "AGPL-1.0", false, true)
+  val `AGPL-3.0-only` = spdx("GNU Affero General Public License v3.0 only",
+                             "AGPL-3.0-only",
+                             true,
+                             false)
+  val `AGPL-3.0-or-later` = spdx(
+    "GNU Affero General Public License v3.0 or later",
+    "AGPL-3.0-or-later",
+    true,
+    false)
+  val Aladdin = spdx("Aladdin Free Public License", "Aladdin", false, false)
+  val AMDPLPA = spdx("AMD's plpa_map.c License", "AMDPLPA", false, false)
+  val AML = spdx("Apple MIT License", "AML", false, false)
+  val AMPAS = spdx("Academy of Motion Picture Arts and Sciences BSD",
+                   "AMPAS",
+                   false,
+                   false)
+  val `ANTLR-PD` =
+    spdx("ANTLR Software Rights Notice", "ANTLR-PD", false, false)
+  val `Apache-1.0` = spdx("Apache License 1.0", "Apache-1.0", false, true)
+  val `Apache-1.1` = spdx("Apache License 1.1", "Apache-1.1", true, true)
+  val `Apache-2.0` = spdx("Apache License 2.0", "Apache-2.0", true, true)
+  val APAFML = spdx("Adobe Postscript AFM License", "APAFML", false, false)
+  val `APL-1.0` = spdx("Adaptive Public License 1.0", "APL-1.0", true, false)
+  val `APSL-1.0` =
+    spdx("Apple Public Source License 1.0", "APSL-1.0", true, false)
+  val `APSL-1.1` =
+    spdx("Apple Public Source License 1.1", "APSL-1.1", true, false)
+  val `APSL-1.2` =
+    spdx("Apple Public Source License 1.2", "APSL-1.2", true, false)
+  val `APSL-2.0` =
+    spdx("Apple Public Source License 2.0", "APSL-2.0", true, true)
+  val `Artistic-1.0-cl8` =
+    spdx("Artistic License 1.0 w/clause 8", "Artistic-1.0-cl8", true, false)
+  val `Artistic-1.0-Perl` =
+    spdx("Artistic License 1.0 (Perl)", "Artistic-1.0-Perl", true, false)
+  val `Artistic-1.0` = spdx("Artistic License 1.0", "Artistic-1.0", true, false)
+  val `Artistic-2.0` = spdx("Artistic License 2.0", "Artistic-2.0", true, true)
+  val Bahyph = spdx("Bahyph License", "Bahyph", false, false)
+  val Barr = spdx("Barr License", "Barr", false, false)
+  val Beerware = spdx("Beerware License", "Beerware", false, false)
+  val `BitTorrent-1.0` =
+    spdx("BitTorrent Open Source License v1.0", "BitTorrent-1.0", false, false)
+  val `BitTorrent-1.1` =
+    spdx("BitTorrent Open Source License v1.1", "BitTorrent-1.1", false, true)
+  val Borceux = spdx("Borceux license", "Borceux", false, false)
+  val `BSD-1-Clause` =
+    spdx("BSD 1-Clause License", "BSD-1-Clause", false, false)
+  val `BSD-2-Clause-FreeBSD` =
+    spdx("BSD 2-Clause FreeBSD License", "BSD-2-Clause-FreeBSD", false, true)
+  val `BSD-2-Clause-NetBSD` =
+    spdx("BSD 2-Clause NetBSD License", "BSD-2-Clause-NetBSD", false, false)
+  val `BSD-2-Clause-Patent` =
+    spdx("BSD-2-Clause Plus Patent License", "BSD-2-Clause-Patent", true, false)
+  val `BSD-2-Clause` =
+    spdx("BSD 2-Clause \"Simplified\" License", "BSD-2-Clause", true, false)
+  val `BSD-3-Clause-Attribution` =
+    spdx("BSD with attribution", "BSD-3-Clause-Attribution", false, false)
+  val `BSD-3-Clause-Clear` =
+    spdx("BSD 3-Clause Clear License", "BSD-3-Clause-Clear", false, true)
+  val `BSD-3-Clause-LBNL` = spdx(
+    "Lawrence Berkeley National Labs BSD variant license",
+    "BSD-3-Clause-LBNL",
+    false,
+    false)
+  val `BSD-3-Clause-No-Nuclear-License-2014` = spdx(
+    "BSD 3-Clause No Nuclear License 2014",
+    "BSD-3-Clause-No-Nuclear-License-2014",
+    false,
+    false)
+  val `BSD-3-Clause-No-Nuclear-License` = spdx(
+    "BSD 3-Clause No Nuclear License",
+    "BSD-3-Clause-No-Nuclear-License",
+    false,
+    false)
+  val `BSD-3-Clause-No-Nuclear-Warranty` = spdx(
+    "BSD 3-Clause No Nuclear Warranty",
+    "BSD-3-Clause-No-Nuclear-Warranty",
+    false,
+    false)
+  val `BSD-3-Clause` = spdx("BSD 3-Clause \"New\" or \"Revised\" License",
+                            "BSD-3-Clause",
+                            true,
+                            true)
+  val `BSD-4-Clause-UC` = spdx(
+    "BSD-4-Clause (University of California-Specific)",
+    "BSD-4-Clause-UC",
+    false,
+    false)
+  val `BSD-4-Clause` = spdx("BSD 4-Clause \"Original\" or \"Old\" License",
+                            "BSD-4-Clause",
+                            false,
+                            true)
+  val `BSD-Protection` =
+    spdx("BSD Protection License", "BSD-Protection", false, false)
+  val `BSD-Source-Code` =
+    spdx("BSD Source Code Attribution", "BSD-Source-Code", false, false)
+  val `BSL-1.0` = spdx("Boost Software License 1.0", "BSL-1.0", true, true)
+  val `bzip2-1.0.5` =
+    spdx("bzip2 and libbzip2 License v1.0.5", "bzip2-1.0.5", false, false)
+  val `bzip2-1.0.6` =
+    spdx("bzip2 and libbzip2 License v1.0.6", "bzip2-1.0.6", false, false)
+  val Caldera = spdx("Caldera License", "Caldera", false, false)
+  val `CATOSL-1.1` = spdx("Computer Associates Trusted Open Source License 1.1",
+                          "CATOSL-1.1",
+                          true,
+                          false)
+  val `CC-BY-1.0` =
+    spdx("Creative Commons Attribution 1.0", "CC-BY-1.0", false, false)
+  val `CC-BY-2.0` =
+    spdx("Creative Commons Attribution 2.0", "CC-BY-2.0", false, false)
+  val `CC-BY-2.5` =
+    spdx("Creative Commons Attribution 2.5", "CC-BY-2.5", false, false)
+  val `CC-BY-3.0` =
+    spdx("Creative Commons Attribution 3.0", "CC-BY-3.0", false, false)
+  val `CC-BY-4.0` =
+    spdx("Creative Commons Attribution 4.0", "CC-BY-4.0", false, true)
+  val `CC-BY-NC-1.0` = spdx("Creative Commons Attribution Non Commercial 1.0",
+                            "CC-BY-NC-1.0",
+                            false,
+                            false)
+  val `CC-BY-NC-2.0` = spdx("Creative Commons Attribution Non Commercial 2.0",
+                            "CC-BY-NC-2.0",
+                            false,
+                            false)
+  val `CC-BY-NC-2.5` = spdx("Creative Commons Attribution Non Commercial 2.5",
+                            "CC-BY-NC-2.5",
+                            false,
+                            false)
+  val `CC-BY-NC-3.0` = spdx("Creative Commons Attribution Non Commercial 3.0",
+                            "CC-BY-NC-3.0",
+                            false,
+                            false)
+  val `CC-BY-NC-4.0` = spdx("Creative Commons Attribution Non Commercial 4.0",
+                            "CC-BY-NC-4.0",
+                            false,
+                            false)
+  val `CC-BY-NC-ND-1.0` = spdx(
+    "Creative Commons Attribution Non Commercial No Derivatives 1.0",
+    "CC-BY-NC-ND-1.0",
+    false,
+    false)
+  val `CC-BY-NC-ND-2.0` = spdx(
+    "Creative Commons Attribution Non Commercial No Derivatives 2.0",
+    "CC-BY-NC-ND-2.0",
+    false,
+    false)
+  val `CC-BY-NC-ND-2.5` = spdx(
+    "Creative Commons Attribution Non Commercial No Derivatives 2.5",
+    "CC-BY-NC-ND-2.5",
+    false,
+    false)
+  val `CC-BY-NC-ND-3.0` = spdx(
+    "Creative Commons Attribution Non Commercial No Derivatives 3.0",
+    "CC-BY-NC-ND-3.0",
+    false,
+    false)
+  val `CC-BY-NC-ND-4.0` = spdx(
+    "Creative Commons Attribution Non Commercial No Derivatives 4.0",
+    "CC-BY-NC-ND-4.0",
+    false,
+    false)
+  val `CC-BY-NC-SA-1.0` = spdx(
+    "Creative Commons Attribution Non Commercial Share Alike 1.0",
+    "CC-BY-NC-SA-1.0",
+    false,
+    false)
+  val `CC-BY-NC-SA-2.0` = spdx(
+    "Creative Commons Attribution Non Commercial Share Alike 2.0",
+    "CC-BY-NC-SA-2.0",
+    false,
+    false)
+  val `CC-BY-NC-SA-2.5` = spdx(
+    "Creative Commons Attribution Non Commercial Share Alike 2.5",
+    "CC-BY-NC-SA-2.5",
+    false,
+    false)
+  val `CC-BY-NC-SA-3.0` = spdx(
+    "Creative Commons Attribution Non Commercial Share Alike 3.0",
+    "CC-BY-NC-SA-3.0",
+    false,
+    false)
+  val `CC-BY-NC-SA-4.0` = spdx(
+    "Creative Commons Attribution Non Commercial Share Alike 4.0",
+    "CC-BY-NC-SA-4.0",
+    false,
+    false)
+  val `CC-BY-ND-1.0` = spdx("Creative Commons Attribution No Derivatives 1.0",
+                            "CC-BY-ND-1.0",
+                            false,
+                            false)
+  val `CC-BY-ND-2.0` = spdx("Creative Commons Attribution No Derivatives 2.0",
+                            "CC-BY-ND-2.0",
+                            false,
+                            false)
+  val `CC-BY-ND-2.5` = spdx("Creative Commons Attribution No Derivatives 2.5",
+                            "CC-BY-ND-2.5",
+                            false,
+                            false)
+  val `CC-BY-ND-3.0` = spdx("Creative Commons Attribution No Derivatives 3.0",
+                            "CC-BY-ND-3.0",
+                            false,
+                            false)
+  val `CC-BY-ND-4.0` = spdx("Creative Commons Attribution No Derivatives 4.0",
+                            "CC-BY-ND-4.0",
+                            false,
+                            false)
+  val `CC-BY-SA-1.0` = spdx("Creative Commons Attribution Share Alike 1.0",
+                            "CC-BY-SA-1.0",
+                            false,
+                            false)
+  val `CC-BY-SA-2.0` = spdx("Creative Commons Attribution Share Alike 2.0",
+                            "CC-BY-SA-2.0",
+                            false,
+                            false)
+  val `CC-BY-SA-2.5` = spdx("Creative Commons Attribution Share Alike 2.5",
+                            "CC-BY-SA-2.5",
+                            false,
+                            false)
+  val `CC-BY-SA-3.0` = spdx("Creative Commons Attribution Share Alike 3.0",
+                            "CC-BY-SA-3.0",
+                            false,
+                            false)
+  val `CC-BY-SA-4.0` = spdx("Creative Commons Attribution Share Alike 4.0",
+                            "CC-BY-SA-4.0",
+                            false,
+                            true)
+  val `CC0-1.0` =
+    spdx("Creative Commons Zero v1.0 Universal", "CC0-1.0", false, true)
+  val `CDDL-1.0` = spdx("Common Development and Distribution License 1.0",
+                        "CDDL-1.0",
+                        true,
+                        true)
+  val `CDDL-1.1` = spdx("Common Development and Distribution License 1.1",
+                        "CDDL-1.1",
+                        false,
+                        false)
+  val `CDLA-Permissive-1.0` = spdx(
+    "Community Data License Agreement Permissive 1.0",
+    "CDLA-Permissive-1.0",
+    false,
+    false)
+  val `CDLA-Sharing-1.0` = spdx("Community Data License Agreement Sharing 1.0",
+                                "CDLA-Sharing-1.0",
+                                false,
+                                false)
+  val `CECILL-1.0` = spdx("CeCILL Free Software License Agreement v1.0",
+                          "CECILL-1.0",
+                          false,
+                          false)
+  val `CECILL-1.1` = spdx("CeCILL Free Software License Agreement v1.1",
+                          "CECILL-1.1",
+                          false,
+                          false)
+  val `CECILL-2.0` = spdx("CeCILL Free Software License Agreement v2.0",
+                          "CECILL-2.0",
+                          false,
+                          true)
+  val `CECILL-2.1` = spdx("CeCILL Free Software License Agreement v2.1",
+                          "CECILL-2.1",
+                          true,
+                          false)
+  val `CECILL-B` =
+    spdx("CeCILL-B Free Software License Agreement", "CECILL-B", false, true)
+  val `CECILL-C` =
+    spdx("CeCILL-C Free Software License Agreement", "CECILL-C", false, true)
+  val ClArtistic = spdx("Clarified Artistic License", "ClArtistic", false, true)
+  val `CNRI-Jython` = spdx("CNRI Jython License", "CNRI-Jython", false, false)
+  val `CNRI-Python-GPL-Compatible` = spdx(
+    "CNRI Python Open Source GPL Compatible License Agreement",
+    "CNRI-Python-GPL-Compatible",
+    false,
+    false)
+  val `CNRI-Python` = spdx("CNRI Python License", "CNRI-Python", true, false)
+  val `Condor-1.1` =
+    spdx("Condor Public License v1.1", "Condor-1.1", false, true)
+  val `CPAL-1.0` =
+    spdx("Common Public Attribution License 1.0", "CPAL-1.0", true, true)
+  val `CPL-1.0` = spdx("Common Public License 1.0", "CPL-1.0", true, true)
+  val `CPOL-1.02` =
+    spdx("Code Project Open License 1.02", "CPOL-1.02", false, false)
+  val Crossword = spdx("Crossword License", "Crossword", false, false)
+  val CrystalStacker =
+    spdx("CrystalStacker License", "CrystalStacker", false, false)
+  val `CUA-OPL-1.0` =
+    spdx("CUA Office Public License v1.0", "CUA-OPL-1.0", true, false)
+  val Cube = spdx("Cube License", "Cube", false, false)
+  val curl = spdx("curl License", "curl", false, false)
+  val `D-FSL-1.0` =
+    spdx("Deutsche Freie Software Lizenz", "D-FSL-1.0", false, false)
+  val diffmark = spdx("diffmark license", "diffmark", false, false)
+  val DOC = spdx("DOC License", "DOC", false, false)
+  val Dotseqn = spdx("Dotseqn License", "Dotseqn", false, false)
+  val DSDP = spdx("DSDP License", "DSDP", false, false)
+  val dvipdfm = spdx("dvipdfm License", "dvipdfm", false, false)
+  val `ECL-1.0` =
+    spdx("Educational Community License v1.0", "ECL-1.0", true, false)
+  val `ECL-2.0` =
+    spdx("Educational Community License v2.0", "ECL-2.0", true, true)
+  val `EFL-1.0` = spdx("Eiffel Forum License v1.0", "EFL-1.0", true, false)
+  val `EFL-2.0` = spdx("Eiffel Forum License v2.0", "EFL-2.0", true, true)
+  val eGenix = spdx("eGenix.com Public License 1.1.0", "eGenix", false, false)
+  val Entessa = spdx("Entessa Public License v1.0", "Entessa", true, false)
+  val `EPL-1.0` = spdx("Eclipse Public License 1.0", "EPL-1.0", true, true)
+  val `EPL-2.0` = spdx("Eclipse Public License 2.0", "EPL-2.0", true, true)
+  val `ErlPL-1.1` =
+    spdx("Erlang Public License v1.1", "ErlPL-1.1", false, false)
+  val EUDatagrid =
+    spdx("EU DataGrid Software License", "EUDatagrid", true, true)
+  val `EUPL-1.0` =
+    spdx("European Union Public License 1.0", "EUPL-1.0", false, false)
+  val `EUPL-1.1` =
+    spdx("European Union Public License 1.1", "EUPL-1.1", true, true)
+  val `EUPL-1.2` =
+    spdx("European Union Public License 1.2", "EUPL-1.2", true, false)
+  val Eurosym = spdx("Eurosym License", "Eurosym", false, false)
+  val Fair = spdx("Fair License", "Fair", true, false)
+  val `Frameworx-1.0` =
+    spdx("Frameworx Open License 1.0", "Frameworx-1.0", true, false)
+  val FreeImage =
+    spdx("FreeImage Public License v1.0", "FreeImage", false, false)
+  val FSFAP = spdx("FSF All Permissive License", "FSFAP", false, true)
+  val FSFUL = spdx("FSF Unlimited License", "FSFUL", false, false)
+  val FSFULLR = spdx("FSF Unlimited License (with License Retention)",
+                     "FSFULLR",
+                     false,
+                     false)
+  val FTL = spdx("Freetype Project License", "FTL", false, true)
+  val `GFDL-1.1-only` = spdx("GNU Free Documentation License v1.1 only",
+                             "GFDL-1.1-only",
+                             false,
+                             false)
+  val `GFDL-1.1-or-later` = spdx("GNU Free Documentation License v1.1 or later",
+                                 "GFDL-1.1-or-later",
+                                 false,
+                                 false)
+  val `GFDL-1.2-only` = spdx("GNU Free Documentation License v1.2 only",
+                             "GFDL-1.2-only",
+                             false,
+                             false)
+  val `GFDL-1.2-or-later` = spdx("GNU Free Documentation License v1.2 or later",
+                                 "GFDL-1.2-or-later",
+                                 false,
+                                 false)
+  val `GFDL-1.3-only` = spdx("GNU Free Documentation License v1.3 only",
+                             "GFDL-1.3-only",
+                             false,
+                             false)
+  val `GFDL-1.3-or-later` = spdx("GNU Free Documentation License v1.3 or later",
+                                 "GFDL-1.3-or-later",
+                                 false,
+                                 false)
+  val Giftware = spdx("Giftware License", "Giftware", false, false)
+  val GL2PS = spdx("GL2PS License", "GL2PS", false, false)
+  val Glide = spdx("3dfx Glide License", "Glide", false, false)
+  val Glulxe = spdx("Glulxe License", "Glulxe", false, false)
+  val gnuplot = spdx("gnuplot License", "gnuplot", false, true)
+  val `GPL-1.0-only` =
+    spdx("GNU General Public License v1.0 only", "GPL-1.0-only", false, false)
+  val `GPL-1.0-or-later` = spdx("GNU General Public License v1.0 or later",
+                                "GPL-1.0-or-later",
+                                false,
+                                false)
+  val `GPL-2.0-only` =
+    spdx("GNU General Public License v2.0 only", "GPL-2.0-only", true, false)
+  val `GPL-2.0-or-later` = spdx("GNU General Public License v2.0 or later",
+                                "GPL-2.0-or-later",
+                                true,
+                                false)
+  val `GPL-3.0-only` =
+    spdx("GNU General Public License v3.0 only", "GPL-3.0-only", true, false)
+  val `GPL-3.0-or-later` = spdx("GNU General Public License v3.0 or later",
+                                "GPL-3.0-or-later",
+                                true,
+                                false)
+  val `gSOAP-1.3b` =
+    spdx("gSOAP Public License v1.3b", "gSOAP-1.3b", false, false)
+  val HaskellReport =
+    spdx("Haskell Language Report License", "HaskellReport", false, false)
+  val HPND =
+    spdx("Historical Permission Notice and Disclaimer", "HPND", true, true)
+  val `IBM-pibs` = spdx("IBM PowerPC Initialization and Boot Software",
+                        "IBM-pibs",
+                        false,
+                        false)
+  val ICU = spdx("ICU License", "ICU", false, false)
+  val IJG = spdx("Independent JPEG Group License", "IJG", false, true)
+  val ImageMagick = spdx("ImageMagick License", "ImageMagick", false, false)
+  val iMatix =
+    spdx("iMatix Standard Function Library Agreement", "iMatix", false, true)
+  val Imlib2 = spdx("Imlib2 License", "Imlib2", false, true)
+  val `Info-ZIP` = spdx("Info-ZIP License", "Info-ZIP", false, false)
+  val `Intel-ACPI` =
+    spdx("Intel ACPI Software License Agreement", "Intel-ACPI", false, false)
+  val Intel = spdx("Intel Open Source License", "Intel", true, true)
+  val `Interbase-1.0` =
+    spdx("Interbase Public License v1.0", "Interbase-1.0", false, false)
+  val IPA = spdx("IPA Font License", "IPA", true, true)
+  val `IPL-1.0` = spdx("IBM Public License v1.0", "IPL-1.0", true, true)
+  val ISC = spdx("ISC License", "ISC", true, true)
+  val `JasPer-2.0` = spdx("JasPer License", "JasPer-2.0", false, false)
+  val JSON = spdx("JSON License", "JSON", false, false)
+  val `LAL-1.2` = spdx("Licence Art Libre 1.2", "LAL-1.2", false, false)
+  val `LAL-1.3` = spdx("Licence Art Libre 1.3", "LAL-1.3", false, false)
+  val Latex2e = spdx("Latex2e License", "Latex2e", false, false)
+  val Leptonica = spdx("Leptonica License", "Leptonica", false, false)
+  val `LGPL-2.0-only` = spdx("GNU Library General Public License v2 only",
+                             "LGPL-2.0-only",
+                             true,
+                             false)
+  val `LGPL-2.0-or-later` = spdx(
+    "GNU Library General Public License v2 or later",
+    "LGPL-2.0-or-later",
+    true,
+    false)
+  val `LGPL-2.1-only` = spdx("GNU Lesser General Public License v2.1 only",
+                             "LGPL-2.1-only",
+                             true,
+                             false)
+  val `LGPL-2.1-or-later` = spdx(
+    "GNU Lesser General Public License v2.1 or later",
+    "LGPL-2.1-or-later",
+    true,
+    false)
+  val `LGPL-3.0-only` = spdx("GNU Lesser General Public License v3.0 only",
+                             "LGPL-3.0-only",
+                             true,
+                             false)
+  val `LGPL-3.0-or-later` = spdx(
+    "GNU Lesser General Public License v3.0 or later",
+    "LGPL-3.0-or-later",
+    true,
+    false)
+  val LGPLLR = spdx("Lesser General Public License For Linguistic Resources",
+                    "LGPLLR",
+                    false,
+                    false)
+  val Libpng = spdx("libpng License", "Libpng", false, false)
+  val libtiff = spdx("libtiff License", "libtiff", false, false)
+  val `LiLiQ-P-1.1` = spdx("Licence Libre du Québec – Permissive version 1.1",
+                           "LiLiQ-P-1.1",
+                           true,
+                           false)
+  val `LiLiQ-R-1.1` = spdx("Licence Libre du Québec – Réciprocité version 1.1",
+                           "LiLiQ-R-1.1",
+                           true,
+                           false)
+  val `LiLiQ-Rplus-1.1` = spdx(
+    "Licence Libre du Québec – Réciprocité forte version 1.1",
+    "LiLiQ-Rplus-1.1",
+    true,
+    false)
+  val `LPL-1.0` =
+    spdx("Lucent Public License Version 1.0", "LPL-1.0", true, false)
+  val `LPL-1.02` = spdx("Lucent Public License v1.02", "LPL-1.02", true, true)
+  val `LPPL-1.0` =
+    spdx("LaTeX Project Public License v1.0", "LPPL-1.0", false, false)
+  val `LPPL-1.1` =
+    spdx("LaTeX Project Public License v1.1", "LPPL-1.1", false, false)
+  val `LPPL-1.2` =
+    spdx("LaTeX Project Public License v1.2", "LPPL-1.2", false, true)
+  val `LPPL-1.3a` =
+    spdx("LaTeX Project Public License v1.3a", "LPPL-1.3a", false, true)
+  val `LPPL-1.3c` =
+    spdx("LaTeX Project Public License v1.3c", "LPPL-1.3c", true, false)
+  val MakeIndex = spdx("MakeIndex License", "MakeIndex", false, false)
+  val MirOS = spdx("MirOS License", "MirOS", true, false)
+  val `MIT-advertising` =
+    spdx("Enlightenment License (e16)", "MIT-advertising", false, false)
+  val `MIT-CMU` = spdx("CMU License", "MIT-CMU", false, false)
+  val `MIT-enna` = spdx("enna License", "MIT-enna", false, false)
+  val `MIT-feh` = spdx("feh License", "MIT-feh", false, false)
+  val MIT = spdx("MIT License", "MIT", true, true)
+  val MITNFA = spdx("MIT +no-false-attribs license", "MITNFA", false, false)
+  val Motosoto = spdx("Motosoto License", "Motosoto", true, false)
+  val mpich2 = spdx("mpich2 License", "mpich2", false, false)
+  val `MPL-1.0` = spdx("Mozilla Public License 1.0", "MPL-1.0", true, false)
+  val `MPL-1.1` = spdx("Mozilla Public License 1.1", "MPL-1.1", true, true)
+  val `MPL-2.0-no-copyleft-exception` = spdx(
+    "Mozilla Public License 2.0 (no copyleft exception)",
+    "MPL-2.0-no-copyleft-exception",
+    true,
+    false)
+  val `MPL-2.0` = spdx("Mozilla Public License 2.0", "MPL-2.0", true, true)
+  val `MS-PL` = spdx("Microsoft Public License", "MS-PL", true, true)
+  val `MS-RL` = spdx("Microsoft Reciprocal License", "MS-RL", true, true)
+  val MTLL = spdx("Matrix Template Library License", "MTLL", false, false)
+  val Multics = spdx("Multics License", "Multics", true, false)
+  val Mup = spdx("Mup License", "Mup", false, false)
+  val `NASA-1.3` =
+    spdx("NASA Open Source Agreement 1.3", "NASA-1.3", true, false)
+  val Naumen = spdx("Naumen Public License", "Naumen", true, false)
+  val `NBPL-1.0` =
+    spdx("Net Boolean Public License v1", "NBPL-1.0", false, false)
+  val NCSA =
+    spdx("University of Illinois/NCSA Open Source License", "NCSA", true, true)
+  val `Net-SNMP` = spdx("Net-SNMP License", "Net-SNMP", false, false)
+  val NetCDF = spdx("NetCDF license", "NetCDF", false, false)
+  val Newsletr = spdx("Newsletr License", "Newsletr", false, false)
+  val NGPL = spdx("Nethack General Public License", "NGPL", true, false)
+  val `NLOD-1.0` =
+    spdx("Norwegian Licence for Open Government Data", "NLOD-1.0", false, false)
+  val NLPL = spdx("No Limit Public License", "NLPL", false, false)
+  val Nokia = spdx("Nokia Open Source License", "Nokia", true, true)
+  val NOSL = spdx("Netizen Open Source License", "NOSL", false, true)
+  val Noweb = spdx("Noweb License", "Noweb", false, false)
+  val `NPL-1.0` = spdx("Netscape Public License v1.0", "NPL-1.0", false, true)
+  val `NPL-1.1` = spdx("Netscape Public License v1.1", "NPL-1.1", false, true)
+  val `NPOSL-3.0` =
+    spdx("Non-Profit Open Software License 3.0", "NPOSL-3.0", true, false)
+  val NRL = spdx("NRL License", "NRL", false, false)
+  val NTP = spdx("NTP License", "NTP", true, false)
+  val `OCCT-PL` =
+    spdx("Open CASCADE Technology Public License", "OCCT-PL", false, false)
+  val `OCLC-2.0` =
+    spdx("OCLC Research Public License 2.0", "OCLC-2.0", true, false)
+  val `ODbL-1.0` =
+    spdx("ODC Open Database License v1.0", "ODbL-1.0", false, true)
+  val `OFL-1.0` = spdx("SIL Open Font License 1.0", "OFL-1.0", false, false)
+  val `OFL-1.1` = spdx("SIL Open Font License 1.1", "OFL-1.1", true, true)
+  val OGTSL = spdx("Open Group Test Suite License", "OGTSL", true, false)
+  val `OLDAP-1.1` =
+    spdx("Open LDAP Public License v1.1", "OLDAP-1.1", false, false)
+  val `OLDAP-1.2` =
+    spdx("Open LDAP Public License v1.2", "OLDAP-1.2", false, false)
+  val `OLDAP-1.3` =
+    spdx("Open LDAP Public License v1.3", "OLDAP-1.3", false, false)
+  val `OLDAP-1.4` =
+    spdx("Open LDAP Public License v1.4", "OLDAP-1.4", false, false)
+  val `OLDAP-2.0.1` =
+    spdx("Open LDAP Public License v2.0.1", "OLDAP-2.0.1", false, false)
+  val `OLDAP-2.0` = spdx(
+    "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
+    "OLDAP-2.0",
+    false,
+    false)
+  val `OLDAP-2.1` =
+    spdx("Open LDAP Public License v2.1", "OLDAP-2.1", false, false)
+  val `OLDAP-2.2.1` =
+    spdx("Open LDAP Public License v2.2.1", "OLDAP-2.2.1", false, false)
+  val `OLDAP-2.2.2` =
+    spdx("Open LDAP Public License 2.2.2", "OLDAP-2.2.2", false, false)
+  val `OLDAP-2.2` =
+    spdx("Open LDAP Public License v2.2", "OLDAP-2.2", false, false)
+  val `OLDAP-2.3` =
+    spdx("Open LDAP Public License v2.3", "OLDAP-2.3", false, true)
+  val `OLDAP-2.4` =
+    spdx("Open LDAP Public License v2.4", "OLDAP-2.4", false, false)
+  val `OLDAP-2.5` =
+    spdx("Open LDAP Public License v2.5", "OLDAP-2.5", false, false)
+  val `OLDAP-2.6` =
+    spdx("Open LDAP Public License v2.6", "OLDAP-2.6", false, false)
+  val `OLDAP-2.7` =
+    spdx("Open LDAP Public License v2.7", "OLDAP-2.7", false, true)
+  val `OLDAP-2.8` =
+    spdx("Open LDAP Public License v2.8", "OLDAP-2.8", false, false)
+  val OML = spdx("Open Market License", "OML", false, false)
+  val OpenSSL = spdx("OpenSSL License", "OpenSSL", false, true)
+  val `OPL-1.0` = spdx("Open Public License v1.0", "OPL-1.0", false, false)
+  val `OSET-PL-2.1` =
+    spdx("OSET Public License version 2.1", "OSET-PL-2.1", true, false)
+  val `OSL-1.0` = spdx("Open Software License 1.0", "OSL-1.0", true, true)
+  val `OSL-1.1` = spdx("Open Software License 1.1", "OSL-1.1", false, true)
+  val `OSL-2.0` = spdx("Open Software License 2.0", "OSL-2.0", true, true)
+  val `OSL-2.1` = spdx("Open Software License 2.1", "OSL-2.1", true, true)
+  val `OSL-3.0` = spdx("Open Software License 3.0", "OSL-3.0", true, true)
+  val `PDDL-1.0` =
+    spdx("ODC Public Domain Dedication & License 1.0", "PDDL-1.0", false, false)
+  val `PHP-3.0` = spdx("PHP License v3.0", "PHP-3.0", true, false)
+  val `PHP-3.01` = spdx("PHP License v3.01", "PHP-3.01", false, true)
+  val Plexus = spdx("Plexus Classworlds License", "Plexus", false, false)
+  val PostgreSQL = spdx("PostgreSQL License", "PostgreSQL", true, false)
+  val psfrag = spdx("psfrag License", "psfrag", false, false)
+  val psutils = spdx("psutils License", "psutils", false, false)
+  val `Python-2.0` = spdx("Python License 2.0", "Python-2.0", true, true)
+  val Qhull = spdx("Qhull License", "Qhull", false, false)
+  val `QPL-1.0` = spdx("Q Public License 1.0", "QPL-1.0", true, true)
+  val Rdisc = spdx("Rdisc License", "Rdisc", false, false)
+  val `RHeCos-1.1` =
+    spdx("Red Hat eCos Public License v1.1", "RHeCos-1.1", false, false)
+  val `RPL-1.1` = spdx("Reciprocal Public License 1.1", "RPL-1.1", true, false)
+  val `RPL-1.5` = spdx("Reciprocal Public License 1.5", "RPL-1.5", true, false)
+  val `RPSL-1.0` =
+    spdx("RealNetworks Public Source License v1.0", "RPSL-1.0", true, true)
+  val `RSA-MD` = spdx("RSA Message-Digest License ", "RSA-MD", false, false)
+  val RSCPL = spdx("Ricoh Source Code Public License", "RSCPL", true, false)
+  val Ruby = spdx("Ruby License", "Ruby", false, true)
+  val `SAX-PD` = spdx("Sax Public Domain Notice", "SAX-PD", false, false)
+  val Saxpath = spdx("Saxpath License", "Saxpath", false, false)
+  val SCEA = spdx("SCEA Shared Source License", "SCEA", false, false)
+  val Sendmail = spdx("Sendmail License", "Sendmail", false, false)
+  val `SGI-B-1.0` =
+    spdx("SGI Free Software License B v1.0", "SGI-B-1.0", false, false)
+  val `SGI-B-1.1` =
+    spdx("SGI Free Software License B v1.1", "SGI-B-1.1", false, false)
+  val `SGI-B-2.0` =
+    spdx("SGI Free Software License B v2.0", "SGI-B-2.0", false, true)
+  val `SimPL-2.0` = spdx("Simple Public License 2.0", "SimPL-2.0", true, false)
+  val `SISSL-1.2` = spdx("Sun Industry Standards Source License v1.2",
+                         "SISSL-1.2",
+                         false,
+                         false)
+  val SISSL =
+    spdx("Sun Industry Standards Source License v1.1", "SISSL", true, false)
+  val Sleepycat = spdx("Sleepycat License", "Sleepycat", true, true)
+  val SMLNJ = spdx("Standard ML of New Jersey License", "SMLNJ", false, true)
+  val SMPPL =
+    spdx("Secure Messaging Protocol Public License", "SMPPL", false, false)
+  val SNIA = spdx("SNIA Public License 1.1", "SNIA", false, false)
+  val `Spencer-86` = spdx("Spencer License 86", "Spencer-86", false, false)
+  val `Spencer-94` = spdx("Spencer License 94", "Spencer-94", false, false)
+  val `Spencer-99` = spdx("Spencer License 99", "Spencer-99", false, false)
+  val `SPL-1.0` = spdx("Sun Public License v1.0", "SPL-1.0", true, true)
+  val `SugarCRM-1.1.3` =
+    spdx("SugarCRM Public License v1.1.3", "SugarCRM-1.1.3", false, false)
+  val SWL = spdx("Scheme Widget Library (SWL) Software License Agreement",
+                 "SWL",
+                 false,
+                 false)
+  val TCL = spdx("TCL/TK License", "TCL", false, false)
+  val `TCP-wrappers` =
+    spdx("TCP Wrappers License", "TCP-wrappers", false, false)
+  val TMate = spdx("TMate Open Source License", "TMate", false, false)
+  val `TORQUE-1.1` =
+    spdx("TORQUE v2.5+ Software License v1.1", "TORQUE-1.1", false, false)
+  val TOSL = spdx("Trusster Open Source License", "TOSL", false, false)
+  val `Unicode-DFS-2015` = spdx(
+    "Unicode License Agreement - Data Files and Software (2015)",
+    "Unicode-DFS-2015",
+    false,
+    false)
+  val `Unicode-DFS-2016` = spdx(
+    "Unicode License Agreement - Data Files and Software (2016)",
+    "Unicode-DFS-2016",
+    false,
+    false)
+  val `Unicode-TOU` = spdx("Unicode Terms of Use", "Unicode-TOU", false, false)
+  val Unlicense = spdx("The Unlicense", "Unlicense", false, true)
+  val `UPL-1.0` =
+    spdx("Universal Permissive License v1.0", "UPL-1.0", true, true)
+  val Vim = spdx("Vim License", "Vim", false, true)
+  val VOSTROM =
+    spdx("VOSTROM Public License for Open Source", "VOSTROM", false, false)
+  val `VSL-1.0` = spdx("Vovida Software License v1.0", "VSL-1.0", true, false)
+  val `W3C-19980720` = spdx("W3C Software Notice and License (1998-07-20)",
+                            "W3C-19980720",
+                            false,
+                            false)
+  val `W3C-20150513` = spdx(
+    "W3C Software Notice and Document License (2015-05-13)",
+    "W3C-20150513",
+    false,
+    false)
+  val W3C =
+    spdx("W3C Software Notice and License (2002-12-31)", "W3C", true, true)
+  val `Watcom-1.0` =
+    spdx("Sybase Open Watcom Public License 1.0", "Watcom-1.0", true, false)
+  val Wsuipa = spdx("Wsuipa License", "Wsuipa", false, false)
+  val WTFPL =
+    spdx("Do What The F*ck You Want To Public License", "WTFPL", false, true)
+  val X11 = spdx("X11 License", "X11", false, true)
+  val Xerox = spdx("Xerox License", "Xerox", false, false)
+  val `XFree86-1.1` = spdx("XFree86 License 1.1", "XFree86-1.1", false, true)
+  val xinetd = spdx("xinetd License", "xinetd", false, true)
+  val Xnet = spdx("X.Net License", "Xnet", true, false)
+  val xpp = spdx("XPP License", "xpp", false, false)
+  val XSkat = spdx("XSkat License", "XSkat", false, false)
+  val `YPL-1.0` = spdx("Yahoo! Public License v1.0", "YPL-1.0", false, false)
+  val `YPL-1.1` = spdx("Yahoo! Public License v1.1", "YPL-1.1", false, true)
+  val Zed = spdx("Zed License", "Zed", false, false)
+  val `Zend-2.0` = spdx("Zend License v2.0", "Zend-2.0", false, true)
+  val `Zimbra-1.3` =
+    spdx("Zimbra Public License v1.3", "Zimbra-1.3", false, true)
+  val `Zimbra-1.4` =
+    spdx("Zimbra Public License v1.4", "Zimbra-1.4", false, false)
+  val `zlib-acknowledgement` = spdx("zlib/libpng License with Acknowledgement",
+                                    "zlib-acknowledgement",
+                                    false,
+                                    false)
+  val Zlib = spdx("zlib License", "Zlib", true, true)
+  val `ZPL-1.1` = spdx("Zope Public License 1.1", "ZPL-1.1", false, false)
+  val `ZPL-2.0` = spdx("Zope Public License 2.0", "ZPL-2.0", true, true)
+  val `ZPL-2.1` = spdx("Zope Public License 2.1", "ZPL-2.1", false, true)
+  val `AGPL-3.0` =
+    spdx("GNU Affero General Public License v3.0", "AGPL-3.0", true, false)
+  val `eCos-2.0` = spdx("eCos license version 2.0", "eCos-2.0", false, false)
+  val `GFDL-1.1` =
+    spdx("GNU Free Documentation License v1.1", "GFDL-1.1", false, false)
+  val `GFDL-1.2` =
+    spdx("GNU Free Documentation License v1.2", "GFDL-1.2", false, false)
+  val `GFDL-1.3` =
+    spdx("GNU Free Documentation License v1.3", "GFDL-1.3", false, false)
+  val `GPL-1.0+` =
+    spdx("GNU General Public License v1.0 or later", "GPL-1.0+", false, false)
+  val `GPL-1.0` =
+    spdx("GNU General Public License v1.0 only", "GPL-1.0", false, false)
+  val `GPL-2.0+` =
+    spdx("GNU General Public License v2.0 or later", "GPL-2.0+", true, false)
+  val `GPL-2.0-with-autoconf-exception` = spdx(
+    "GNU General Public License v2.0 w/Autoconf exception",
+    "GPL-2.0-with-autoconf-exception",
+    false,
+    false)
+  val `GPL-2.0-with-bison-exception` = spdx(
+    "GNU General Public License v2.0 w/Bison exception",
+    "GPL-2.0-with-bison-exception",
+    false,
+    false)
+  val `GPL-2.0-with-classpath-exception` = spdx(
+    "GNU General Public License v2.0 w/Classpath exception",
+    "GPL-2.0-with-classpath-exception",
+    false,
+    false)
+  val `GPL-2.0-with-font-exception` = spdx(
+    "GNU General Public License v2.0 w/Font exception",
+    "GPL-2.0-with-font-exception",
+    false,
+    false)
+  val `GPL-2.0-with-GCC-exception` = spdx(
+    "GNU General Public License v2.0 w/GCC Runtime Library exception",
+    "GPL-2.0-with-GCC-exception",
+    false,
+    false)
+  val `GPL-2.0` =
+    spdx("GNU General Public License v2.0 only", "GPL-2.0", true, false)
+  val `GPL-3.0+` =
+    spdx("GNU General Public License v3.0 or later", "GPL-3.0+", true, false)
+  val `GPL-3.0-with-autoconf-exception` = spdx(
+    "GNU General Public License v3.0 w/Autoconf exception",
+    "GPL-3.0-with-autoconf-exception",
+    false,
+    false)
+  val `GPL-3.0-with-GCC-exception` = spdx(
+    "GNU General Public License v3.0 w/GCC Runtime Library exception",
+    "GPL-3.0-with-GCC-exception",
+    true,
+    false)
+  val `GPL-3.0` =
+    spdx("GNU General Public License v3.0 only", "GPL-3.0", true, false)
+  val `LGPL-2.0+` = spdx("GNU Library General Public License v2 or later",
+                         "LGPL-2.0+",
+                         true,
+                         false)
+  val `LGPL-2.0` =
+    spdx("GNU Library General Public License v2 only", "LGPL-2.0", true, false)
+  val `LGPL-2.1+` = spdx("GNU Library General Public License v2 or later",
+                         "LGPL-2.1+",
+                         true,
+                         false)
+  val `LGPL-2.1` =
+    spdx("GNU Lesser General Public License v2.1 only", "LGPL-2.1", true, false)
+  val `LGPL-3.0+` = spdx("GNU Lesser General Public License v3.0 or later",
+                         "LGPL-3.0+",
+                         true,
+                         false)
+  val `LGPL-3.0` =
+    spdx("GNU Lesser General Public License v3.0 only", "LGPL-3.0", true, false)
+  val Nunit = spdx("Nunit License", "Nunit", false, false)
+  val `StandardML-NJ` =
+    spdx("Standard ML of New Jersey License", "StandardML-NJ", false, false)
+  val wxWindows = spdx("wxWindows Library License", "wxWindows", false, false)
 
-  private def spdx(fullName: String, id: String, isOsiApproved: Boolean, isFsfLibre: Boolean): License = 
-    License(fullName, id, s"https://spdx.org/licenses/$id.html", isOsiApproved, isFsfLibre, "repo")
+  private def spdx(fullName: String,
+                   id: String,
+                   isOsiApproved: Boolean,
+                   isFsfLibre: Boolean): License =
+    License(fullName,
+            id,
+            s"https://spdx.org/licenses/$id.html",
+            isOsiApproved,
+            isFsfLibre,
+            "repo")
 
   val PublicDomain = License(
     id = "Public Domain",
@@ -462,7 +880,8 @@ object License {
   val TypesafeSubscriptionAgreement = License(
     id = "Typesafe Subscription Agreement",
     name = "Typesafe Subscription Agreement",
-    url = "http://downloads.typesafe.com/website/legal/TypesafeSubscriptionAgreement.pdf",
+    url =
+      "http://downloads.typesafe.com/website/legal/TypesafeSubscriptionAgreement.pdf",
     isOsiApproved = false,
     isFsfLibre = false,
     distribution = "repo"
@@ -470,10 +889,10 @@ object License {
 
   // https://github.com/sbt/sbt/issues/1937#issuecomment-214963983
   object Common {
-    val Apache2  = License.`Apache-2.0`
-    val MIT      = License.MIT
-    val BSD4     = License.`BSD-4-Clause`
+    val Apache2 = License.`Apache-2.0`
+    val MIT = License.MIT
+    val BSD4 = License.`BSD-4-Clause`
     val Typesafe = License.TypesafeSubscriptionAgreement
-    val BSD3     = License.`BSD-3-Clause`
+    val BSD3 = License.`BSD-3-Clause`
   }
 }

--- a/scalalib/src/mill/scalalib/publish/Pom.scala
+++ b/scalalib/src/mill/scalalib/publish/Pom.scala
@@ -10,16 +10,18 @@ object Pom {
 
   implicit class XmlOps(val e: Elem) extends AnyVal {
     // source: https://stackoverflow.com/a/5254068/449071
-    def optional : NodeSeq = {
+    def optional: NodeSeq = {
       require(e.child.length == 1)
       e.child.head match {
-        case atom: Atom[Option[_]] => atom.data match {
-          case None    => NodeSeq.Empty
-          case Some(x) => e.copy(child = x match {
-            case n: NodeSeq => n
-            case x => new Atom(x)
-          })
-        }
+        case atom: Atom[Option[_]] =>
+          atom.data match {
+            case None => NodeSeq.Empty
+            case Some(x) =>
+              e.copy(child = x match {
+                case n: NodeSeq => n
+                case x          => new Atom(x)
+              })
+          }
         case _ => e
       }
     }

--- a/scalalib/src/mill/scalalib/publish/SonatypeHttpApi.scala
+++ b/scalalib/src/mill/scalalib/publish/SonatypeHttpApi.scala
@@ -2,8 +2,6 @@ package mill.scalalib.publish
 
 import java.util.Base64
 
-
-
 import scala.concurrent.duration._
 import scalaj.http.{BaseHttp, HttpOptions, HttpRequest, HttpResponse}
 
@@ -29,8 +27,7 @@ class SonatypeHttpApi(uri: String, credentials: String) {
   // https://oss.sonatype.org/nexus-staging-plugin/default/docs/path__staging_profiles.html
   def getStagingProfileUri(groupId: String): String = {
     val response = withRetry(
-      PatientHttp(s"$uri/staging/profiles").headers(commonHeaders))
-        .throwError
+      PatientHttp(s"$uri/staging/profiles").headers(commonHeaders)).throwError
 
     val resourceUri =
       ujson
@@ -60,8 +57,7 @@ class SonatypeHttpApi(uri: String, credentials: String) {
     val response = withRetry(PatientHttp(s"${profileUri}/start")
       .headers(commonHeaders)
       .postData(
-        s"""{"data": {"description": "fresh staging profile for ${groupId}"}}"""))
-      .throwError
+        s"""{"data": {"description": "fresh staging profile for ${groupId}"}}""")).throwError
 
     ujson.read(response.body)("data")("stagedRepositoryId").str.toString
   }

--- a/scalalib/src/mill/scalalib/publish/SonatypePublisher.scala
+++ b/scalalib/src/mill/scalalib/publish/SonatypePublisher.scala
@@ -17,10 +17,13 @@ class SonatypePublisher(uri: String,
 
   private val api = new SonatypeHttpApi(uri, credentials)
 
-  def publish(fileMapping: Seq[(Path, String)], artifact: Artifact, release: Boolean): Unit = {
+  def publish(fileMapping: Seq[(Path, String)],
+              artifact: Artifact,
+              release: Boolean): Unit = {
     publishAll(release, fileMapping -> artifact)
   }
-  def publishAll(release: Boolean, artifacts: (Seq[(Path, String)], Artifact)*): Unit = {
+  def publishAll(release: Boolean,
+                 artifacts: (Seq[(Path, String)], Artifact)*): Unit = {
 
     val mappings = for ((fileMapping0, artifact) <- artifacts) yield {
       val publishPath = Seq(
@@ -28,7 +31,9 @@ class SonatypePublisher(uri: String,
         artifact.id,
         artifact.version
       ).mkString("/")
-      val fileMapping = fileMapping0.map{ case (file, name) => (file, publishPath+"/"+name) }
+      val fileMapping = fileMapping0.map {
+        case (file, name) => (file, publishPath + "/" + name)
+      }
 
       val signedArtifacts = if (signed) fileMapping.map {
         case (file, name) => poorMansSign(file, gpgPassphrase) -> s"$name.asc"
@@ -47,12 +52,15 @@ class SonatypePublisher(uri: String,
     }
 
     val (snapshots, releases) = mappings.partition(_._1.isSnapshot)
-    if(snapshots.nonEmpty) {
+    if (snapshots.nonEmpty) {
       publishSnapshot(snapshots.flatMap(_._2), snapshots.map(_._1))
     }
     val releaseGroups = releases.groupBy(_._1.group)
-    for((group, groupReleases) <- releaseGroups){
-      publishRelease(release, groupReleases.flatMap(_._2), group, releases.map(_._1))
+    for ((group, groupReleases) <- releaseGroups) {
+      publishRelease(release,
+                     groupReleases.flatMap(_._2),
+                     group,
+                     releases.map(_._1))
     }
   }
 
@@ -136,12 +144,20 @@ class SonatypePublisher(uri: String,
   }
 
   // http://central.sonatype.org/pages/working-with-pgp-signatures.html#signing-a-file
-  private def poorMansSign(file: Path, maybePassphrase: Option[String]): Path = {
+  private def poorMansSign(file: Path,
+                           maybePassphrase: Option[String]): Path = {
     val fileName = file.toString
     import ammonite.ops.ImplicitWd._
     maybePassphrase match {
       case Some(passphrase) =>
-        %("gpg", "--passphrase", passphrase, "--batch", "--yes", "-a", "-b", fileName)
+        %("gpg",
+          "--passphrase",
+          passphrase,
+          "--batch",
+          "--yes",
+          "-a",
+          "-b",
+          fileName)
       case None =>
         %("gpg", "--batch", "--yes", "-a", "-b", fileName)
     }

--- a/scalalib/src/mill/scalalib/publish/VersionControl.scala
+++ b/scalalib/src/mill/scalalib/publish/VersionControl.scala
@@ -14,10 +14,10 @@ package mill.scalalib.publish
  *        (example: v2.12.4, HEAD, my-branch, fd8a2567ad32c11bcf8adbaca85bdba72bb4f935, ...)
  */
 case class VersionControl(
-  browsableRepository: Option[String] = None,
-  connection: Option[String] = None,
-  developerConnection: Option[String] = None,
-  tag: Option[String] = None
+    browsableRepository: Option[String] = None,
+    connection: Option[String] = None,
+    developerConnection: Option[String] = None,
+    tag: Option[String] = None
 )
 
 @deprecated("use VersionControl", "0.1.3")
@@ -27,11 +27,16 @@ case class SCM(
 )
 
 object VersionControl {
-  def github(owner: String, repo: String, tag: Option[String] = None): VersionControl = 
+  def github(owner: String,
+             repo: String,
+             tag: Option[String] = None): VersionControl =
     VersionControl(
       browsableRepository = Some(s"https://github.com/$owner/$repo"),
-      connection = Some(VersionControlConnection.gitGit("github.com", s"$owner/$repo.git")),
-      developerConnection = Some(VersionControlConnection.gitSsh("github.com", s":$owner/$repo.git", username = Some("git"))),
+      connection = Some(
+        VersionControlConnection.gitGit("github.com", s"$owner/$repo.git")),
+      developerConnection = Some(
+        VersionControlConnection
+          .gitSsh("github.com", s":$owner/$repo.git", username = Some("git"))),
       tag = tag
     )
 }
@@ -53,12 +58,12 @@ object VersionControlConnection {
         case None =>
           password match {
             case Some(p) => sys.error(s"no username set for password: $p")
-            case _ => ""
+            case _       => ""
           }
       }
 
     val path0 =
-      if(path.startsWith(":") || path.startsWith("/")) path
+      if (path.startsWith(":") || path.startsWith("/")) path
       else "/" + path
 
     s"scm:${scm}:${protocol}://${credentials}${hostname}${portPart}${path0}"
@@ -70,7 +75,7 @@ object VersionControlConnection {
 
   def gitGit(hostname: String,
              path: String = "",
-             port: Option[Int] = None): String = 
+             port: Option[Int] = None): String =
     network("git", "git", hostname, path, port = port)
 
   def gitHttp(hostname: String,

--- a/scalalib/src/mill/scalalib/publish/settings.scala
+++ b/scalalib/src/mill/scalalib/publish/settings.scala
@@ -18,9 +18,7 @@ object Artifact {
         )
     }
   }
-  def fromDep(dep: Dep,
-              scalaFull: String,
-              scalaBin: String): Dependency = {
+  def fromDep(dep: Dep, scalaFull: String, scalaBin: String): Dependency = {
     dep match {
       case d: Dep.Java => fromDepJava(d)
       case Dep.Scala(dep, cross, force) =>

--- a/scalalib/test/src/mill/scalalib/GenIdeaTests.scala
+++ b/scalalib/test/src/mill/scalalib/GenIdeaTests.scala
@@ -26,36 +26,37 @@ object GenIdeaTests extends TestSuite {
     'genIdeaTests - {
       val pp = new scala.xml.PrettyPrinter(999, 4)
 
-      val layout = GenIdeaImpl.xmlFileLayout(
-        helloWorldEvaluator.evaluator,
-        HelloWorld,
-        ("JDK_1_8", "1.8 (1)"), fetchMillModules = false)
-      for((relPath, xml) <- layout){
-        write.over(millSourcePath/ "generated"/ relPath, pp.format(xml))
+      val layout = GenIdeaImpl.xmlFileLayout(helloWorldEvaluator.evaluator,
+                                             HelloWorld,
+                                             ("JDK_1_8", "1.8 (1)"),
+                                             fetchMillModules = false)
+      for ((relPath, xml) <- layout) {
+        write.over(millSourcePath / "generated" / relPath, pp.format(xml))
       }
 
       Seq(
         "gen-idea/idea_modules/iml" ->
-          millSourcePath / "generated" / ".idea_modules" /".iml",
+          millSourcePath / "generated" / ".idea_modules" / ".iml",
         "gen-idea/idea_modules/test.iml" ->
-          millSourcePath / "generated" / ".idea_modules" /"test.iml",
+          millSourcePath / "generated" / ".idea_modules" / "test.iml",
         "gen-idea/idea_modules/mill-build.iml" ->
-          millSourcePath / "generated" / ".idea_modules" /"mill-build.iml",
+          millSourcePath / "generated" / ".idea_modules" / "mill-build.iml",
         "gen-idea/idea/libraries/scala-library-2.12.4.jar.xml" ->
           millSourcePath / "generated" / ".idea" / "libraries" / "scala-library-2.12.4.jar.xml",
         "gen-idea/idea/modules.xml" ->
           millSourcePath / "generated" / ".idea" / "modules.xml",
         "gen-idea/idea/misc.xml" ->
           millSourcePath / "generated" / ".idea" / "misc.xml"
-      ).foreach { case (resource, generated) =>
-          val resourceString = scala.io.Source.fromResource(resource).getLines().mkString("\n")
-          val generatedString = normaliseLibraryPaths(read! generated)
+      ).foreach {
+        case (resource, generated) =>
+          val resourceString =
+            scala.io.Source.fromResource(resource).getLines().mkString("\n")
+          val generatedString = normaliseLibraryPaths(read ! generated)
 
           assert(resourceString == generatedString)
-        }
+      }
     }
   }
-
 
   private def normaliseLibraryPaths(in: String): String = {
     in.replaceAll(Cache.default.toPath.toAbsolutePath.toString, "COURSIER_HOME")

--- a/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloJavaTests.scala
@@ -1,7 +1,6 @@
 package mill
 package scalalib
 
-
 import ammonite.ops.{%, %%, cp, ls, mkdir, pwd, rm, up}
 import ammonite.ops.ImplicitWd._
 import mill.eval.Result
@@ -9,20 +8,20 @@ import mill.util.{TestEvaluator, TestUtil}
 import utest._
 import utest.framework.TestPath
 
-
 object HelloJavaTests extends TestSuite {
 
-  object HelloJava extends TestUtil.BaseModule{
-    def millSourcePath =  TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
-    trait JUnitTests extends TestModule{
+  object HelloJava extends TestUtil.BaseModule {
+    def millSourcePath =
+      TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+    trait JUnitTests extends TestModule {
       def testFrameworks = Seq("com.novocode.junit.JUnitFramework")
       def ivyDeps = Agg(ivy"com.novocode:junit-interface:0.11")
     }
 
-    object core extends JavaModule{
+    object core extends JavaModule {
       object test extends Tests with JUnitTests
     }
-    object app extends JavaModule{
+    object app extends JavaModule {
       def moduleDeps = Seq(core)
       object test extends Tests with JUnitTests
     }
@@ -55,7 +54,7 @@ object HelloJavaTests extends TestSuite {
         !ls.rec(res3.classes.path).exists(_.last == "Core.class")
       )
     }
-    'docJar  - {
+    'docJar - {
       val eval = init()
 
       val Right((ref1, _)) = eval.apply(HelloJava.core.docJar)
@@ -69,7 +68,8 @@ object HelloJavaTests extends TestSuite {
     'test - {
       val eval = init()
 
-      val Left(Result.Failure(ref1, Some(v1))) = eval.apply(HelloJava.core.test.test())
+      val Left(Result.Failure(ref1, Some(v1))) =
+        eval.apply(HelloJava.core.test.test())
 
       assert(
         v1._2(0).fullyQualifiedName == "hello.MyCoreTests.lengthTest",
@@ -106,8 +106,10 @@ object HelloJavaTests extends TestSuite {
       val Left(_) = eval.apply(HelloJava.core.compile)
       val Left(_) = eval.apply(HelloJava.app.compile)
 
-      ammonite.ops.write.over(mainJava, ammonite.ops.read(mainJava).dropRight(1))
-      ammonite.ops.write.over(coreJava, ammonite.ops.read(coreJava).dropRight(1))
+      ammonite.ops.write.over(mainJava,
+                              ammonite.ops.read(mainJava).dropRight(1))
+      ammonite.ops.write.over(coreJava,
+                              ammonite.ops.read(coreJava).dropRight(1))
 
       val Right(_) = eval.apply(HelloJava.core.compile)
       val Right(_) = eval.apply(HelloJava.app.compile)

--- a/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
+++ b/scalalib/test/src/mill/scalalib/HelloWorldTests.scala
@@ -16,22 +16,27 @@ import utest.framework.TestPath
 
 import scala.collection.JavaConverters._
 
-
 object HelloWorldTests extends TestSuite {
-  trait HelloBase extends TestUtil.BaseModule{
-    def millSourcePath =  TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+  trait HelloBase extends TestUtil.BaseModule {
+    def millSourcePath =
+      TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
   }
   trait HelloWorldModule extends scalalib.ScalaModule {
     def scalaVersion = "2.12.4"
   }
 
-
   object HelloWorld extends HelloBase {
     object core extends HelloWorldModule
   }
   object CrossHelloWorld extends HelloBase {
-    object core extends Cross[HelloWorldCross]("2.10.6", "2.11.11", "2.12.3", "2.12.4", "2.13.0-M3")
-    class HelloWorldCross(val crossScalaVersion: String) extends CrossScalaModule
+    object core
+        extends Cross[HelloWorldCross]("2.10.6",
+                                       "2.11.11",
+                                       "2.12.3",
+                                       "2.12.4",
+                                       "2.13.0-M3")
+    class HelloWorldCross(val crossScalaVersion: String)
+        extends CrossScalaModule
   }
 
   object HelloWorldDefaultMain extends HelloBase {
@@ -39,32 +44,32 @@ object HelloWorldTests extends TestSuite {
   }
 
   object HelloWorldWithoutMain extends HelloBase {
-    object core extends HelloWorldModule{
+    object core extends HelloWorldModule {
       def mainClass = None
     }
   }
 
   object HelloWorldWithMain extends HelloBase {
-    object core extends HelloWorldModule{
+    object core extends HelloWorldModule {
       def mainClass = Some("Main")
     }
   }
 
-  object HelloWorldWarnUnused extends HelloBase{
+  object HelloWorldWarnUnused extends HelloBase {
     object core extends HelloWorldModule {
       def scalacOptions = T(Seq("-Ywarn-unused"))
     }
   }
 
-  object HelloWorldFatalWarnings extends HelloBase{
+  object HelloWorldFatalWarnings extends HelloBase {
     object core extends HelloWorldModule {
       def scalacOptions = T(Seq("-Ywarn-unused", "-Xfatal-warnings"))
     }
 
   }
 
-  object HelloWorldWithPublish extends HelloBase{
-    object core extends HelloWorldModule with PublishModule{
+  object HelloWorldWithPublish extends HelloBase {
+    object core extends HelloWorldModule with PublishModule {
 
       def artifactName = "hello-world"
       def publishVersion = "0.0.1"
@@ -81,14 +86,14 @@ object HelloWorldTests extends TestSuite {
     }
   }
 
-  object HelloWorldScalaOverride extends HelloBase{
+  object HelloWorldScalaOverride extends HelloBase {
     object core extends HelloWorldModule {
 
       override def scalaVersion: Target[String] = "2.11.11"
     }
   }
 
-  object HelloWorldIvyDeps extends HelloBase{
+  object HelloWorldIvyDeps extends HelloBase {
     object moduleA extends HelloWorldModule {
 
       override def ivyDeps = Agg(ivy"com.lihaoyi::sourcecode:0.1.3")
@@ -99,12 +104,13 @@ object HelloWorldTests extends TestSuite {
     }
   }
 
-  object HelloWorldTypeLevel extends HelloBase{
+  object HelloWorldTypeLevel extends HelloBase {
     object foo extends ScalaModule {
       def scalaVersion = "2.11.8"
       override def mapDependencies(d: coursier.Dependency) = {
         val artifacts = Set("scala-library", "scala-compiler", "scala-reflect")
-        if (d.module.organization != "org.scala-lang" || !artifacts(d.module.name)) d
+        if (d.module.organization != "org.scala-lang" || !artifacts(
+              d.module.name)) d
         else d.copy(module = d.module.copy(organization = "org.typelevel"))
       }
 
@@ -117,7 +123,7 @@ object HelloWorldTests extends TestSuite {
     }
   }
 
-  object HelloWorldMacros extends HelloBase{
+  object HelloWorldMacros extends HelloBase {
     object core extends ScalaModule {
       def scalaVersion = "2.12.4"
 
@@ -130,21 +136,21 @@ object HelloWorldTests extends TestSuite {
     }
   }
 
-  object HelloWorldFlags extends HelloBase{
+  object HelloWorldFlags extends HelloBase {
     object core extends ScalaModule {
       def scalaVersion = "2.12.4"
-      
+
       def scalacOptions = super.scalacOptions() ++ Seq(
         "-Ypartial-unification"
       )
     }
   }
 
-  object HelloScalacheck extends HelloBase{
+  object HelloScalacheck extends HelloBase {
     object foo extends ScalaModule {
       def scalaVersion = "2.12.4"
       object test extends Tests {
-        def ivyDeps     = Agg(ivy"org.scalacheck::scalacheck:1.13.5")
+        def ivyDeps = Agg(ivy"org.scalacheck::scalacheck:1.13.5")
         def testFrameworks = Seq("org.scalacheck.ScalaCheckFramework")
       }
     }
@@ -168,9 +174,10 @@ object HelloWorldTests extends TestSuite {
     "Person$.class"
   )
 
-  def workspaceTest[T, M <: TestUtil.BaseModule](m: M, resourcePath: Path = resourcePath)
-                                                (t: TestEvaluator[M] => T)
-                                                (implicit tp: TestPath): T = {
+  def workspaceTest[T, M <: TestUtil.BaseModule](
+      m: M,
+      resourcePath: Path = resourcePath)(t: TestEvaluator[M] => T)(
+      implicit tp: TestPath): T = {
     val eval = new TestEvaluator(m)
     rm(m.millSourcePath)
     rm(eval.outPath)
@@ -178,23 +185,22 @@ object HelloWorldTests extends TestSuite {
     cp(resourcePath, m.millSourcePath)
     t(eval)
   }
-  
-
-
 
   def tests: Tests = Tests {
     'scalaVersion - {
-      
-      'fromBuild - workspaceTest(HelloWorld){eval => 
-        val Right((result, evalCount)) = eval.apply(HelloWorld.core.scalaVersion)
+
+      'fromBuild - workspaceTest(HelloWorld) { eval =>
+        val Right((result, evalCount)) =
+          eval.apply(HelloWorld.core.scalaVersion)
 
         assert(
           result == "2.12.4",
           evalCount > 0
         )
       }
-      'override - workspaceTest(HelloWorldScalaOverride){eval =>
-        val Right((result, evalCount)) = eval.apply(HelloWorldScalaOverride.core.scalaVersion)
+      'override - workspaceTest(HelloWorldScalaOverride) { eval =>
+        val Right((result, evalCount)) =
+          eval.apply(HelloWorldScalaOverride.core.scalaVersion)
 
         assert(
           result == "2.11.11",
@@ -204,16 +210,18 @@ object HelloWorldTests extends TestSuite {
     }
 
     'scalacOptions - {
-      'emptyByDefault - workspaceTest(HelloWorld){eval =>
-        val Right((result, evalCount)) = eval.apply(HelloWorld.core.scalacOptions)
+      'emptyByDefault - workspaceTest(HelloWorld) { eval =>
+        val Right((result, evalCount)) =
+          eval.apply(HelloWorld.core.scalacOptions)
 
         assert(
           result.isEmpty,
           evalCount > 0
         )
       }
-      'override - workspaceTest(HelloWorldFatalWarnings){ eval =>
-        val Right((result, evalCount)) = eval.apply(HelloWorldFatalWarnings.core.scalacOptions)
+      'override - workspaceTest(HelloWorldFatalWarnings) { eval =>
+        val Right((result, evalCount)) =
+          eval.apply(HelloWorldFatalWarnings.core.scalacOptions)
 
         assert(
           result == Seq("-Ywarn-unused", "-Xfatal-warnings"),
@@ -223,7 +231,7 @@ object HelloWorldTests extends TestSuite {
     }
 
     'compile - {
-      'fromScratch - workspaceTest(HelloWorld){eval =>
+      'fromScratch - workspaceTest(HelloWorld) { eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorld.core.compile)
 
         val analysisFile = result.analysisFile
@@ -244,20 +252,22 @@ object HelloWorldTests extends TestSuite {
 
         assert(unchangedEvalCount == 0)
       }
-      'recompileOnChange - workspaceTest(HelloWorld){eval =>
+      'recompileOnChange - workspaceTest(HelloWorld) { eval =>
         val Right((_, freshCount)) = eval.apply(HelloWorld.core.compile)
         assert(freshCount > 0)
 
-        write.append(HelloWorld.millSourcePath / 'core / 'src / "Main.scala", "\n")
+        write.append(HelloWorld.millSourcePath / 'core / 'src / "Main.scala",
+                     "\n")
 
         val Right((_, incCompileCount)) = eval.apply(HelloWorld.core.compile)
         assert(incCompileCount > 0, incCompileCount < freshCount)
       }
-      'failOnError - workspaceTest(HelloWorld){eval =>
-        write.append(HelloWorld.millSourcePath / 'core / 'src / "Main.scala", "val x: ")
+      'failOnError - workspaceTest(HelloWorld) { eval =>
+        write.append(HelloWorld.millSourcePath / 'core / 'src / "Main.scala",
+                     "val x: ")
 
-        val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorld.core.compile)
-
+        val Left(Result.Failure("Compilation failed", _)) =
+          eval.apply(HelloWorld.core.compile)
 
         val paths = Evaluator.resolveDestPaths(
           eval.outPath,
@@ -271,23 +281,26 @@ object HelloWorldTests extends TestSuite {
         // Works when fixed
         write.over(
           HelloWorld.millSourcePath / 'core / 'src / "Main.scala",
-          read(HelloWorld.millSourcePath / 'core / 'src / "Main.scala").dropRight("val x: ".length)
+          read(HelloWorld.millSourcePath / 'core / 'src / "Main.scala")
+            .dropRight("val x: ".length)
         )
 
         val Right((result, evalCount)) = eval.apply(HelloWorld.core.compile)
       }
-      'passScalacOptions - workspaceTest(HelloWorldFatalWarnings){ eval =>
+      'passScalacOptions - workspaceTest(HelloWorldFatalWarnings) { eval =>
         // compilation fails because of "-Xfatal-warnings" flag
-        val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorldFatalWarnings.core.compile)
+        val Left(Result.Failure("Compilation failed", _)) =
+          eval.apply(HelloWorldFatalWarnings.core.compile)
 
       }
     }
 
     'runMain - {
-      'runMainObject - workspaceTest(HelloWorld){eval =>
+      'runMainObject - workspaceTest(HelloWorld) { eval =>
         val runResult = eval.outPath / 'core / 'runMain / 'dest / "hello-mill"
 
-        val Right((_, evalCount)) = eval.apply(HelloWorld.core.runMain("Main", runResult.toString))
+        val Right((_, evalCount)) =
+          eval.apply(HelloWorld.core.runMain("Main", runResult.toString))
         assert(evalCount > 0)
 
         assert(
@@ -306,40 +319,45 @@ object HelloWorldTests extends TestSuite {
 
           assert(evalCount > 0)
 
-
           assert(
             exists(runResult),
             read(runResult) == expectedOut
           )
         }
-        'v210 - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(_, "2.10.6", "2.10.6 rox")))
-        'v211 - TestUtil.disableInJava9OrAbove(workspaceTest(CrossHelloWorld)(cross(_, "2.11.11", "2.11.11 pwns")))
-        'v2123 - workspaceTest(CrossHelloWorld)(cross(_, "2.12.3", "2.12.3 leet"))
-        'v2124 - workspaceTest(CrossHelloWorld)(cross(_, "2.12.4", "2.12.4 leet"))
-        'v2130M3 - workspaceTest(CrossHelloWorld)(cross(_, "2.13.0-M3", "2.13.0-M3 idk"))
+        'v210 - TestUtil.disableInJava9OrAbove(
+          workspaceTest(CrossHelloWorld)(cross(_, "2.10.6", "2.10.6 rox")))
+        'v211 - TestUtil.disableInJava9OrAbove(
+          workspaceTest(CrossHelloWorld)(cross(_, "2.11.11", "2.11.11 pwns")))
+        'v2123 - workspaceTest(CrossHelloWorld)(
+          cross(_, "2.12.3", "2.12.3 leet"))
+        'v2124 - workspaceTest(CrossHelloWorld)(
+          cross(_, "2.12.4", "2.12.4 leet"))
+        'v2130M3 - workspaceTest(CrossHelloWorld)(
+          cross(_, "2.13.0-M3", "2.13.0-M3 idk"))
       }
 
-
-      'notRunInvalidMainObject - workspaceTest(HelloWorld){eval =>
-        val Left(Result.Failure("subprocess failed", _)) = eval.apply(HelloWorld.core.runMain("Invalid"))
+      'notRunInvalidMainObject - workspaceTest(HelloWorld) { eval =>
+        val Left(Result.Failure("subprocess failed", _)) =
+          eval.apply(HelloWorld.core.runMain("Invalid"))
       }
-      'notRunWhenCompileFailed - workspaceTest(HelloWorld){eval =>
-        write.append(HelloWorld.millSourcePath / 'core / 'src / "Main.scala", "val x: ")
+      'notRunWhenCompileFailed - workspaceTest(HelloWorld) { eval =>
+        write.append(HelloWorld.millSourcePath / 'core / 'src / "Main.scala",
+                     "val x: ")
 
-        val Left(Result.Failure("Compilation failed", _)) = eval.apply(HelloWorld.core.runMain("Main"))
+        val Left(Result.Failure("Compilation failed", _)) =
+          eval.apply(HelloWorld.core.runMain("Main"))
 
       }
     }
 
     'forkRun - {
-      'runIfMainClassProvided - workspaceTest(HelloWorldWithMain){eval =>
+      'runIfMainClassProvided - workspaceTest(HelloWorldWithMain) { eval =>
         val runResult = eval.outPath / 'core / 'run / 'dest / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldWithMain.core.run(runResult.toString)
         )
 
         assert(evalCount > 0)
-
 
         assert(
           exists(runResult),
@@ -349,11 +367,12 @@ object HelloWorldTests extends TestSuite {
       'notRunWithoutMainClass - workspaceTest(
         HelloWorldWithoutMain,
         pwd / 'scalalib / 'test / 'resources / "hello-world-no-main"
-      ){eval =>
-        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.run())
+      ) { eval =>
+        val Left(Result.Failure(_, None)) =
+          eval.apply(HelloWorldWithoutMain.core.run())
       }
 
-      'runDiscoverMainClass - workspaceTest(HelloWorldWithoutMain){eval =>
+      'runDiscoverMainClass - workspaceTest(HelloWorldWithoutMain) { eval =>
         // Make sure even if there isn't a main class defined explicitly, it gets
         // discovered by Zinc and used
         val runResult = eval.outPath / 'core / 'run / 'dest / "hello-mill"
@@ -363,7 +382,6 @@ object HelloWorldTests extends TestSuite {
 
         assert(evalCount > 0)
 
-
         assert(
           exists(runResult),
           read(runResult) == "hello rockjam, your age is: 25"
@@ -372,7 +390,7 @@ object HelloWorldTests extends TestSuite {
     }
 
     'run - {
-      'runIfMainClassProvided - workspaceTest(HelloWorldWithMain){eval =>
+      'runIfMainClassProvided - workspaceTest(HelloWorldWithMain) { eval =>
         val runResult = eval.outPath / 'core / 'run / 'dest / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldWithMain.core.runLocal(runResult.toString)
@@ -380,20 +398,18 @@ object HelloWorldTests extends TestSuite {
 
         assert(evalCount > 0)
 
-
         assert(
           exists(runResult),
           read(runResult) == "hello rockjam, your age is: 25"
         )
       }
-      'runWithDefaultMain - workspaceTest(HelloWorldDefaultMain){eval =>
+      'runWithDefaultMain - workspaceTest(HelloWorldDefaultMain) { eval =>
         val runResult = eval.outPath / 'core / 'run / 'dest / "hello-mill"
         val Right((_, evalCount)) = eval.apply(
           HelloWorldDefaultMain.core.runLocal(runResult.toString)
         )
 
         assert(evalCount > 0)
-
 
         assert(
           exists(runResult),
@@ -403,14 +419,15 @@ object HelloWorldTests extends TestSuite {
       'notRunWithoutMainClass - workspaceTest(
         HelloWorldWithoutMain,
         pwd / 'scalalib / 'test / 'resources / "hello-world-no-main"
-      ){eval =>
-        val Left(Result.Failure(_, None)) = eval.apply(HelloWorldWithoutMain.core.runLocal())
+      ) { eval =>
+        val Left(Result.Failure(_, None)) =
+          eval.apply(HelloWorldWithoutMain.core.runLocal())
 
       }
     }
 
     'jar - {
-      'nonEmpty - workspaceTest(HelloWorldWithMain){eval =>
+      'nonEmpty - workspaceTest(HelloWorldWithMain) { eval =>
         val Right((result, evalCount)) = eval.apply(HelloWorldWithMain.core.jar)
 
         assert(
@@ -435,7 +452,7 @@ object HelloWorldTests extends TestSuite {
         assert(mainClass.contains("Main"))
       }
 
-      'logOutputToFile - workspaceTest(HelloWorld){eval =>
+      'logOutputToFile - workspaceTest(HelloWorld) { eval =>
         val outPath = eval.outPath
         eval.apply(HelloWorld.core.compile)
 
@@ -445,8 +462,9 @@ object HelloWorldTests extends TestSuite {
     }
 
     'assembly - {
-      'assembly - workspaceTest(HelloWorldWithMain){ eval =>
-        val Right((result, evalCount)) = eval.apply(HelloWorldWithMain.core.assembly)
+      'assembly - workspaceTest(HelloWorldWithMain) { eval =>
+        val Right((result, evalCount)) =
+          eval.apply(HelloWorldWithMain.core.assembly)
         assert(
           exists(result.path),
           evalCount > 0
@@ -462,8 +480,9 @@ object HelloWorldTests extends TestSuite {
         assert(mainClass.contains("Main"))
       }
 
-      'run - workspaceTest(HelloWorldWithMain){eval =>
-        val Right((result, evalCount)) = eval.apply(HelloWorldWithMain.core.assembly)
+      'run - workspaceTest(HelloWorldWithMain) { eval =>
+        val Right((result, evalCount)) =
+          eval.apply(HelloWorldWithMain.core.assembly)
 
         assert(
           exists(result.path),
@@ -480,36 +499,41 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
-    'ivyDeps - workspaceTest(HelloWorldIvyDeps){ eval =>
-      val Right((result, _)) = eval.apply(HelloWorldIvyDeps.moduleA.runClasspath)
+    'ivyDeps - workspaceTest(HelloWorldIvyDeps) { eval =>
+      val Right((result, _)) =
+        eval.apply(HelloWorldIvyDeps.moduleA.runClasspath)
       assert(
         result.exists(_.path.last == "sourcecode_2.12-0.1.3.jar"),
         !result.exists(_.path.last == "sourcecode_2.12-0.1.4.jar")
       )
 
-      val Right((result2, _)) = eval.apply(HelloWorldIvyDeps.moduleB.runClasspath)
+      val Right((result2, _)) =
+        eval.apply(HelloWorldIvyDeps.moduleB.runClasspath)
       assert(
         result2.exists(_.path.last == "sourcecode_2.12-0.1.4.jar"),
         !result2.exists(_.path.last == "sourcecode_2.12-0.1.3.jar")
       )
     }
 
-    'typeLevel - workspaceTest(HelloWorldTypeLevel){ eval =>
+    'typeLevel - workspaceTest(HelloWorldTypeLevel) { eval =>
       val classPathsToCheck = Seq(
         HelloWorldTypeLevel.foo.runClasspath,
         HelloWorldTypeLevel.foo.ammoniteReplClasspath,
         HelloWorldTypeLevel.foo.compileClasspath
       )
-      for(cp <- classPathsToCheck){
+      for (cp <- classPathsToCheck) {
         val Right((result, _)) = eval.apply(cp)
         assert(
           // Make sure every relevant piece org.scala-lang has been substituted for org.typelevel
-          !result.map(_.toString).exists(x =>
-            x.contains("scala-lang") &&
-            (x.contains("scala-library") || x.contains("scala-compiler") || x.contains("scala-reflect"))
-          ),
-          result.map(_.toString).exists(x => x.contains("typelevel") && x.contains("scala-library"))
-
+          !result
+            .map(_.toString)
+            .exists(x =>
+              x.contains("scala-lang") &&
+                (x.contains("scala-library") || x
+                  .contains("scala-compiler") || x.contains("scala-reflect"))),
+          result
+            .map(_.toString)
+            .exists(x => x.contains("typelevel") && x.contains("scala-library"))
         )
       }
     }
@@ -519,15 +543,16 @@ object HelloWorldTests extends TestSuite {
       'runMain - workspaceTest(
         HelloWorldMacros,
         resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-world-macros"
-      ){ eval =>
-        val Right((_, evalCount)) = eval.apply(HelloWorldMacros.core.runMain("Main"))
+      ) { eval =>
+        val Right((_, evalCount)) =
+          eval.apply(HelloWorldMacros.core.runMain("Main"))
         assert(evalCount > 0)
       }
       // make sure macros are applied when compiling during scaladoc generation
       'docJar - workspaceTest(
         HelloWorldMacros,
         resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-world-macros"
-      ){ eval =>
+      ) { eval =>
         val Right((_, evalCount)) = eval.apply(HelloWorldMacros.core.docJar)
         assert(evalCount > 0)
       }
@@ -538,15 +563,16 @@ object HelloWorldTests extends TestSuite {
       'runMain - workspaceTest(
         HelloWorldFlags,
         resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-world-flags"
-      ){ eval =>
-        val Right((_, evalCount)) = eval.apply(HelloWorldFlags.core.runMain("Main"))
+      ) { eval =>
+        val Right((_, evalCount)) =
+          eval.apply(HelloWorldFlags.core.runMain("Main"))
         assert(evalCount > 0)
       }
       // make sure flags are passed during ScalaDoc generation
       'docJar - workspaceTest(
         HelloWorldFlags,
         resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-world-flags"
-      ){ eval =>
+      ) { eval =>
         val Right((_, evalCount)) = eval.apply(HelloWorldFlags.core.docJar)
         assert(evalCount > 0)
       }
@@ -555,7 +581,7 @@ object HelloWorldTests extends TestSuite {
     'scalacheck - workspaceTest(
       HelloScalacheck,
       resourcePath = pwd / 'scalalib / 'test / 'resources / "hello-scalacheck"
-    ){ eval =>
+    ) { eval =>
       val Right((res, evalCount)) = eval.apply(HelloScalacheck.foo.test.test())
       assert(
         evalCount > 0,

--- a/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
+++ b/scalalib/test/src/mill/scalalib/ResolveDepsTests.scala
@@ -8,7 +8,8 @@ import mill.util.Loose.Agg
 import utest._
 
 object ResolveDepsTests extends TestSuite {
-  val repos = Seq(Cache.ivy2Local, MavenRepository("https://repo1.maven.org/maven2"))
+  val repos =
+    Seq(Cache.ivy2Local, MavenRepository("https://repo1.maven.org/maven2"))
 
   def evalDeps(deps: Agg[Dep]): Result[Agg[PathRef]] = Lib.resolveDependencies(
     repos,
@@ -39,7 +40,8 @@ object ResolveDepsTests extends TestSuite {
     }
 
     'excludeTransitiveDeps - {
-      val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3".exclude("com.lihaoyi" -> "fansi_2.12"))
+      val deps = Agg(
+        ivy"com.lihaoyi::pprint:0.5.3".exclude("com.lihaoyi" -> "fansi_2.12"))
       val Success(paths) = evalDeps(deps)
       assert(!paths.exists(_.path.toString.contains("fansi_2.12")))
     }
@@ -47,7 +49,10 @@ object ResolveDepsTests extends TestSuite {
     'excludeTransitiveDepsByOrg - {
       val deps = Agg(ivy"com.lihaoyi::pprint:0.5.3".excludeOrg("com.lihaoyi"))
       val Success(paths) = evalDeps(deps)
-      assert(!paths.exists(path => path.path.toString.contains("com/lihaoyi") && !path.path.toString.contains("pprint_2.12")))
+      assert(
+        !paths.exists(path =>
+          path.path.toString.contains("com/lihaoyi") && !path.path.toString
+            .contains("pprint_2.12")))
     }
 
     'excludeTransitiveDepsByName - {

--- a/scalalib/test/src/mill/scalalib/VersionControlTests.scala
+++ b/scalalib/test/src/mill/scalalib/VersionControlTests.scala
@@ -16,9 +16,10 @@ object VersionContolTests extends TestSuite {
           VersionControl(
             browsableRepository = Some("https://github.com/lihaoyi/mill"),
             connection = Some("scm:git:git://github.com/lihaoyi/mill.git"),
-            developerConnection = Some("scm:git:ssh://git@github.com:lihaoyi/mill.git"),
+            developerConnection =
+              Some("scm:git:ssh://git@github.com:lihaoyi/mill.git"),
             tag = None
-          )        
+          )
       )
     }
     'git - {
@@ -51,7 +52,7 @@ object VersionContolTests extends TestSuite {
     'svn - {
       assert(
         svnSsh("example.org", "repo") ==
-         "scm:svn:svn+ssh://example.org/repo"
+          "scm:svn:svn+ssh://example.org/repo"
       )
       assert(
         svnHttp("example.org", "repo", Some("user"), Some("pass")) ==

--- a/scalalib/test/src/mill/scalalib/publish/IvyTests.scala
+++ b/scalalib/test/src/mill/scalalib/publish/IvyTests.scala
@@ -13,11 +13,13 @@ object IvyTests extends TestSuite {
       Artifact("com.lihaoyi", "mill-scalalib_2.12", "0.0.1")
     val deps = Agg(
       Dependency(Artifact("com.lihaoyi", "mill-main_2.12", "0.1.4"),
-        Scope.Compile),
+                 Scope.Compile),
       Dependency(Artifact("org.scala-sbt", "test-interface", "1.0"),
-        Scope.Compile),
+                 Scope.Compile),
       Dependency(Artifact("com.lihaoyi", "pprint_2.12", "0.5.3"),
-        Scope.Compile, exclusions = List("com.lihaoyi" -> "fansi_2.12", "*" -> "sourcecode_2.12"))
+                 Scope.Compile,
+                 exclusions = List("com.lihaoyi" -> "fansi_2.12",
+                                   "*" -> "sourcecode_2.12"))
     )
 
     'fullIvy - {
@@ -38,16 +40,22 @@ object IvyTests extends TestSuite {
 
         assert(dependencies.size == ivyDeps.size)
 
-        dependencies.zipWithIndex.foreach { case (dep, index) =>
-          assert(
-            singleAttr(dep, "org") == ivyDeps(index).artifact.group,
-            singleAttr(dep, "name") == ivyDeps(index).artifact.id,
-            singleAttr(dep, "rev") == ivyDeps(index).artifact.version,
-            (dep \ "exclude").zipWithIndex forall { case (exclude, j) =>
-              singleAttr(exclude, "org") == ivyDeps(index).exclusions(j)._1 &&
-                singleAttr(exclude, "name") == ivyDeps(index).exclusions(j)._2
-            }
-          )
+        dependencies.zipWithIndex.foreach {
+          case (dep, index) =>
+            assert(
+              singleAttr(dep, "org") == ivyDeps(index).artifact.group,
+              singleAttr(dep, "name") == ivyDeps(index).artifact.id,
+              singleAttr(dep, "rev") == ivyDeps(index).artifact.version,
+              (dep \ "exclude").zipWithIndex forall {
+                case (exclude, j) =>
+                  singleAttr(exclude, "org") == ivyDeps(index)
+                    .exclusions(j)
+                    ._1 &&
+                    singleAttr(exclude, "name") == ivyDeps(index)
+                      .exclusions(j)
+                      ._2
+              }
+            )
         }
       }
     }
@@ -56,5 +64,8 @@ object IvyTests extends TestSuite {
   def singleNode(seq: NodeSeq): Node =
     seq.headOption.getOrElse(throw new RuntimeException("empty seq"))
   def singleAttr(node: Node, attr: String): String =
-    node.attribute(attr).flatMap(_.headOption.map(_.text)).getOrElse(throw new RuntimeException(s"empty attr $attr"))
+    node
+      .attribute(attr)
+      .flatMap(_.headOption.map(_.text))
+      .getOrElse(throw new RuntimeException(s"empty attr $attr"))
 }

--- a/scalalib/test/src/mill/scalalib/publish/PomTests.scala
+++ b/scalalib/test/src/mill/scalalib/publish/PomTests.scala
@@ -17,7 +17,9 @@ object PomTests extends TestSuite {
       Dependency(Artifact("org.scala-sbt", "test-interface", "1.0"),
                  Scope.Compile),
       Dependency(Artifact("com.lihaoyi", "pprint_2.12", "0.5.3"),
-                 Scope.Compile, exclusions = List("com.lihaoyi" -> "fansi_2.12", "*" -> "sourcecode_2.12"))
+                 Scope.Compile,
+                 exclusions = List("com.lihaoyi" -> "fansi_2.12",
+                                   "*" -> "sourcecode_2.12"))
     )
     val settings = PomSettings(
       description = "mill-scalalib",
@@ -117,9 +119,13 @@ object PomTests extends TestSuite {
               singleText(dep \ "artifactId") == pomDeps(index).artifact.id,
               singleText(dep \ "version") == pomDeps(index).artifact.version,
               optText(dep \ "scope").isEmpty,
-              (dep \ "exclusions").zipWithIndex.forall { case (node, j) =>
-                singleText(node \ "exclusion" \ "groupId") == pomDeps(index).exclusions(j)._1 &&
-                  singleText(node \ "exclusion" \ "artifactId") == pomDeps(index).exclusions(j)._2
+              (dep \ "exclusions").zipWithIndex.forall {
+                case (node, j) =>
+                  singleText(node \ "exclusion" \ "groupId") == pomDeps(index)
+                    .exclusions(j)
+                    ._1 &&
+                    singleText(node \ "exclusion" \ "artifactId") == pomDeps(
+                      index).exclusions(j)._2
               }
             )
         }

--- a/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -44,13 +44,12 @@ trait TwirlModule extends mill.Module {
 
   def compileTwirl: T[CompilationResult] = T.persistent {
     TwirlWorkerApi.twirlWorker
-      .compile(
-        twirlClasspath().map(_.path),
-        twirlSources().map(_.path),
-        T.ctx().dest,
-        twirlAdditionalImports,
-        twirlConstructorAnnotations,
-        twirlCodec,
-        twirlInclusiveDot)
+      .compile(twirlClasspath().map(_.path),
+               twirlSources().map(_.path),
+               T.ctx().dest,
+               twirlAdditionalImports,
+               twirlConstructorAnnotations,
+               twirlCodec,
+               twirlInclusiveDot)
   }
 }

--- a/twirllib/src/mill/twirllib/TwirlWorker.scala
+++ b/twirllib/src/mill/twirllib/TwirlWorker.scala
@@ -16,13 +16,17 @@ class TwirlWorker {
   private var twirlInstanceCache = Option.empty[(Long, TwirlWorkerApi)]
 
   private def twirl(twirlClasspath: Agg[Path]) = {
-    val classloaderSig = twirlClasspath.map(p => p.toString().hashCode + p.mtime.toMillis).sum
+    val classloaderSig =
+      twirlClasspath.map(p => p.toString().hashCode + p.mtime.toMillis).sum
     twirlInstanceCache match {
       case Some((sig, instance)) if sig == classloaderSig => instance
       case _ =>
-        val cl = new URLClassLoader(twirlClasspath.map(_.toIO.toURI.toURL).toArray)
-        val twirlCompilerClass = cl.loadClass("play.twirl.compiler.TwirlCompiler")
-        val compileMethod = twirlCompilerClass.getMethod("compile",
+        val cl = new URLClassLoader(
+          twirlClasspath.map(_.toIO.toURI.toURL).toArray)
+        val twirlCompilerClass =
+          cl.loadClass("play.twirl.compiler.TwirlCompiler")
+        val compileMethod = twirlCompilerClass.getMethod(
+          "compile",
           classOf[java.io.File],
           classOf[java.io.File],
           classOf[java.io.File],
@@ -30,12 +34,17 @@ class TwirlWorker {
           cl.loadClass("scala.collection.Seq"),
           cl.loadClass("scala.collection.Seq"),
           cl.loadClass("scala.io.Codec"),
-          classOf[Boolean])
+          classOf[Boolean]
+        )
 
-        val defaultAdditionalImportsMethod = twirlCompilerClass.getMethod("compile$default$5")
-        val defaultConstructorAnnotationsMethod = twirlCompilerClass.getMethod("compile$default$6")
-        val defaultCodecMethod = twirlCompilerClass.getMethod("compile$default$7")
-        val defaultFlagMethod = twirlCompilerClass.getMethod("compile$default$8")
+        val defaultAdditionalImportsMethod =
+          twirlCompilerClass.getMethod("compile$default$5")
+        val defaultConstructorAnnotationsMethod =
+          twirlCompilerClass.getMethod("compile$default$6")
+        val defaultCodecMethod =
+          twirlCompilerClass.getMethod("compile$default$7")
+        val defaultFlagMethod =
+          twirlCompilerClass.getMethod("compile$default$8")
 
         val instance = new TwirlWorkerApi {
           override def compileTwirl(source: File,
@@ -46,14 +55,17 @@ class TwirlWorker {
                                     constructorAnnotations: Seq[String],
                                     codec: Codec,
                                     inclusiveDot: Boolean) {
-            val o = compileMethod.invoke(null, source,
+            val o = compileMethod.invoke(
+              null,
+              source,
               sourceDirectory,
               generatedDirectory,
               formatterType,
               defaultAdditionalImportsMethod.invoke(null),
               defaultConstructorAnnotationsMethod.invoke(null),
               defaultCodecMethod.invoke(null),
-              defaultFlagMethod.invoke(null))
+              defaultFlagMethod.invoke(null)
+            )
           }
         }
         twirlInstanceCache = Some((classloaderSig, instance))
@@ -67,23 +79,23 @@ class TwirlWorker {
               additionalImports: Seq[String],
               constructorAnnotations: Seq[String],
               codec: Codec,
-              inclusiveDot: Boolean)
-             (implicit ctx: mill.util.Ctx): mill.eval.Result[CompilationResult] = {
+              inclusiveDot: Boolean)(
+      implicit ctx: mill.util.Ctx): mill.eval.Result[CompilationResult] = {
     val compiler = twirl(twirlClasspath)
 
     def compileTwirlDir(inputDir: Path) {
-      ls.rec(inputDir).filter(_.name.matches(".*.scala.(html|xml|js|txt)"))
+      ls.rec(inputDir)
+        .filter(_.name.matches(".*.scala.(html|xml|js|txt)"))
         .foreach { template =>
           val extFormat = twirlExtensionFormat(template.name)
           compiler.compileTwirl(template.toIO,
-            inputDir.toIO,
-            dest.toIO,
-            s"play.twirl.api.$extFormat",
-            additionalImports,
-            constructorAnnotations,
-            codec,
-            inclusiveDot
-          )
+                                inputDir.toIO,
+                                dest.toIO,
+                                s"play.twirl.api.$extFormat",
+                                additionalImports,
+                                constructorAnnotations,
+                                codec,
+                                inclusiveDot)
         }
     }
 

--- a/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
+++ b/twirllib/test/src/mill/twirllib/HelloWorldTests.scala
@@ -8,7 +8,8 @@ import utest.{TestSuite, Tests, assert, _}
 object HelloWorldTests extends TestSuite {
 
   trait HelloBase extends TestUtil.BaseModule {
-    override def millSourcePath: Path = TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+    override def millSourcePath: Path =
+      TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
   }
 
   trait HelloWorldModule extends mill.twirllib.TwirlModule {
@@ -24,9 +25,10 @@ object HelloWorldTests extends TestSuite {
 
   val resourcePath: Path = pwd / 'twirllib / 'test / 'resources / "hello-world"
 
-  def workspaceTest[T, M <: TestUtil.BaseModule](m: M, resourcePath: Path = resourcePath)
-                                                (t: TestEvaluator[M] => T)
-                                                (implicit tp: TestPath): T = {
+  def workspaceTest[T, M <: TestUtil.BaseModule](
+      m: M,
+      resourcePath: Path = resourcePath)(t: TestEvaluator[M] => T)(
+      implicit tp: TestPath): T = {
     val eval = new TestEvaluator(m)
     rm(m.millSourcePath)
     rm(eval.outPath)
@@ -43,7 +45,8 @@ object HelloWorldTests extends TestSuite {
     'twirlVersion - {
 
       'fromBuild - workspaceTest(HelloWorld) { eval =>
-        val Right((result, evalCount)) = eval.apply(HelloWorld.core.twirlVersion)
+        val Right((result, evalCount)) =
+          eval.apply(HelloWorld.core.twirlVersion)
 
         assert(
           result == "1.3.15",
@@ -67,7 +70,8 @@ object HelloWorldTests extends TestSuite {
       )
 
       // don't recompile if nothing changed
-      val Right((_, unchangedEvalCount)) = eval.apply(HelloWorld.core.compileTwirl)
+      val Right((_, unchangedEvalCount)) =
+        eval.apply(HelloWorld.core.compileTwirl)
 
       assert(unchangedEvalCount == 0)
     }


### PR DESCRIPTION
I ran `mill mill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources`(pretty long command, btw) on mill's sources with standard scalafmt config. I know that it's pretty tedious to review this PR, but it's one-time only, and I think it worth to have a unified formatting for project to simplify contribution for newcomers and being more confident about how code should look like. 

I started with scalafmt's defaults, but I'd happily adjust configuration if there are any suggestions.