### PR TITLE
Upgrade ammonite to 1.1.2-30-53edc31

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -85,7 +85,8 @@ object main extends MillModule {
     )
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi:::ammonite:1.1.2-6-27842d9",
+      // Keep synchronized with ammonite in Versions.scala
+      ivy"com.lihaoyi:::ammonite:1.1.2-30-53edc31",
       // Necessary so we can share the JNA classes throughout the build process
       ivy"net.java.dev.jna:jna:4.5.0",
       ivy"net.java.dev.jna:jna-platform:4.5.0"

--- a/integration/test/resources/caffeine/build.sc
+++ b/integration/test/resources/caffeine/build.sc
@@ -8,11 +8,11 @@ import deps.{benchmarkLibraries, benchmarkVersions, libraries, testLibraries, te
 
 trait CaffeineModule extends MavenModule{
   def repositories = super.repositories ++ Seq(
-    coursier.ivy.IvyRepository(
+    coursier.ivy.IvyRepository.parse(
       "https://dl.bintray.com/sbt/sbt-plugin-releases/" +
       coursier.ivy.Pattern.default.string,
       dropInfoAttributes = true
-    ),
+    ).toOption.get,
     MavenRepository("https://jcenter.bintray.com/"),
     MavenRepository("https://jitpack.io/"),
     MavenRepository("http://repo.spring.io/plugins-release")
@@ -25,7 +25,6 @@ trait CaffeineModule extends MavenModule{
       libraries.guava,
       testLibraries.mockito,
       testLibraries.hamcrest,
-      ivy"org.hamcrest:hamcrest-library:1.3",
       testLibraries.awaitility,
     ) ++
       testLibraries.testng ++

--- a/main/src/mill/modules/Jvm.scala
+++ b/main/src/mill/modules/Jvm.scala
@@ -10,6 +10,7 @@ import java.util.jar.{JarEntry, JarFile, JarOutputStream}
 
 import ammonite.ops._
 import coursier.{Cache, Dependency, Fetch, Repository, Resolution}
+import coursier.util.{Gather, Task}
 import geny.Generator
 import mill.main.client.InputPumper
 import mill.eval.{PathRef, Result}
@@ -413,17 +414,19 @@ object Jvm {
 
       def load(artifacts: Seq[coursier.Artifact]) = {
         val logger = None
-        val loadedArtifacts = scalaz.concurrent.Task.gatherUnordered(
+
+        import scala.concurrent.ExecutionContext.Implicits.global
+        val loadedArtifacts = Gather[Task].gather(
           for (a <- artifacts)
-            yield coursier.Cache.file(a, logger = logger).run
+            yield coursier.Cache.file[Task](a, logger = logger).run
               .map(a.isOptional -> _)
-        ).unsafePerformSync
+        ).unsafeRun
 
         val errors = loadedArtifacts.collect {
-          case (false, scalaz.-\/(x)) => x
-          case (true, scalaz.-\/(x)) if !x.notFound => x
+          case (false, Left(x)) => x
+          case (true, Left(x)) if !x.notFound => x
         }
-        val successes = loadedArtifacts.collect { case (_, scalaz.\/-(x)) => x }
+        val successes = loadedArtifacts.collect { case (_, Right(x)) => x }
         (errors, successes)
       }
 
@@ -459,8 +462,10 @@ object Jvm {
       mapDependencies = mapDependencies
     )
 
-    val fetch = Fetch.from(repositories, Cache.fetch())
-    val resolution = start.process.run(fetch).unsafePerformSync
+    val fetch = Fetch.from(repositories, Cache.fetch[Task]())
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val resolution = start.process.run(fetch).unsafeRun()
     (deps.toSeq, resolution)
   }
 }

--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -204,7 +204,7 @@ trait ScalaModule extends JavaModule { outer =>
     unmanagedClasspath() ++
     resolveDeps(T.task{
       runIvyDeps() ++ scalaLibraryIvyDeps() ++ transitiveIvyDeps() ++
-      Agg(ivy"com.lihaoyi:::ammonite:1.1.2")
+      Agg(ivy"com.lihaoyi:::ammonite:${Versions.ammonite}")
     })()
   }
 

--- a/scalalib/src/mill/scalalib/Versions.scala
+++ b/scalalib/src/mill/scalalib/Versions.scala
@@ -1,6 +1,8 @@
 package mill.scalalib
 
 object Versions {
+  // Keep synchronized with ammonite dependency in core in build.sc
+  val ammonite = "1.1.2-30-53edc31"
   // Keep synchronized with zinc dependency in scalalib.worker in build.sc
   val zinc = "1.1.7"
 }

--- a/scalalib/src/mill/scalalib/dependency/metadata/MavenMetadataLoader.scala
+++ b/scalalib/src/mill/scalalib/dependency/metadata/MavenMetadataLoader.scala
@@ -2,16 +2,18 @@ package mill.scalalib.dependency.metadata
 
 import coursier.Cache
 import coursier.maven.MavenRepository
+import coursier.util.Task
 import mill.scalalib.dependency.versions.Version
 
 private[dependency] final case class MavenMetadataLoader(mavenRepo: MavenRepository)
     extends MetadataLoader {
 
-  private val fetch = Cache.fetch()
+  private val fetch = Cache.fetch[Task]()
 
   override def getVersions(module: coursier.Module): List[Version] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
     // TODO fallback to 'versionsFromListing' if 'versions' doesn't work? (needs to be made public in coursier first)
-    val allVersions = mavenRepo.versions(module, fetch).run.unsafePerformSync
+    val allVersions = mavenRepo.versions(module, fetch).run.unsafeRun
     allVersions
       .map(_.available.map(Version(_)))
       .getOrElse(List.empty)

--- a/scalalib/test/src/mill/scalalib/dependency/metadata/MetadataLoaderFactoryTests.scala
+++ b/scalalib/test/src/mill/scalalib/dependency/metadata/MetadataLoaderFactoryTests.scala
@@ -32,7 +32,7 @@ import coursier.Fetch.Content
 import coursier.core.{Artifact, Module, Project, Repository}
 import coursier.ivy.IvyRepository
 import coursier.maven.MavenRepository
-import scalaz.{EitherT, Monad}
+import coursier.util.{EitherT, Monad}
 import utest._
 
 object MetadataLoaderFactoryTests extends TestSuite {
@@ -45,7 +45,7 @@ object MetadataLoaderFactoryTests extends TestSuite {
       }
     }
     'ivyRepository - {
-      val ivyRepo = IvyRepository(
+      val Right(ivyRepo) = IvyRepository.parse(
         "https://dl.bintray.com/sbt/sbt-plugin-releases/" + coursier.ivy.Pattern.default.string,
         dropInfoAttributes = true)
       assertMatch(MetadataLoaderFactory(ivyRepo)) { case None => }


### PR DESCRIPTION
This is mainly to get https://github.com/lihaoyi/Ammonite/pull/851 which
should reduce the amount of unnecessary work done by incremental
compilation in the Mill build. This requires some code changes since
this means we now depend on a more recent version of coursier, as
a side-effect this means that we do not depend on scalaz anymore.

Also use the same ammonite version in the Mill build and in
ScalaModule#ammoniteReplClasspath.