### PR TITLE
Fix bug with 'u' at the beginning of path

### DIFF
--- a/main/src/mill/MillMain.scala
+++ b/main/src/mill/MillMain.scala
@@ -94,14 +94,13 @@ object MillMain {
           stderr.println("Build repl needs to be run with the -i/--interactive flag")
           (false, stateCache)
         }else{
-          val tqs = "\"\"\""
           val config =
             if(!repl) cliConfig
             else cliConfig.copy(
               predefCode =
                 s"""import $$file.build, build._
                   |implicit val replApplyHandler = mill.main.ReplApplyHandler(
-                  |  ammonite.ops.Path($tqs${cliConfig.home.toIO.getCanonicalPath.replaceAllLiterally("$", "$$")}$tqs),
+                  |  ammonite.ops.Path(${pprint.apply(cliConfig.home.toIO.getCanonicalPath.replaceAllLiterally("$", "$$")).plainText}),
                   |  $disableTicker,
                   |  interp.colors(),
                   |  repl.pprinter(),


### PR DESCRIPTION
This fixes  #378 

I forced this error for testing purposes by applying the following patch on Windows:

    diff --git a/core/src/mill/util/Ctx.scala b/core/src/mill/util/Ctx.scala
    index 6c8b2af..ce3fe0c 100644
    --- a/core/src/mill/util/Ctx.scala
    +++ b/core/src/mill/util/Ctx.scala
    @@ -33,7 +33,7 @@ object Ctx{
         def args: IndexedSeq[_]
       }
     
    -  def defaultHome = ammonite.ops.home / ".mill" / "ammonite"
    +  def defaultHome = ammonite.ops.home / ".mill" / "uammonite"
     
     }
     class Ctx(val args: IndexedSeq[_],


