### PR TITLE
syntax fix for example upickle jvm build

### DIFF
--- a/integration/test/resources/upickle/build.sc
+++ b/integration/test/resources/upickle/build.sc
@@ -113,7 +113,7 @@ class UpickleJvmModule(val crossScalaVersion: String) extends UpickleModule{
     super.ivyDeps() ++ Seq(ivy"org.spire-math::jawn-parser:0.11.0")
   }
   object test extends Tests with UpickleTestModule{
-    def platformSegment = "js"
+    def platformSegment = "jvm"
     def millSourcePath = build.millSourcePath / "upickle"
   }
 }


### PR DESCRIPTION
Only recently had a chance to review mill, and spotted what looked to be a copy/paste issue w/ the upickle example build