### PR TITLE
Use the same Scala version everywhere

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,3 +1,5 @@
+import $file.buildVersions
+import buildVersions.BuildVersions
 import $file.ci.shared
 import $file.ci.upload
 import java.nio.file.attribute.PosixFilePermission
@@ -9,6 +11,7 @@ import mill.scalalib._
 import publish._
 import mill.modules.Jvm.createAssembly
 import upickle.Js
+
 trait MillPublishModule extends PublishModule{
 
   def artifactName = "mill-" + super.artifactName()
@@ -29,7 +32,7 @@ trait MillPublishModule extends PublishModule{
 }
 
 trait MillModule extends MillPublishModule with ScalaModule{ outer =>
-  def scalaVersion = T{ "2.12.6" }
+  def scalaVersion = T{ BuildVersions.scala }
   def compileIvyDeps = Agg(ivy"com.lihaoyi::acyclic:0.1.7")
   def scalacOptions = Seq("-P:acyclic:force")
   def scalacPluginIvyDeps = Agg(ivy"com.lihaoyi::acyclic:0.1.7")
@@ -85,8 +88,7 @@ object main extends MillModule {
     )
 
     def ivyDeps = Agg(
-      // Keep synchronized with ammonite in Versions.scala
-      ivy"com.lihaoyi:::ammonite:1.1.2-30-53edc31",
+      ivy"com.lihaoyi:::ammonite:${BuildVersions.ammonite}",
       // Necessary so we can share the JNA classes throughout the build process
       ivy"net.java.dev.jna:jna:4.5.0",
       ivy"net.java.dev.jna:jna-platform:4.5.0"
@@ -98,7 +100,7 @@ object main extends MillModule {
   }
 
   object moduledefs extends MillPublishModule with ScalaModule{
-    def scalaVersion = T{ "2.12.6" }
+    def scalaVersion = T{ BuildVersions.scala }
     def ivyDeps = Agg(
       ivy"org.scala-lang:scala-compiler:${scalaVersion()}",
       ivy"com.lihaoyi::sourcecode:0.1.4"
@@ -176,8 +178,7 @@ object scalalib extends MillModule {
     def moduleDeps = Seq(main, scalalib)
 
     def ivyDeps = Agg(
-      // Keep synchronized with zinc in Versions.scala
-      ivy"org.scala-sbt::zinc:1.2.1"
+      ivy"org.scala-sbt::zinc:${BuildVersions.zinc}"
     )
     def testArgs = Seq(
       "-DMILL_SCALA_WORKER=" + runClasspath().map(_.path).mkString(",")

--- a/buildVersions.sc
+++ b/buildVersions.sc
@@ -1,0 +1,6 @@
+// Keep this synchronized with Versions.scala
+object BuildVersions {
+  val ammonite = "1.1.2-30-53edc31"
+  val scala = "2.12.6"
+  val zinc = "1.2.1"
+}

--- a/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/mill/contrib/scalapblib/ScalaPBModule.scala
@@ -54,7 +54,7 @@ trait ScalaPBModule extends ScalaModule {
         Cache.ivy2Local,
         MavenRepository("https://repo1.maven.org/maven2")
       ),
-      Lib.depToDependency(_, "2.12.4"),
+      Lib.depToDependency(_, Versions.scala),
       Seq(ivy"com.thesamet.scalapb::scalapbc:${scalaPBVersion()}")
     )
   }

--- a/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
+++ b/contrib/twirllib/src/mill/twirllib/TwirlModule.scala
@@ -25,7 +25,7 @@ trait TwirlModule extends mill.Module {
         Cache.ivy2Local,
         MavenRepository("https://repo1.maven.org/maven2")
       ),
-      Lib.depToDependency(_, "2.12.4"),
+      Lib.depToDependency(_, Versions.scala),
       Seq(
         ivy"com.typesafe.play::twirl-compiler:${twirlVersion()}",
         ivy"org.scala-lang.modules::scala-parser-combinators:1.1.0"

--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -7,7 +7,7 @@ import coursier.maven.MavenRepository
 import mill.eval.{PathRef, Result}
 import mill.eval.Result.Success
 import mill.scalalib.Lib.resolveDependencies
-import mill.scalalib.{DepSyntax, Lib, TestModule, TestRunner}
+import mill.scalalib.{DepSyntax, Lib, TestModule, TestRunner, Versions}
 import mill.util.{Ctx, Loose}
 
 trait ScalaJSModule extends scalalib.ScalaModule { outer =>
@@ -47,7 +47,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     }
     resolveDependencies(
       repositories,
-      Lib.depToDependency(_, "2.12.4", ""),
+      Lib.depToDependency(_, Versions.scala, ""),
       commonDeps :+ envDep
     )
   }

--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -76,7 +76,7 @@ object GenIdeaImpl {
           val artifactNames = Seq("main-moduledefs", "main-core", "scalalib", "scalajslib")
           val Result.Success(res) = scalalib.Lib.resolveDependencies(
             repos.toList,
-            Lib.depToDependency(_, "2.12.4", ""),
+            Lib.depToDependency(_, Versions.scala, ""),
             for(name <- artifactNames)
             yield ivy"com.lihaoyi::mill-$name:${sys.props("MILL_VERSION")}"
           )

--- a/scalalib/src/mill/scalalib/Versions.scala
+++ b/scalalib/src/mill/scalalib/Versions.scala
@@ -1,8 +1,8 @@
 package mill.scalalib
 
+// Keep this synchronized with buildVersions.sc
 object Versions {
-  // Keep synchronized with ammonite dependency in core in build.sc
   val ammonite = "1.1.2-30-53edc31"
-  // Keep synchronized with zinc dependency in scalalib.worker in build.sc
+  val scala = "2.12.6"
   val zinc = "1.2.1"
 }

--- a/scalalib/src/mill/scalalib/ZincWorkerApi.scala
+++ b/scalalib/src/mill/scalalib/ZincWorkerApi.scala
@@ -50,7 +50,7 @@ trait ZincWorkerModule extends mill.Module{
   def compilerInterfaceClasspath = T{
     resolveDependencies(
       repositories,
-      Lib.depToDependency(_, "2.12.4", ""),
+      Lib.depToDependency(_, Versions.scala, ""),
       Seq(ivy"org.scala-sbt:compiler-interface:${Versions.zinc}")
     )
   }

--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -24,7 +24,7 @@ trait ScalafmtModule extends JavaModule {
   def scalafmtDeps: T[Agg[PathRef]] = T {
     Lib.resolveDependencies(
       zincWorker.repositories,
-      Lib.depToDependency(_, "2.12.4"),
+      Lib.depToDependency(_, Versions.scala),
       Seq(ivy"com.geirsson::scalafmt-cli:${scalafmtVersion()}")
     )
   }

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -9,7 +9,7 @@ import coursier.maven.MavenRepository
 import mill.define.{Target, Task}
 import mill.eval.Result
 import mill.modules.Jvm
-import mill.scalalib.{Dep, DepSyntax, Lib, SbtModule, ScalaModule, TestModule, TestRunner}
+import mill.scalalib.{Dep, DepSyntax, Lib, SbtModule, ScalaModule, TestModule, TestRunner, Versions}
 import mill.util.Loose.Agg
 import sbt.testing.{AnnotatedFingerprint, SubclassFingerprint}
 import sbt.testing.Fingerprint
@@ -75,7 +75,7 @@ trait ScalaNativeModule extends ScalaModule { outer =>
     else
       Lib.resolveDependencies(
         Seq(Cache.ivy2Local, MavenRepository("https://repo1.maven.org/maven2")),
-        Lib.depToDependency(_, "2.12.4", ""),
+        Lib.depToDependency(_, Versions.scala, ""),
         Seq(ivy"com.lihaoyi::mill-scalanativelib-worker-${scalaNativeBinaryVersion()}:${sys.props("MILL_VERSION")}")
       )
   }


### PR DESCRIPTION
Using both 2.12.4 and 2.12.6 in different places didn't seem justified.

Also add a buildVersions.sc to mirror Versions.scala (I don't think
there's a way to have a source file shared between the build and the
project itself).