### PR TITLE
Add scoop as installation option for Windows

### DIFF
--- a/docs/pages/1 - Intro to Mill.md
+++ b/docs/pages/1 - Intro to Mill.md
@@ -39,6 +39,12 @@ To get started, download Mill from:
 https://github.com/lihaoyi/mill/releases/download/0.2.3/0.2.3, and save it as
 `mill.bat`.
 
+If you're using [Scoop](https://scoop.sh) you can install Mill via
+
+```bash
+scoop install mill
+```
+
 Mill also works on a sh environment on Windows (e.g.,
 [MSYS2](https://www.msys2.org),
 [Cygwin](https://www.cygwin.com),


### PR DESCRIPTION
I just [added Mill to scoop](https://github.com/lukesampson/scoop/pull/2333) (with excellent support from the maintainers) and added the corresponding documentation to the Windows installation instructions.
Btw, it would be nice to have `0.2.4` released sometime soon 😃 

