### PR TITLE
tiny PR fixing ScalafmtModule usability

### DIFF
--- a/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/mill/scalalib/scalafmt/ScalafmtModule.scala
@@ -6,7 +6,7 @@ import mill.scalalib._
 
 trait ScalafmtModule extends JavaModule {
 
-  def reformat(): Command[Unit] = T.command {
+  def reformat: Command[Unit] = T.command {
     ScalafmtWorkerModule
       .worker()
       .reformat(


### PR DESCRIPTION
removed parentheses from ScalafmtModule.reformat (details below)

Tasks in `Mill` (e.g. compile) don't have parentheses. Having them for reformat introduces an issue in usability when trying to apply this task.

I just spent some time figuring out why `reformat` is not executed having this code:

```
  override def compile = T {
    reformat()
    super.compile()
  }
```

while the same code sample works in https://github.com/rockjam/mill-basic-stuff/blob/master/build.sc#L45



### Current workaround

With current code one has to write of the following lines to actually execute reformat:
```
reformat().apply()
// OR
reformat()()
```
Which is inconvenient and currently not in line with the rest.