### PR TITLE
Allow configuration of JavaModule and ScalafmtModule scala workers

### DIFF
--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -91,7 +91,7 @@ trait JavaModule extends mill.Module with TaskModule { outer =>
   }
 
 
-  def repositories: Seq[Repository] = ScalaWorkerModule.repositories
+  def repositories: Seq[Repository] = scalaWorker.repositories
 
   def platformSuffix = T{ "" }
 

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -23,7 +23,7 @@ trait ScalafmtModule extends JavaModule {
 
   def scalafmtDeps: T[Agg[PathRef]] = T {
     Lib.resolveDependencies(
-      ScalaWorkerModule.repositories,
+      scalaWorker.repositories,
       Lib.depToDependency(_, "2.12.4"),
       Seq(ivy"com.geirsson::scalafmt-cli:${scalafmtVersion()}")
     )


### PR DESCRIPTION
I missed 2 hard-coded ScalaWorkerModules in my prior PR: https://github.com/lihaoyi/mill/pull/364
I did a grep this time and didn't find any others.