### PR TITLE
fix GenIdea to create required folders

### DIFF
--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -43,7 +43,7 @@ object GenIdeaImpl {
     val evaluator = new Evaluator(ctx.home, os.pwd / 'out, os.pwd / 'out, rootModule, ctx.log)
 
     for((relPath, xml) <- xmlFileLayout(evaluator, rootModule, jdkInfo)){
-      os.write.over(os.pwd/relPath, pp.format(xml))
+      os.write.over(os.pwd/relPath, pp.format(xml), createFolders = true)
     }
   }
 


### PR DESCRIPTION
GenIdea is broken as it is no longer creating the required folder structure when needed.