### PR TITLE
Add --disable-ticker, handle --color correctly

### DIFF
--- a/core/src/mill/util/Logger.scala
+++ b/core/src/mill/util/Logger.scala
@@ -79,6 +79,7 @@ object PrintState{
   case object Middle extends PrintState
 }
 case class PrintLogger(colored: Boolean,
+                       disableTicker: Boolean,
                        colors: ammonite.util.Colors,
                        outStream: PrintStream,
                        infoStream: PrintStream,
@@ -100,23 +101,25 @@ case class PrintLogger(colored: Boolean,
     errStream.println(colors.error()(s))
   }
   def ticker(s: String) = {
-    printState match{
-      case PrintState.Newline =>
-        infoStream.println(colors.info()(s))
-      case PrintState.Middle =>
-        infoStream.println()
-        infoStream.println(colors.info()(s))
-      case PrintState.Ticker =>
-        val p = new PrintWriter(infoStream)
-        val nav = new ammonite.terminal.AnsiNav(p)
-        nav.up(1)
-        nav.clearLine(2)
-        nav.left(9999)
-        p.flush()
+    if(!disableTicker) {
+      printState match{
+        case PrintState.Newline =>
+          infoStream.println(colors.info()(s))
+        case PrintState.Middle =>
+          infoStream.println()
+          infoStream.println(colors.info()(s))
+        case PrintState.Ticker =>
+          val p = new PrintWriter(infoStream)
+          val nav = new ammonite.terminal.AnsiNav(p)
+          nav.up(1)
+          nav.clearLine(2)
+          nav.left(9999)
+          p.flush()
 
-        infoStream.println(colors.info()(s))
+          infoStream.println(colors.info()(s))
+      }
+      printState = PrintState.Ticker
     }
-    printState = PrintState.Ticker
   }
 }
 

--- a/main/src/mill/MillMain.scala
+++ b/main/src/mill/MillMain.scala
@@ -38,6 +38,8 @@ object MillMain {
             env: Map[String, String],
             setIdle: Boolean => Unit): (Boolean, Option[Evaluator.State]) = {
     import ammonite.main.Cli
+    
+    val millHome = mill.util.Ctx.defaultHome
 
     val removed = Set("predef-code", "no-home-predef")
     var interactive = false
@@ -49,10 +51,21 @@ object MillMain {
         c
       }
     )
-    val millArgSignature =
-      Cli.genericSignature.filter(a => !removed(a.name)) :+ interactiveSignature
 
-    val millHome = mill.util.Ctx.defaultHome
+
+
+    var disableTicker = false
+    val disableTickerSignature = Arg[Config, Unit](
+      "disable-ticker", None,
+      "Disable ticker log (e.g. short-lived prints of stages and progress bars)",
+      (c, v) =>{
+        disableTicker = true
+        c
+      }
+    )
+
+    val millArgSignature =
+      Cli.genericSignature.filter(a => !removed(a.name)) ++ Seq(interactiveSignature, disableTickerSignature)
 
     Cli.groupArgs(
       args.toList,
@@ -89,6 +102,7 @@ object MillMain {
                 s"""import $$file.build, build._
                   |implicit val replApplyHandler = mill.main.ReplApplyHandler(
                   |  ammonite.ops.Path($tqs${cliConfig.home.toIO.getCanonicalPath.replaceAllLiterally("$", "$$")}$tqs),
+                  |  $disableTicker,
                   |  interp.colors(),
                   |  repl.pprinter(),
                   |  build.millSelf.get,
@@ -102,7 +116,8 @@ object MillMain {
             )
 
           val runner = new mill.main.MainRunner(
-            config.copy(colored = Some(mainInteractive)),
+            config.copy(colored = config.colored orElse Option(mainInteractive)),
+            disableTicker,
             stdout, stderr, stdin,
             stateCache,
             env,

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -173,7 +173,7 @@ trait MainModule extends mill.Module{
         // When using `show`, redirect all stdout of the evaluated tasks so the
         // printed JSON is the only thing printed to stdout.
         log = evaluator.log match{
-          case PrintLogger(c1, c2, o, i, e, in) => PrintLogger(c1, c2, e, i, e, in)
+          case PrintLogger(c1, d, c2, o, i, e, in) => PrintLogger(c1, d, c2, e, i, e, in)
           case l => l
         }
       ),

--- a/main/src/mill/main/MainRunner.scala
+++ b/main/src/mill/main/MainRunner.scala
@@ -18,6 +18,7 @@ import scala.annotation.tailrec
   * `scriptCodeWrapper` or with a persistent evaluator between runs.
   */
 class MainRunner(val config: ammonite.main.Cli.Config,
+                 disableTicker: Boolean,
                  outprintStream: PrintStream,
                  errPrintStream: PrintStream,
                  stdIn: InputStream,
@@ -74,6 +75,7 @@ class MainRunner(val config: ammonite.main.Cli.Config,
           stateCache,
           new PrintLogger(
             colors != ammonite.util.Colors.BlackWhite,
+            disableTicker,
             colors,
             outprintStream,
             errPrintStream,

--- a/main/src/mill/main/ReplApplyHandler.scala
+++ b/main/src/mill/main/ReplApplyHandler.scala
@@ -11,6 +11,7 @@ import mill.util.Strict.Agg
 import scala.collection.mutable
 object ReplApplyHandler{
   def apply[T](home: Path,
+               disableTicker: Boolean,
                colors: ammonite.util.Colors,
                pprinter0: pprint.PPrinter,
                rootModule: mill.define.BaseModule,
@@ -24,6 +25,7 @@ object ReplApplyHandler{
         rootModule,
         new mill.util.PrintLogger(
           colors != ammonite.util.Colors.BlackWhite,
+          disableTicker,
           colors,
           System.out,
           System.err,

--- a/main/test/src/mill/util/ScriptTestSuite.scala
+++ b/main/test/src/mill/util/ScriptTestSuite.scala
@@ -14,8 +14,9 @@ abstract class ScriptTestSuite(fork: Boolean) extends TestSuite{
   val wd = workspacePath / buildPath / up
   val stdOutErr = new PrintStream(new ByteArrayOutputStream())
   val stdIn = new ByteArrayInputStream(Array())
+  val disableTicker = false
   lazy val runner = new mill.main.MainRunner(
-    ammonite.main.Cli.Config(wd = wd),
+    ammonite.main.Cli.Config(wd = wd), disableTicker,
     stdOutErr, stdOutErr, stdIn, None, Map.empty,
     b => ()
   )

--- a/main/test/src/mill/util/TestEvaluator.scala
+++ b/main/test/src/mill/util/TestEvaluator.scala
@@ -26,7 +26,7 @@ class TestEvaluator[T <: TestUtil.BaseModule](module: T)
 
 //  val logger = DummyLogger
   val logger = new PrintLogger(
-    true,
+    colored = true, disableTicker=false,
     ammonite.util.Colors.Default, System.out, System.out, System.err, System.in
  )
   val evaluator = new Evaluator(Ctx.defaultHome, outPath, TestEvaluator.externalOutPath, module, logger)

--- a/scalalib/src/mill/scalalib/TestRunner.scala
+++ b/scalalib/src/mill/scalalib/TestRunner.scala
@@ -31,6 +31,7 @@ object TestRunner {
       val ctx = new Ctx.Log with Ctx.Home {
         val log = PrintLogger(
           colored == "true",
+          true,
           if(colored == "true") Colors.Default
           else Colors.BlackWhite,
           System.out,

--- a/scalalib/worker/src/mill/scalalib/worker/ScalaWorker.scala
+++ b/scalalib/worker/src/mill/scalalib/worker/ScalaWorker.scala
@@ -35,7 +35,7 @@ class ScalaWorker(ctx0: mill.util.Ctx,
     val compiledDest = workingDir / 'compiled
     if (!exists(workingDir)) {
 
-      println("Compiling compiler interface...")
+      ctx0.log.info("Compiling compiler interface...")
 
       mkdir(workingDir)
       mkdir(compiledDest)


### PR DESCRIPTION
Follow up from a [question on Gitter](https://gitter.im/lihaoyi/mill?at=5b3c8932f166440661184b95) 

- Correctly¹ handles `--color false` (instead of ignoring it)
- Allows disabling ticker logs.

¹ - I'm not sure if current logic was intentional or not

Example:

```bash
➜  mill git:(disable-ticker) ✗ mill --color false show __.version
[1/1] show # those are coloured
[1/1] version
0.2.2
"0.2.2"
➜  mill git:(disable-ticker) ✗ ./out/dev/assembly/dest/mill --color false show __.version
ill version changed (0.2.2 -> 0.2.3-17637010), re-starting s%                                                                                                                        ➜  mill git:(disable-ticker) ✗ ./out/dev/assembly/dest/mill --color false show __.version
[1/1] show # no colour
[1/1] version
0.2.3-17-637010
"0.2.3-17-637010"
➜  mill git:(disable-ticker) ✗ ./out/dev/assembly/dest/mill --color false --disable-ticker show __.version
0.2.3-17-637010 # note the lack of ticker messages
"0.2.3-17-637010"
```

This is a rough cut of the PR - I'm open to comments from maintainers on how to make this better. One obstacle I see is using Ammonite's config parser, which slightly complicates things when one needs to add an argument to `Cli.Config`.