### PR TITLE
Remove plugin options when generating ScalaDoc

### DIFF
--- a/scalalib/src/mill/scalalib/ScalaModule.scala
+++ b/scalalib/src/mill/scalalib/ScalaModule.scala
@@ -145,12 +145,11 @@ trait ScalaModule extends JavaModule { outer =>
     val files = for{
       ref <- allSources()
       if exists(ref.path)
-      p <- (if (ref.path.isDir) ls.rec(ref.path) else Seq(ref.path))
-      if (p.isFile && ((p.ext == "scala") || (p.ext == "java")))
+      p <- if (ref.path.isDir) ls.rec(ref.path) else Seq(ref.path)
+      if p.isFile && ((p.ext == "scala") || (p.ext == "java"))
     } yield p.toNIO.toString
 
-    val pluginOptions = scalacPluginClasspath().map(pluginPathRef => s"-Xplugin:${pluginPathRef.path}")
-    val options = Seq("-d", javadocDir.toNIO.toString, "-usejavacp") ++ pluginOptions ++ scalacOptions()
+    val options = Seq("-d", javadocDir.toNIO.toString, "-usejavacp") ++ scalacOptions().filter(!_.startsWith("-Xplugin-require:"))
 
     if (files.nonEmpty) subprocess(
       "scala.tools.nsc.ScalaDoc",


### PR DESCRIPTION
When `macroparadise` plugin is enabled, the command hangs forever.
As an alternative we could use a dedicated `scalacOptions` and `pluginOptions` for the docJar task.

We could also be more specific by removing only the `macroparadise` plugin ?

Here's the verbose output:

<details>
  <summary><strong>macroparadise disabled</strong></summary>
  <pre>[loaded package loader resources.jar in 74ms]
[loaded package loader java in 1ms]
[loaded package loader lang in 12ms]
[loaded package loader annotation in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/reflect/package.class) in 15ms]
[loaded package loader reflect in 18ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/package.class) in 26ms]
[loaded package loader scala in 43ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/CloneNotSupportedException.class) in 0ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/InterruptedException.class) in 1ms]
[loaded package loader io in 1ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/Throwable.class) in 7ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/Object.class) in 74ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/runtime/package.class) in 1ms]
[loaded package loader runtime in 3ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/collection/package.class) in 1ms]
[loaded package loader collection in 3ms]
[loaded package loader util in 2ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/io/UnsupportedEncodingException.class) in 0ms]
[loaded package loader nio in 0ms]
[loaded package loader charset in 0ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/String.class) in 13ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/Comparable.class) in 1ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/io/Serializable.class) in 1ms]
[loaded plugin macroparadise]
[dropping dependency on node with no phase object: constructors]
[dropping dependency on node with no phase object: dce]
[parsing Retry.scala]
[parser in 33ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Predef.class) in 12ms]
[loaded package loader resources.jar in 0ms]
[namer in 50ms]
[packageobjects in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/LowPriorityImplicits.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/DeprecatedPredef.class) in 2ms]
[loaded package loader util in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/annotation/ClassfileAnnotation.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/annotation/Annotation.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/annotation/StaticAnnotation.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/package.class) in 1ms]
[loaded package loader api in 2ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Universe.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Symbols.class) in 3ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Types.class) in 3ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/FlagSets.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Scopes.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Names.class) in 2ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Trees.class) in 7ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Constants.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Annotations.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Positions.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Exprs.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/TypeTags.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/ImplicitTags.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/StandardDefinitions.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/StandardNames.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/StandardLiftables.class) in 4ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Mirrors.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Printers.class) in 2ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Liftables.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Quasiquotes.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Internals.class) in 4ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Symbol.class) in 1ms]
[loaded module class loader in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/StringContext.class) in 4ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Product.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Equals.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Serializable.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/runtime/package.class) in 1ms]
[loaded package loader runtime in 2ms]
[loaded package loader invoke in 1ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/IllegalAccessException.class) in 1ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/invoke/LambdaForm.class) in 5ms]
[loaded package loader sun in 0ms]
[loaded package loader invoke in 0ms]
[loaded package loader empty in 0ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/invoke/MethodHandleImpl.class) in 14ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/invoke/MethodHandle.class) in 18ms]
[loaded package loader immutable in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/AnyVal.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/util/Try.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Int.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Function1.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Unit.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/AnyValCompanion.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Specializable.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Dynamic.class) in 1ms]</pre>
</details>

