### PR TITLE
GenIdea - handle projects not in the main build.sc file

### DIFF
--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -66,9 +66,12 @@ object GenIdeaImpl {
                     fetchMillModules: Boolean = true): Seq[(os.RelPath, scala.xml.Node)] = {
 
     val modules = rootModule.millInternal.segmentsToModules.values
-      .collect{ case x: scalalib.JavaModule => (x.millModuleSegments, x)}
+      .collect{ case x: scalalib.JavaModule => x }
+      .flatMap(_.transitiveModuleDeps)
+      .map(x => (x.millModuleSegments, x))
       .toSeq
-
+      .distinct
+    
     val buildLibraryPaths =
       if (!fetchMillModules) Nil
       else sys.props.get("MILL_BUILD_LIBRARIES") match {


### PR DESCRIPTION
Projects which are imported from other files and used as module dependencies are not found by GenIdea and this causes an exception. This PR transitively adds all the modules to the lookup map.