### PR TITLE
Add Maven/SBT-style integration test folders

### DIFF
--- a/docs/pages/3 - Common Project Layouts.md
+++ b/docs/pages/3 - Common Project Layouts.md
@@ -217,6 +217,8 @@ foo/
             scala/
         test/
             scala/
+        it/
+            scala/
 ```
 
 Useful if you want to migrate an existing project built with SBT without having

--- a/scalalib/src/mill/scalalib/MiscModule.scala
+++ b/scalalib/src/mill/scalalib/MiscModule.scala
@@ -56,6 +56,15 @@ trait MavenTests extends TestModule{
   )
   override def resources = T.sources{ millSourcePath / 'src / 'test / 'resources }
 }
+
+trait MavenIntegrationTests extends TestModule {
+  override def sources = T.sources(
+    millSourcePath / 'src / 'it / 'scala,
+    millSourcePath / 'src / 'it / 'java
+  )
+  override def resources = T.sources{ millSourcePath / 'src / 'it / 'resources }
+}
+
 trait MavenModule extends JavaModule{outer =>
 
   override def sources = T.sources(
@@ -73,6 +82,10 @@ trait SbtModule extends MavenModule with ScalaModule{ outer =>
   trait Tests extends super.Tests with MavenTests {
     override def millSourcePath = outer.millSourcePath
     override def intellijModulePath = outer.millSourcePath / 'src / 'test
+  }
+  trait IntegrationTests extends super.Tests with MavenTests {
+    override def millSourcePath = outer.millSourcePath
+    override def intellijModulePath = outer.millSourcePath / 'src / 'it
   }
 }
 


### PR DESCRIPTION
This PR adds the folders under `src/it/` to the `SbtModule`.

These folders are used to separate the integration tests (slow) from the normal unit tests (fast).

The documentation is a little sparse but I'm not sure where exactly I should add it. Any pointers would be welcome.