### PR TITLE
Added additional debug log channel (default: log-file only)

### DIFF
--- a/docs/pages/4 - Tasks.md
+++ b/docs/pages/4 - Tasks.md
@@ -199,6 +199,9 @@ task are streamed to standard out/error as you would expect, but each task's
 specific output is also streamed to a log file on disk, e.g. `out/run/log` or
 `out/classFiles/log` for you to inspect later.
 
+Messages logged with `log.debug` appear by default only in the log files.
+You can use the `--debug` option when running mill to show them on the console too.
+
 ### mill.util.Ctx.Env
 
 - `T.ctx().env`

--- a/main/core/src/mill/eval/Evaluator.scala
+++ b/main/core/src/mill/eval/Evaluator.scala
@@ -342,7 +342,7 @@ case class Evaluator(home: Path,
 
   def resolveLogger(logPath: Option[Path]): Logger = logPath match{
     case None => log
-    case Some(path) => MultiLogger(log.colored, log, FileLogger(log.colored, path))
+    case Some(path) => MultiLogger(log.colored, log, FileLogger(log.colored, path, debugEnabled = true))
   }
 }
 

--- a/main/core/src/mill/util/Logger.scala
+++ b/main/core/src/mill/util/Logger.scala
@@ -138,7 +138,7 @@ case class PrintLogger(
 
   def debug(s: String) = if (debugEnabled) {
     printState = PrintState.Newline
-    errStream.println(colors.info()(s))
+    errStream.println(s)
   }
 }
 

--- a/main/src/mill/MillMain.scala
+++ b/main/src/mill/MillMain.scala
@@ -64,8 +64,18 @@ object MillMain {
       }
     )
 
+    var debugLog = false
+    val debugLogSignature = Arg[Config, Unit](
+      name = "debug", shortName = Some('d'),
+      doc = "Show debug output on STDOUT",
+      (c, v) => {
+        debugLog = true
+        c
+      }
+    )
+
     val millArgSignature =
-      Cli.genericSignature.filter(a => !removed(a.name)) ++ Seq(interactiveSignature, disableTickerSignature)
+      Cli.genericSignature.filter(a => !removed(a.name)) ++ Seq(interactiveSignature, disableTickerSignature, debugLogSignature)
 
     Cli.groupArgs(
       args.toList,
@@ -105,7 +115,8 @@ object MillMain {
                   |  interp.colors(),
                   |  repl.pprinter(),
                   |  build.millSelf.get,
-                  |  build.millDiscover
+                  |  build.millDiscover,
+                  |  $debugLog
                   |)
                   |repl.pprinter() = replApplyHandler.pprinter
                   |import replApplyHandler.generatedEval._
@@ -120,7 +131,8 @@ object MillMain {
             stdout, stderr, stdin,
             stateCache,
             env,
-            setIdle
+            setIdle,
+            debugLog
           )
 
           if (mill.main.client.Util.isJava9OrAbove) {

--- a/main/src/mill/main/MainModule.scala
+++ b/main/src/mill/main/MainModule.scala
@@ -178,7 +178,7 @@ trait MainModule extends mill.Module{
         // When using `show`, redirect all stdout of the evaluated tasks so the
         // printed JSON is the only thing printed to stdout.
         log = evaluator.log match{
-          case PrintLogger(c1, d, c2, o, i, e, in) => PrintLogger(c1, d, c2, e, i, e, in)
+          case PrintLogger(c1, d, c2, o, i, e, in, de) => PrintLogger(c1, d, c2, e, i, e, in, de)
           case l => l
         }
       ),

--- a/main/src/mill/main/MainRunner.scala
+++ b/main/src/mill/main/MainRunner.scala
@@ -24,7 +24,8 @@ class MainRunner(val config: ammonite.main.Cli.Config,
                  stdIn: InputStream,
                  stateCache0: Option[Evaluator.State] = None,
                  env : Map[String, String],
-                 setIdle: Boolean => Unit)
+                 setIdle: Boolean => Unit,
+                 debugLog: Boolean)
   extends ammonite.MainRunner(
     config, outprintStream, errPrintStream,
     stdIn, outprintStream, errPrintStream
@@ -81,7 +82,7 @@ class MainRunner(val config: ammonite.main.Cli.Config,
             errPrintStream,
             errPrintStream,
             stdIn,
-            debugEnabled = false // TODO: read from cmdline args
+            debugEnabled = debugLog
           ),
           env
         )

--- a/main/src/mill/main/MainRunner.scala
+++ b/main/src/mill/main/MainRunner.scala
@@ -80,7 +80,8 @@ class MainRunner(val config: ammonite.main.Cli.Config,
             outprintStream,
             errPrintStream,
             errPrintStream,
-            stdIn
+            stdIn,
+            debugEnabled = false // TODO: read from cmdline args
           ),
           env
         )

