### PR TITLE
don't pass in sbt scalatest test args as remoteArgs too

### DIFF
--- a/scalalib/src/mill/scalalib/TestRunner.scala
+++ b/scalalib/src/mill/scalalib/TestRunner.scala
@@ -74,7 +74,7 @@ object TestRunner {
       val events = mutable.Buffer.empty[Event]
 
       val doneMessages = frameworks.map{ framework =>
-        val runner = framework.runner(args.toArray, args.toArray, cl)
+        val runner = framework.runner(args.toArray, Array[String](), cl)
 
         val testClasses = discoverTests(cl, framework, testClassfilePath)
 


### PR DESCRIPTION
I am trying to convert a sbt/scalatest project to mill.

We have various tagged tests which I am trying to run with
`mill foo.test -l MyTagHere`
unfortunately it seems that mill reuses the sbt test runners and passes in the args for both `remoteArgs` and `args`, when I only want to set `args`.
This is because for scalatest `remoteArgs` activates remote connect and the first two params are supposed to be a host name and port number, wheras `args` is the ones documented that you might want to pass in for normal running as mill would be doing.

The documentation for the sbt interface is just that it's test framework specific https://github.com/scala-native/scala-native/blob/master/test-interface-sbt-defs/src/main/scala/sbt/testing/Framework.scala#L22 Therefore I'm not sure if the real solution is to let people choose which arguments to pass in to each, but the remoteArgs for scalatest is merely the port for communication so should probably not be set by the command line.

Possibly related (as this person reported the same trace without realising it wasn't related to their problem https://github.com/lihaoyi/mill/issues/344#issuecomment-390646891 )