### PR TITLE
Add a shutdown target which allows user to kill background server

### DIFF
--- a/main/src/main/MainModule.scala
+++ b/main/src/main/MainModule.scala
@@ -247,6 +247,14 @@ trait MainModule extends mill.Module{
     }
   }
 
+  /**
+    * Shuts down mill's background server
+    */
+  def shutdown() = mill.T.command {
+    T.ctx().log.info("Shutting down Mill server...")
+    System.exit(0)
+  }
+
   private type VizWorker = (LinkedBlockingQueue[(scala.Seq[_], scala.Seq[_], os.Path)],
     LinkedBlockingQueue[Result[scala.Seq[PathRef]]])
 


### PR DESCRIPTION
Never got any response in gitter so I just went through the codebase and found a place to put that `System.exit(1)` in :smiley: 

Rationale for this is: in a Jenkins pipeline (and also when working locally on several projects at once) one would like to be able to manage lifetimes of mill servers manually. For instance first Jenkins pipeline stage would implicitly spawn server, then other stages would reuse existing server and reap the benefit of running in warm jvm and after that in pipeline's finally block one would issue `mill shutdown` to prevent resource leaks.

Give me a shout if you see this functionality in any other way. It would help a lot in my attempt to migrate build to mill. Thanks!