### PR TITLE
Configure Idea project generator per module

### DIFF
--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -28,7 +28,7 @@ object GenIdea extends ExternalModule {
 }
 
 /**
-  * Marker trait to manipulate idea project generation.
+  * Module specific control over Idea project file generation.
   */
 trait IdeaConfigModule extends mill.Module {
   def skipIdea: Boolean = false

--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -27,13 +27,6 @@ object GenIdea extends ExternalModule {
   lazy val millDiscover = Discover[this.type]
 }
 
-/**
-  * Module specific control over Idea project file generation.
-  */
-trait IdeaConfigModule extends mill.Module {
-  def skipIdea: Boolean = false
-}
-
 object GenIdeaImpl {
 
   def apply(ctx: Log with Home,
@@ -234,10 +227,7 @@ object GenIdeaImpl {
         ".idea"/"modules.xml",
         allModulesXmlTemplate(
           modules
-            .filter {
-              case (_, x: IdeaConfigModule) => !x.skipIdea
-              case _ => true
-            }
+            .filter(!_._2.skipIdea)
             .map { case (path, mod) => moduleName(path) }
         )
       ),

--- a/scalalib/src/mill/scalalib/GenIdeaImpl.scala
+++ b/scalalib/src/mill/scalalib/GenIdeaImpl.scala
@@ -26,6 +26,14 @@ object GenIdea extends ExternalModule {
   implicit def millScoptEvaluatorReads[T] = new mill.main.EvaluatorScopt[T]()
   lazy val millDiscover = Discover[this.type]
 }
+
+/**
+  * Marker trait to manipulate idea project generation.
+  */
+trait IdeaConfigModule extends mill.Module {
+  def skipIdea: Boolean = false
+}
+
 object GenIdeaImpl {
 
   def apply(ctx: Log with Home,
@@ -225,8 +233,12 @@ object GenIdeaImpl {
       Tuple2(
         ".idea"/"modules.xml",
         allModulesXmlTemplate(
-          for((path, mod) <- modules)
-            yield moduleName(path)
+          modules
+            .filter {
+              case (_, x: IdeaConfigModule) => !x.skipIdea
+              case _ => true
+            }
+            .map { case (path, mod) => moduleName(path) }
         )
       ),
       Tuple2(

--- a/scalalib/src/mill/scalalib/JavaModule.scala
+++ b/scalalib/src/mill/scalalib/JavaModule.scala
@@ -527,6 +527,11 @@ trait JavaModule extends mill.Module with TaskModule { outer =>
   def intellijModulePath: Path = millSourcePath
 
   def forkWorkingDir = T{ ammonite.ops.pwd }
+
+  /**
+   * Skip Idea project file generation.
+   */
+  def skipIdea: Boolean = false
 }
 
 trait TestModule extends JavaModule with TaskModule {


### PR DESCRIPTION
This PR is a first sketch how to skip some modules in Idea project generator.

The motivation is simple:
* Idea cannot handle multiple projects with the same base directory
* When working with Cross to enable cross compile projects of any kind, Idea selects one of the cross versions (almost) randomly per directory, which is undesired

This is a quickly hacked PR to sketch one possible solution to tackle the need to customize project generation. I'm open for input / change requests. If we can reach a consensus about the general direction, we can beautify, e.g. move the `IdeaConfigModule` into it's own file. Also tests would be nice, but I'm not familiar with the integration test setup of mill yet.