### PR TITLE
Fix/shutdown hook manager failure

### DIFF
--- a/main/core/src/mill/util/ClassLoader.scala
+++ b/main/core/src/mill/util/ClassLoader.scala
@@ -8,17 +8,7 @@ import io.github.retronym.java9rtexport.Export
 object ClassLoader {
 
   def create(urls: Seq[URL], parent: java.lang.ClassLoader)(
-      implicit ctx: Ctx.Home): URLClassLoader = {
-    new URLClassLoader(
-      makeUrls(urls).toArray,
-      refinePlatformParent(parent)
-    ) {
-      override def findClass(name: String): Class[_] = {
-        if (name.startsWith("com.sun.jna")) getClass.getClassLoader.loadClass(name)
-        else super.findClass(name)
-      }
-    }
-  }
+      implicit ctx: Ctx.Home): URLClassLoader = create(urls, parent, _ => None)
 
   def create(urls: Seq[URL],
              parent: java.lang.ClassLoader,

--- a/scalalib/src/mill/scalalib/TestRunner.scala
+++ b/scalalib/src/mill/scalalib/TestRunner.scala
@@ -68,7 +68,8 @@ object TestRunner {
                testClassfilePath: Agg[Path],
                args: Seq[String])
               (implicit ctx: Ctx.Log with Ctx.Home): (String, Seq[mill.scalalib.TestRunner.Result]) = {
-    Jvm.inprocess(entireClasspath, classLoaderOverrideSbtTesting = true, isolated = true, cl => {
+    //Leave the context class loader set and open so that shutdown hooks can access it
+    Jvm.inprocess(entireClasspath, classLoaderOverrideSbtTesting = true, isolated = true, closeContextClassLoaderWhenDone = false, cl => {
       val frameworks = frameworkInstances(cl)
 
       val events = mutable.Buffer.empty[Event]

--- a/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
+++ b/scalanativelib/src/mill/scalanativelib/ScalaNativeModule.scala
@@ -265,7 +265,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule { testOute
     val frameworkInstances = TestRunner.frameworks(testFrameworks()) _
 
     val testClasses =
-      Jvm.inprocess(testClasspathJvm().map(_.path), classLoaderOverrideSbtTesting = true, isolated = true,
+      Jvm.inprocess(testClasspathJvm().map(_.path), classLoaderOverrideSbtTesting = true, isolated = true, closeContextClassLoaderWhenDone = true,
         cl => {
           frameworkInstances(cl).flatMap { framework =>
             val df = Lib.discoverTests(cl, framework, Agg(compile().classes.path))


### PR DESCRIPTION
Currently, any tests that use shutdown hooks fails to properly shutdown due to the context class loader being switched out before the shutdown hooks run. I don't feel great about this solution (due to the introduction of a potential side-effect to Jvm.inprocess), but it works.

Here's an example of running Apache Spark tests.
**Before**
![screenshot from 2018-09-01 06-20-37](https://user-images.githubusercontent.com/1888108/44945121-42b7ef00-adb0-11e8-96d1-d3b36a16e075.png)
**After**
![screenshot from 2018-09-01 06-16-13](https://user-images.githubusercontent.com/1888108/44945122-4a779380-adb0-11e8-884a-65cd493177ad.png)

BTW, thanks for making Mill so easy to hack on. I love "dev.run".