### PR TITLE
Allow configuration of TestRunner's ScalaWorkerModule

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -17,6 +17,8 @@ import mill.util.Loose.Agg
   * Core configuration required to compile a single Scala compilation target
   */
 trait JavaModule extends mill.Module with TaskModule { outer =>
+  def scalaWorker: ScalaWorkerModule = mill.scalalib.ScalaWorkerModule
+
   trait Tests extends TestModule{
     override def moduleDeps = Seq(outer)
     override def repositories = outer.repositories
@@ -311,7 +313,7 @@ trait TestModule extends JavaModule with TaskModule {
 
     Jvm.subprocess(
       mainClass = "mill.scalalib.TestRunner",
-      classPath = ScalaWorkerModule.scalalibClasspath().map(_.path),
+      classPath = scalaWorker.scalalibClasspath().map(_.path),
       jvmArgs = forkArgs(),
       envArgs = forkEnv(),
       mainArgs =

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -16,8 +16,6 @@ import mill.util.DummyInputStream
   * Core configuration required to compile a single Scala compilation target
   */
 trait ScalaModule extends JavaModule { outer =>
-  def scalaWorker: ScalaWorkerModule = mill.scalalib.ScalaWorkerModule
-
   trait Tests extends TestModule with ScalaModule{
     def scalaVersion = outer.scalaVersion()
     override def repositories = outer.repositories


### PR DESCRIPTION
Hi,
My environment proxies everything and has some internal repositories that we're mandated to use. We can currently compile (thanks to this issue's resolution: https://github.com/lihaoyi/mill/issues/246) but we can't run tests.