### PR TITLE
Fix bullets in manual

### DIFF
--- a/docs/pages/2 - Configuring Mill.md
+++ b/docs/pages/2 - Configuring Mill.md
@@ -395,9 +395,10 @@ object unhyphenatedModule extends Module {
 ```
 
 Mill modules and tasks may be composed of any of the following characters types:
- - Alphanumeric (A-Z, a-z, and 0-9)
- - Underscore (_)
- - Hyphen (-)
+
+- Alphanumeric (A-Z, a-z, and 0-9)
+- Underscore (_)
+- Hyphen (-)
 
 Due to Scala naming restrictions, module and task names with hyphens must be surrounded by back-ticks (`).
 


### PR DESCRIPTION
Really a small thing, but the bullets do not show correctly in my addition to the Mill manual with regard to Module/Task Names.

@lihaoyi: Is there any way to preview the manual? Looking at the Markdown on Github shows correctly without this change. See [2 - Configuring Mill.md](https://github.com/lihaoyi/mill/blob/master/docs/pages/2%20-%20Configuring%20Mill.md).

I would like to make sure that my change actually corrects the problem. Right now, I am just imitating what I see elsewhere, i.e., empty line before the bullets, and no indentation.