<details>
  <summary><strong>macroparadise enabled...</strong> command hangs forever!</summary>
  <pre>[loaded package loader resources.jar in 73ms]
[loaded package loader java in 1ms]
[loaded package loader lang in 12ms]
[loaded package loader annotation in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/reflect/package.class) in 15ms]
[loaded package loader reflect in 19ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/package.class) in 27ms]
[loaded package loader scala in 48ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/CloneNotSupportedException.class) in 1ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/InterruptedException.class) in 0ms]
[loaded package loader io in 1ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/Throwable.class) in 6ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/Object.class) in 78ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/runtime/package.class) in 1ms]
[loaded package loader runtime in 3ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/collection/package.class) in 1ms]
[loaded package loader collection in 3ms]
[loaded package loader util in 2ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/io/UnsupportedEncodingException.class) in 0ms]
[loaded package loader nio in 0ms]
[loaded package loader charset in 1ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/String.class) in 17ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/Comparable.class) in 1ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/io/Serializable.class) in 0ms]
[loaded plugin macroparadise]
[dropping dependency on node with no phase object: constructors]
[dropping dependency on node with no phase object: dce]
[parsing Tailrec.scala]
[parser in 32ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Predef.class) in 10ms]
[loaded package loader resources.jar in 0ms]
[namer in 46ms]
[packageobjects in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/LowPriorityImplicits.class) in 2ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/DeprecatedPredef.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/annotation/ClassfileAnnotation.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/annotation/Annotation.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/annotation/StaticAnnotation.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/package.class) in 1ms]
[loaded package loader api in 3ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Universe.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Symbols.class) in 3ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Types.class) in 4ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/FlagSets.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Scopes.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Names.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Trees.class) in 6ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Constants.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Annotations.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Positions.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Exprs.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/TypeTags.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/ImplicitTags.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/StandardDefinitions.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/StandardNames.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/StandardLiftables.class) in 5ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Mirrors.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Printers.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Liftables.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Quasiquotes.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/api/Internals.class) in 4ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Symbol.class) in 1ms]
[loaded module class loader in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/StringContext.class) in 3ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Product.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Equals.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Serializable.class) in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.11/scala-reflect-2.11.11.jar(scala/reflect/runtime/package.class) in 0ms]
[loaded package loader runtime in 1ms]
[loaded package loader invoke in 1ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/IllegalAccessException.class) in 0ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/invoke/LambdaForm.class) in 5ms]
[loaded package loader sun in 0ms]
[loaded package loader invoke in 0ms]
[loaded package loader empty in 0ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/invoke/MethodHandleImpl.class) in 12ms]
[loaded class file /home/guillaume/tool/jdk1.8.0_171/jre/lib/rt.jar(java/lang/invoke/MethodHandle.class) in 17ms]
[loaded package loader immutable in 0ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/AnyVal.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/Int.class) in 1ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/collection/immutable/List.class) in 2ms]
[loaded class file /home/guillaume/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar(scala/collection/generic/package.class) in 0ms]
[loaded package loader generic in 2ms]
</pre>
</details>

<br/>

**Sample source file**

```scala
object Sum {

  def sum(ints: List[Int]): Int = {
    @annotation.tailrec
    def sumAccumulator(ints: List[Int], accum: Int): Int = {
      ints match {
        case Nil => accum
        case x :: tail => sumAccumulator(tail, accum + x)
      }
    }
    sumAccumulator(ints, 0)
  }
}
```

No doubt that there's some interactions between the annotation `@tailrec` and the plugin `macroparadise`. I don't know if this issue is limited to the annotation `@tailrec` or if the issue can be reproduce if an annotation is used in the source code.
