### PR TITLE
More improvements to ZincWorkerImpl

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -187,7 +187,7 @@ object scalalib extends MillModule {
 
     def ivyDeps = Agg(
       // Keep synchronized with zinc in Versions.scala
-      ivy"org.scala-sbt::zinc:1.2.5"
+      ivy"org.scala-sbt::zinc:1.3.0-M1"
     )
     def testArgs = T{Seq(
       "-DMILL_SCALA_WORKER=" + runClasspath().map(_.path).mkString(",")

--- a/scalalib/src/ZincWorkerModule.scala
+++ b/scalalib/src/ZincWorkerModule.scala
@@ -52,7 +52,8 @@ trait ZincWorkerModule extends mill.Module{
       ],
       classOf[(Agg[os.Path], String) => os.Path],
       classOf[(Agg[os.Path], String) => os.Path],
-      classOf[KeyedLockedCache[_]]
+      classOf[KeyedLockedCache[_]],
+      classOf[Boolean]
     )
       .newInstance(
         Left((
@@ -62,7 +63,8 @@ trait ZincWorkerModule extends mill.Module{
         )),
         mill.scalalib.api.Util.grepJar(_, "scala-library", _, sources = false),
         mill.scalalib.api.Util.grepJar(_, "scala-compiler", _, sources = false),
-        new KeyedLockedCache.RandomBoundedCache(1, 1)
+        new KeyedLockedCache.RandomBoundedCache(1, 1),
+        false.asInstanceOf[AnyRef]
       )
     instance.asInstanceOf[mill.scalalib.api.ZincWorkerApi]
   }

--- a/scalalib/worker/src/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/ZincWorkerImpl.scala
@@ -285,7 +285,7 @@ class ZincWorkerImpl(compilerBridge: Either[
 
     val zincFile = ctx.dest / 'zinc
     val classesDir = 
-      if (jarOut) ctx.dest / "classes.jar"
+      if (compileToJar) ctx.dest / "classes.jar"
       else ctx.dest / "classes"
 
     val zincIOFile = zincFile.toIO


### PR DESCRIPTION
- Cache classloaders separately from `ScalaInstance`s
- Pre-compute `analysisMap` to speed up lookups
- Allow compile-to-jar using sbt/zinc 1.3.0-m1