### PR TITLE
Make the REPL evaluator accessible from the REPL itself

### DIFF
--- a/main/src/mill/main/ReplApplyHandler.scala
+++ b/main/src/mill/main/ReplApplyHandler.scala
@@ -91,7 +91,7 @@ object ReplApplyHandler{
 
 }
 class ReplApplyHandler(pprinter0: pprint.PPrinter,
-                       evaluator: Evaluator[_]) extends ApplyHandler[Task] {
+                       val evaluator: Evaluator[_]) extends ApplyHandler[Task] {
   // Evaluate classLoaderSig only once in the REPL to avoid busting caches
   // as the user enters more REPL commands and changes the classpath
   val classLoaderSig = Evaluator.classLoaderSig


### PR DESCRIPTION
This makes it easier to hack on Mill using Mill itself, the evaluator is
available using `replApplyHandler.evaluator`