### PR TITLE
Allow usage of ZincWorkerImpl without hashing files

### DIFF
--- a/scalalib/worker/src/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/ZincWorkerImpl.scala
@@ -121,13 +121,13 @@ class ZincWorkerImpl(compilerBridge: Either[
                   compileClasspath: Agg[os.Path],
                   javacOptions: Seq[String])
                  (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] = {
-    val res = compileJava0(
+
+    for(res <- compileJava0(
       upstreamCompileOutput,
       sources,
       compileClasspath,
       javacOptions
-    )
-    for((zincFile, classesDir) <- res) yield CompilationResult(zincFile, PathRef(classesDir))
+    )) yield CompilationResult(res._1, PathRef(res._2))
   }
   def compileJava0(upstreamCompileOutput: Seq[CompilationResult],
                    sources: Agg[os.Path],
@@ -154,7 +154,8 @@ class ZincWorkerImpl(compilerBridge: Either[
                    compilerClasspath: Agg[os.Path],
                    scalacPluginClasspath: Agg[os.Path])
                   (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] = {
-    val res = compileMixed0(
+
+    for (res <- compileMixed0(
       upstreamCompileOutput,
       sources,
       compileClasspath,
@@ -164,8 +165,7 @@ class ZincWorkerImpl(compilerBridge: Either[
       scalacOptions,
       compilerClasspath,
       scalacPluginClasspath
-    )
-    for ((zincFile, classesDir) <- res) yield CompilationResult(zincFile, PathRef(classesDir))
+    )) yield CompilationResult(res._1, PathRef(res._2))
   }
 
   def compileMixed0(upstreamCompileOutput: Seq[CompilationResult],

--- a/scalalib/worker/src/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/ZincWorkerImpl.scala
@@ -121,13 +121,12 @@ class ZincWorkerImpl(compilerBridge: Either[
                   compileClasspath: Agg[os.Path],
                   javacOptions: Seq[String])
                  (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] = {
-    val (zincFile, classesDir) = compileJava0(
+    for((zincFile, classesDir) <- compileJava0(
       upstreamCompileOutput,
       sources,
       compileClasspath,
       javacOptions
-    )
-    CompilationResult(zincFile, PathRef(classesDir))
+    )) yield CompilationResult(zincFile, PathRef(classesDir))
   }
   def compileJava0(upstreamCompileOutput: Seq[CompilationResult],
                    sources: Agg[os.Path],
@@ -154,7 +153,7 @@ class ZincWorkerImpl(compilerBridge: Either[
                    compilerClasspath: Agg[os.Path],
                    scalacPluginClasspath: Agg[os.Path])
                   (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] = {
-    val (zincFile, classesDir) = compileMixed0(
+    for ((zincFile, classesDir) <- compileMixed0(
       upstreamCompileOutput,
       sources,
       compileClasspath,
@@ -164,8 +163,7 @@ class ZincWorkerImpl(compilerBridge: Either[
       scalacOptions,
       compilerClasspath,
       scalacPluginClasspath
-    )
-    CompilationResult(zincFile, PathRef(classesDir))
+    )) yield CompilationResult(zincFile, PathRef(classesDir))
   }
 
   def compileMixed0(upstreamCompileOutput: Seq[CompilationResult],

--- a/scalalib/worker/src/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/ZincWorkerImpl.scala
@@ -121,6 +121,19 @@ class ZincWorkerImpl(compilerBridge: Either[
                   compileClasspath: Agg[os.Path],
                   javacOptions: Seq[String])
                  (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] = {
+    val (zincFile, classesDir) = compileJava0(
+      upstreamCompileOutput,
+      sources,
+      compileClasspath,
+      javacOptions
+    )
+    CompilationResult(zincFile, PathRef(classesDir))
+  }
+  def compileJava0(upstreamCompileOutput: Seq[CompilationResult],
+                   sources: Agg[os.Path],
+                   compileClasspath: Agg[os.Path],
+                   javacOptions: Seq[String])
+                  (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[(os.Path, os.Path)] = {
     compileInternal(
       upstreamCompileOutput,
       sources,
@@ -141,6 +154,30 @@ class ZincWorkerImpl(compilerBridge: Either[
                    compilerClasspath: Agg[os.Path],
                    scalacPluginClasspath: Agg[os.Path])
                   (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] = {
+    val (zincFile, classesDir) = compileMixed0(
+      upstreamCompileOutput,
+      sources,
+      compileClasspath,
+      javacOptions,
+      scalaVersion,
+      scalaOrganization,
+      scalacOptions,
+      compilerClasspath,
+      scalacPluginClasspath
+    )
+    CompilationResult(zincFile, PathRef(classesDir))
+  }
+
+  def compileMixed0(upstreamCompileOutput: Seq[CompilationResult],
+                    sources: Agg[os.Path],
+                    compileClasspath: Agg[os.Path],
+                    javacOptions: Seq[String],
+                    scalaVersion: String,
+                    scalaOrganization: String,
+                    scalacOptions: Seq[String],
+                    compilerClasspath: Agg[os.Path],
+                    scalacPluginClasspath: Agg[os.Path])
+                   (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[(os.Path, os.Path)] = {
     withCompilers(
       scalaVersion,
       scalaOrganization,
@@ -208,7 +245,7 @@ class ZincWorkerImpl(compilerBridge: Either[
                               javacOptions: Seq[String],
                               scalacOptions: Seq[String],
                               compilers: Compilers)
-                             (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] = {
+                             (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[(os.Path, os.Path)] = {
     os.makeDir.all(ctx.dest)
 
     val logger = {
@@ -281,7 +318,7 @@ class ZincWorkerImpl(compilerBridge: Either[
         )
       )
 
-      mill.api.Result.Success(CompilationResult(zincFile, PathRef(classesDir)))
+      mill.api.Result.Success((zincFile, classesDir))
     }catch{case e: CompileFailed => mill.api.Result.Failure(e.toString)}
   }
 }

--- a/scalalib/worker/src/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/ZincWorkerImpl.scala
@@ -121,12 +121,13 @@ class ZincWorkerImpl(compilerBridge: Either[
                   compileClasspath: Agg[os.Path],
                   javacOptions: Seq[String])
                  (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] = {
-    for((zincFile, classesDir) <- compileJava0(
+    val res = compileJava0(
       upstreamCompileOutput,
       sources,
       compileClasspath,
       javacOptions
-    )) yield CompilationResult(zincFile, PathRef(classesDir))
+    )
+    for((zincFile, classesDir) <- res) yield CompilationResult(zincFile, PathRef(classesDir))
   }
   def compileJava0(upstreamCompileOutput: Seq[CompilationResult],
                    sources: Agg[os.Path],
@@ -153,7 +154,7 @@ class ZincWorkerImpl(compilerBridge: Either[
                    compilerClasspath: Agg[os.Path],
                    scalacPluginClasspath: Agg[os.Path])
                   (implicit ctx: ZincWorkerApi.Ctx): mill.api.Result[CompilationResult] = {
-    for ((zincFile, classesDir) <- compileMixed0(
+    val res = compileMixed0(
       upstreamCompileOutput,
       sources,
       compileClasspath,
@@ -163,7 +164,8 @@ class ZincWorkerImpl(compilerBridge: Either[
       scalacOptions,
       compilerClasspath,
       scalacPluginClasspath
-    )) yield CompilationResult(zincFile, PathRef(classesDir))
+    )
+    for ((zincFile, classesDir) <- res) yield CompilationResult(zincFile, PathRef(classesDir))
   }
 
   def compileMixed0(upstreamCompileOutput: Seq[CompilationResult],


### PR DESCRIPTION
This is to better support non-Mill build tools like Bazel or Make who might do their own file hashing/mtiming for change-detection