### PR TITLE
Discover - break overridesRoutes into fixed size chunks

### DIFF
--- a/integration/test/resources/large-project/build.sc
+++ b/integration/test/resources/large-project/build.sc
@@ -1,0 +1,294 @@
+import $file.conf
+import mill._, scalalib._
+
+trait TModule extends SbtModule {
+  def scalaVersion = "2.12.7"
+}
+
+object foo extends Module {
+  object common extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq(foo.common.one)
+    }
+    object three extends TModule {
+      def moduleDeps = Seq(foo.common.two)
+    }
+  }
+  object domain extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq(foo.common.one)
+    }
+    object two extends TModule {
+      def moduleDeps = Seq(foo.domain.one)
+    }
+    object three extends TModule {
+      def moduleDeps = Seq(foo.domain.two)
+    }
+  }
+  object server extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq(foo.domain.three)
+    }
+    object two extends TModule {
+      def moduleDeps = Seq(foo.server.one)
+    }
+    object three extends TModule {
+      def moduleDeps = Seq(foo.server.two)
+    }
+  }
+}
+
+object bar extends Module {
+  object common extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq(foo.common.three)
+    }
+    object two extends TModule {
+      def moduleDeps = Seq(bar.common.one)
+    }
+    object three extends TModule {
+      def moduleDeps = Seq(bar.common.two)
+    }
+  }
+  object domain extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq(foo.domain.three)
+    }
+    object two extends TModule {
+      def moduleDeps = Seq(bar.domain.one)
+    }
+    object three extends TModule {
+      def moduleDeps = Seq(bar.domain.two)
+    }
+  }
+  object server extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq(foo.server.one)
+    }
+    object two extends TModule {
+      def moduleDeps = Seq(bar.server.one)
+    }
+    object three extends TModule {
+      def moduleDeps = Seq(bar.server.two)
+    }
+  }
+}
+
+object ham extends Module {
+  object common extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq(bar.common.one)
+    }
+    object two extends TModule {
+      def moduleDeps = Seq(bar.common.two)
+    }
+    object three extends TModule {
+      def moduleDeps = Seq(bar.common.three)
+    }
+  }
+  object domain extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq(bar.domain.three)
+    }
+    object two extends TModule {
+      def moduleDeps = Seq(bar.domain.two, ham.common.three)
+    }
+    object three extends TModule {
+      def moduleDeps = Seq(bar.domain.two)
+    }
+  }
+  object server extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+}
+
+object eggs extends Module {
+  object common extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+  object domain extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+  object server extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+}
+
+object salt extends Module {
+  object common extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+  object domain extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+  object server extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+}
+
+object pepper extends Module {
+  object common extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+  object domain extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+  object server extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+}
+
+object oregano extends Module {
+  object common extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+  object domain extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+  object server extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+}
+
+object rosmarin extends Module {
+  object common extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+  object domain extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+  object server extends Module {
+    object one extends TModule {
+      def moduleDeps = Seq()
+    }
+    object two extends TModule {
+      def moduleDeps = Seq()
+    }
+    object three extends TModule {
+      def moduleDeps = Seq()
+    }
+  }
+}