--- a/main/src/mill/main/ReplApplyHandler.scala
+++ b/main/src/mill/main/ReplApplyHandler.scala
@@ -16,7 +16,8 @@ object ReplApplyHandler{
                colors: ammonite.util.Colors,
                pprinter0: pprint.PPrinter,
                rootModule: mill.define.BaseModule,
-               discover: Discover[_]) = {
+               discover: Discover[_],
+               debugLog: Boolean) = {
     new ReplApplyHandler(
       pprinter0,
       new Evaluator(
@@ -32,7 +33,7 @@ object ReplApplyHandler{
           System.err,
           System.err,
           System.in,
-          debugEnabled = false
+          debugEnabled = debugLog
         )
       )
     )

--- a/main/src/mill/main/ReplApplyHandler.scala
+++ b/main/src/mill/main/ReplApplyHandler.scala
@@ -31,7 +31,8 @@ object ReplApplyHandler{
           System.out,
           System.err,
           System.err,
-          System.in
+          System.in,
+          debugEnabled = false
         )
       )
     )

--- a/main/test/src/mill/util/ScriptTestSuite.scala
+++ b/main/test/src/mill/util/ScriptTestSuite.scala
@@ -15,10 +15,11 @@ abstract class ScriptTestSuite(fork: Boolean) extends TestSuite{
   val stdOutErr = new PrintStream(new ByteArrayOutputStream())
   val stdIn = new ByteArrayInputStream(Array())
   val disableTicker = false
+  val debugLog = false
   lazy val runner = new mill.main.MainRunner(
     ammonite.main.Cli.Config(wd = wd), disableTicker,
     stdOutErr, stdOutErr, stdIn, None, Map.empty,
-    b => ()
+    b => (), debugLog
   )
   def eval(s: String*) = {
     if (!fork) runner.runScript(workspacePath / buildPath , s.toList)

--- a/main/test/src/mill/util/TestEvaluator.scala
+++ b/main/test/src/mill/util/TestEvaluator.scala
@@ -26,7 +26,7 @@ class TestEvaluator(module: TestUtil.BaseModule)
 //  val logger = DummyLogger
   val logger = new PrintLogger(
     colored = true, disableTicker=false,
-    ammonite.util.Colors.Default, System.out, System.out, System.err, System.in
+    ammonite.util.Colors.Default, System.out, System.out, System.err, System.in, debugEnabled = false
  )
   val evaluator = new Evaluator(Ctx.defaultHome, outPath, TestEvaluator.externalOutPath, module, logger)
 

--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,13 @@ optimizer without classpath conflicts.
 
 ## Changelog
 
+### {master}
+
+- Added new `debug` method to context logger, to log additional debug info into the
+  task specific output dir (`out/<task>/log`)
+
+- Added `--debug` option to enable debug output to STDERR
+
 ### 0.3.2
 
 - Automatically detect main class to make `ScalaModule#assembly` self-executable

--- a/scalalib/src/mill/scalalib/TestRunner.scala
+++ b/scalalib/src/mill/scalalib/TestRunner.scala
@@ -37,7 +37,8 @@ object TestRunner {
           System.out,
           System.err,
           System.err,
-          System.in
+          System.in,
+          debugEnabled = false
         )
         val home = Path(homeStr)
       }


### PR DESCRIPTION
Use it to add additional debug messages when executing a task/target. By default, those message will only land in the log file under `out/`, but they can also be enabled via the `--debug` cmdline option.

Usage:
```scala
def complexTask(): T.command {
  T.ctx().log.debug("About to process bla bla bla")
}
```