### PR TITLE
Added compiler-classpath properties to generated IntelliJ xml files

### DIFF
--- a/scalalib/test/resources/gen-idea/idea/libraries/scala-library-2.12.4.jar.xml
+++ b/scalalib/test/resources/gen-idea/idea/libraries/scala-library-2.12.4.jar.xml
@@ -1,5 +1,13 @@
 <component name="libraryTable">
     <library name="scala-library-2.12.4.jar" type="Scala">
+        <properties>
+            <compiler-classpath>
+                <root url="file://COURSIER_HOME/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar"/>
+                <root url="file://COURSIER_HOME/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.4/scala-compiler-2.12.4.jar"/>
+                <root url="file://COURSIER_HOME/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.4/scala-library-2.12.4.jar"/>
+                <root url="file://COURSIER_HOME/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.4/scala-reflect-2.12.4.jar"/>
+            </compiler-classpath>
+        </properties>
         <CLASSES>
             <root url="jar://COURSIER_HOME/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.4/scala-library-2.12.4.jar!/"/>
         </CLASSES>


### PR DESCRIPTION
Fixes #512 

Simple implementation that adds entries from`module.scalaCompilerClasspath` to `scala-library`'s Idea XML file.