--- a/integration/test/resources/large-project/build.sc
+++ b/integration/test/resources/large-project/build.sc
@@ -1,4 +1,3 @@
-import $file.conf
 import mill._, scalalib._
 
 trait TModule extends SbtModule {

--- a/integration/test/resources/large-project/conf.sc
+++ b/integration/test/resources/large-project/conf.sc
@@ -1,0 +1,1 @@
+interp.configureCompiler(_.settings.Ydelambdafy.tryToSetColon(List("inline")))

--- a/integration/test/resources/large-project/conf.sc
+++ b/integration/test/resources/large-project/conf.sc
@@ -1,1 +1,0 @@
-interp.configureCompiler(_.settings.Ydelambdafy.tryToSetColon(List("inline")))

--- a/integration/test/resources/large-project/foo/common/one/src/main/scala/foo/common/one/Main.scala
+++ b/integration/test/resources/large-project/foo/common/one/src/main/scala/foo/common/one/Main.scala
@@ -1,0 +1,5 @@
+package foo.common.one
+
+object Main extends App {
+  println("large-project")
+}

--- a/integration/test/src/LargeProjectTests.scala
+++ b/integration/test/src/LargeProjectTests.scala
@@ -1,0 +1,19 @@
+package mill.integration
+
+import mill.util.ScriptTestSuite
+import utest._
+
+class LargeProjectTests(fork: Boolean)
+  extends ScriptTestSuite(fork) {
+  def workspaceSlug: String = "large-project"
+  def scriptSourcePath: os.Path = os.pwd / 'integration / 'test / 'resources / workspaceSlug
+
+  val tests = Tests{
+    initWorkspace()
+    'test - {
+
+      assert(eval("foo.common.one.compile"))
+    }
+
+  }
+}

--- a/integration/test/src/forked/Tests.scala
+++ b/integration/test/src/forked/Tests.scala
@@ -3,6 +3,7 @@ package mill.integration.forked
 object AcyclicTests extends mill.integration.AcyclicTests(fork = true)
 object AmmoniteTests extends mill.integration.AmmoniteTests(fork = true)
 object BetterFilesTests extends mill.integration.BetterFilesTests(fork = true)
+object LargeProjectTests extends mill.integration.LargeProjectTests(fork = true)
 object JawnTests extends mill.integration.JawnTests(fork = true)
 object UpickleTests extends mill.integration.UpickleTests(fork = true)
 object PlayJsonTests extends mill.integration.PlayJsonTests(fork = true)

--- a/integration/test/src/local/Tests.scala
+++ b/integration/test/src/local/Tests.scala
@@ -3,6 +3,7 @@ package mill.integration.local
 object AcyclicTests extends mill.integration.AcyclicTests(fork = false)
 object AmmoniteTests extends mill.integration.AmmoniteTests(fork = false)
 object BetterFilesTests extends mill.integration.BetterFilesTests(fork = false)
+object LargeProjectTests extends mill.integration.LargeProjectTests(fork = false)
 object JawnTests extends mill.integration.JawnTests(fork = false)
 object UpickleTests extends mill.integration.UpickleTests(fork = false)
 object PlayJsonTests extends mill.integration.PlayJsonTests(fork = false)

--- a/main/core/src/define/Discover.scala
+++ b/main/core/src/define/Discover.scala
@@ -79,18 +79,12 @@ object Discover {
       }
       if overridesRoutes.nonEmpty
     } yield {
-      // by grouping the `overridesRoutes` into a sequence of lambda functions
-      // containing chunks of 512 elements we kind of work around the problem
-      // of generating a *huge* macro method body that finally exceeds the
+      // by wrapping the `overridesRoutes` in a lambda function we kind of work around
+      // the problem of generating a *huge* macro method body that finally exceeds the
       // JVM's maximum allowed method size
-      val splitSize = 512
-      val groupedLambdas =
-        overridesRoutes
-          .sliding(splitSize, splitSize).toSeq
-          .map(grp => q"(() => $grp)()")
-          .reduce((a, b) => q"$a ++ $b")
+      val overridesLambda = q"(() => $overridesRoutes)()"
       val lhs =  q"classOf[${discoveredModuleType.typeSymbol.asClass}]"
-      q"$lhs -> $groupedLambdas"
+      q"$lhs -> $overridesLambda"
     }
 
     c.Expr[Discover[T]](q"mill.define.Discover(scala.collection.immutable.Map(..$mapping))")


### PR DESCRIPTION
I now did try to tackle #508 - as I said before I have not too much experience in scala macros so there might be a much nicer solution to this problem.

However this change successfully builds the example I posted before.