### PR TITLE
Add scala JS version suffix to ivy deps for published JS ivy.xml

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -38,7 +38,12 @@ trait ScalaModule extends JavaModule { outer =>
   }
 
   override def resolvePublishDependency: Task[Dep => publish.Dependency] = T.task{
-    publish.Artifact.fromDep(_: Dep, scalaVersion(), Lib.scalaBinaryVersion(scalaVersion()))
+    publish.Artifact.fromDep(
+      _: Dep,
+      scalaVersion(),
+      Lib.scalaBinaryVersion(scalaVersion()),
+      platformSuffix()
+    )
   }
 
   override def finalMainClassOpt: T[Either[String, String]] = T{

--- a/scalalib/src/mill/scalalib/publish/settings.scala
+++ b/scalalib/src/mill/scalalib/publish/settings.scala
@@ -20,14 +20,15 @@ object Artifact {
   }
   def fromDep(dep: Dep,
               scalaFull: String,
-              scalaBin: String): Dependency = {
+              scalaBin: String,
+              platformSuffix: String): Dependency = {
     dep match {
       case d: Dep.Java => fromDepJava(d)
       case Dep.Scala(dep, cross, force) =>
         Dependency(
           Artifact(
             dep.module.organization,
-            s"${dep.module.name}_${scalaBin}",
+            s"${dep.module.name}${platformSuffix}_${scalaBin}",
             dep.version
           ),
           Scope.Compile,
@@ -38,7 +39,7 @@ object Artifact {
         Dependency(
           Artifact(
             dep.module.organization,
-            s"${dep.module.name}_${scalaFull}",
+            s"${dep.module.name}${platformSuffix}_${scalaFull}",
             dep.version
           ),
           Scope.Compile,


### PR DESCRIPTION
When compiling a JS library, the platform suffix (e.g., `_sjs0.6`) is correctly appended before the scala version to dependencies during resolution. However, when publishing, the artifact ID listed in the published `ixy.xml` is missing the suffix, causing dependency resolution to fail for downstream clients using the published JS library.

Maybe in the longer term it'd be good to just have one code path producing the artifact names so they wouldn't ever end up disagreeing like this.

But anyway, this super simple patch works for me for now.