### PR TITLE
Make sure files are readable when traversing source files.

### DIFF
--- a/main/core/src/mill/eval/PathRef.scala
+++ b/main/core/src/mill/eval/PathRef.scala
@@ -43,7 +43,7 @@ object PathRef{
               digest.update((value >>> 16).toByte)
               digest.update((value >>> 8).toByte)
               digest.update(value.toByte)
-            }else {
+            } else if (jnio.Files.isReadable(file)) {
               val is = jnio.Files.newInputStream(file)
               IO.stream(is, digestOut)
               is.close()


### PR DESCRIPTION
Mill was trying to read all files found under the source directory to
create a digest for each of them. This was causing an error for broken
symlinks.

At first I believed temporary files should be ignored to avoid this problem,
and asked at the gitter channel how to go about this, but overriding the `sources`
task as [suggested](https://gitter.im/lihaoyi/mill?at=5ad6cd801130fe3d36eb7655)
by @lihaoyi  didn't actually help, because it was `T.sources` macro who was actually
triggering the exception.

So, on a simple scala project, editing a file with Emacs, creates a link file, like:

```
vic@oeiuwq ~/h/foo> ls -la foo/src/
total 8
drwxr-xr-x  4 vic  staff  128 Sep  1 12:23 .
lrwxr-xr-x  1 vic  staff   22 Sep  1 12:23 .#hello.scala -> vic@oeiuwq.local.10748
drwxr-xr-x  3 vic  staff   96 Sep  1 12:22 ..
-rw-r--r--  1 vic  staff   12 Sep  1 12:22 hello.scala
```

This patch only makes sures that the files (or the symlink here) is actually
readable before trying to digest it.

Fixes #402