### PR TITLE
contrib BuildInfo plugin: fix generatedSources, it must be a folder

### DIFF
--- a/contrib/buildinfo/src/BuildInfo.scala
+++ b/contrib/buildinfo/src/BuildInfo.scala
@@ -1,8 +1,8 @@
 package mill.contrib.buildinfo
 
 import mill.T
-import mill.define.Target
-import mill.api.{Ctx, Logger, PathRef}
+import mill.api.Logger
+import mill.api.PathRef
 import mill.scalalib.ScalaModule
 
 trait BuildInfo extends ScalaModule {
@@ -15,33 +15,35 @@ trait BuildInfo extends ScalaModule {
     Map.empty[String, String]
   }
 
-  private def generateBuildInfo(members: Map[String, Any])(implicit dest: Ctx.Dest, log: Ctx.Log): Seq[PathRef] =
-    if (!members.isEmpty) {
-      val outputFile = dest.dest / "BuildInfo.scala"
+  def generatedBuildInfo: T[Seq[PathRef]] = T {
+    val logger: Logger = T.ctx.log
+    val members: Map[String, String] = buildInfoMembers()
+    if (members.nonEmpty) {
+      val outputFile = T.ctx.dest / "BuildInfo.scala"
       val internalMembers =
         members
           .map {
             case (name, value) => s"""  def ${name} = "${value}""""
           }
           .mkString("\n")
-      log.log.debug(s"Generating object [${buildInfoPackageName.map(_ + ".").getOrElse("")}${buildInfoObjectName}] with [${members.size}] members to [${outputFile}]")
+      logger.debug(s"Generating object [${buildInfoPackageName.map(_ + ".").getOrElse("")}${buildInfoObjectName}] with [${members.size}] members to [${outputFile}]")
       os.write(
         outputFile,
-        s"""|${buildInfoPackageName.map(p => s"package ${p}").getOrElse("")}
-          |object ${buildInfoObjectName} {
-          |$internalMembers
-          |}""".stripMargin
+        s"""|${buildInfoPackageName.map(packageName => s"package ${packageName}\n").getOrElse("")}
+            |object ${buildInfoObjectName} {
+            |$internalMembers
+            |}""".stripMargin
       )
       Seq(PathRef(outputFile))
     } else {
-      log.log.debug("No build info member defined, skipping code generation")
+      logger.debug("No build info member defined, skipping code generation")
       Seq.empty[PathRef]
     }
-
-  def buildInfo = T {
-    generateBuildInfo(buildInfoMembers())
   }
 
-  override def generatedSources: Target[Seq[PathRef]] = T { super.generatedSources() ++ buildInfo() }
+  override def generatedSources = T {
+    super.generatedSources() ++
+      generatedBuildInfo().map(pathRef => PathRef(pathRef.path / os.up))
+  }
 
 }

--- a/contrib/buildinfo/src/BuildInfo.scala
+++ b/contrib/buildinfo/src/BuildInfo.scala
@@ -15,7 +15,7 @@ trait BuildInfo extends ScalaModule {
     Map.empty[String, String]
   }
 
-  def generatedBuildInfo: T[Seq[PathRef]] = T {
+  def generatedBuildInfo: T[(Seq[PathRef], PathRef)] = T {
     val logger: Logger = T.ctx().log
     val members: Map[String, String] = buildInfoMembers()
     if (members.nonEmpty) {
@@ -34,16 +34,16 @@ trait BuildInfo extends ScalaModule {
             |$internalMembers
             |}""".stripMargin
       )
-      Seq(PathRef(outputFile))
+      (Seq(PathRef(outputFile)), PathRef(T.ctx().dest))
     } else {
       logger.debug("No build info member defined, skipping code generation")
-      Seq.empty[PathRef]
+      (Seq.empty[PathRef], PathRef(T.ctx().dest))
     }
   }
 
   override def generatedSources = T {
-    super.generatedSources() ++
-      generatedBuildInfo().map(pathRef => PathRef(pathRef.path / os.up))
+    val (_, destPathRef) = generatedBuildInfo()
+    super.generatedSources() :+ destPathRef
   }
 
 }

--- a/contrib/buildinfo/src/BuildInfo.scala
+++ b/contrib/buildinfo/src/BuildInfo.scala
@@ -16,10 +16,10 @@ trait BuildInfo extends ScalaModule {
   }
 
   def generatedBuildInfo: T[Seq[PathRef]] = T {
-    val logger: Logger = T.ctx.log
+    val logger: Logger = T.ctx().log
     val members: Map[String, String] = buildInfoMembers()
     if (members.nonEmpty) {
-      val outputFile = T.ctx.dest / "BuildInfo.scala"
+      val outputFile = T.ctx().dest / "BuildInfo.scala"
       val internalMembers =
         members
           .map {

--- a/contrib/buildinfo/test/src/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/BuildInfoTests.scala
@@ -108,11 +108,12 @@ object BuildInfoTests extends TestSuite {
       }
 
       "generatedSources must be a folder" - workspaceTest(BuildInfo) { eval =>
-        val generatedSourcesPath = eval.outPath / 'generatedBuildInfo / 'dest
+        val buildInfoGeneratedSourcesFolder = eval.outPath / 'generatedBuildInfo / 'dest
         val Right((result, evalCount)) = eval.apply(BuildInfo.generatedSources)
         assert(
           result.size == 1,
-          result.head.path == generatedSourcesPath
+          os.isDir(result.head.path),
+          result.head.path == buildInfoGeneratedSourcesFolder
         )
       }
     }

--- a/contrib/buildinfo/test/src/BuildInfoTests.scala
+++ b/contrib/buildinfo/test/src/BuildInfoTests.scala
@@ -62,7 +62,7 @@ object BuildInfoTests extends TestSuite {
               |object BuildInfo {
               |  def scalaVersion = "2.12.4"
               |}""".stripMargin
-        val Right((result, evalCount)) = eval.apply(BuildInfo.generatedBuildInfo)
+        val Right(((result, _), evalCount)) = eval.apply(BuildInfo.generatedBuildInfo)
         assert(
           result.head.path == eval.outPath / 'generatedBuildInfo / 'dest / "BuildInfo.scala" &&
             os.exists(result.head.path) &&
@@ -71,7 +71,7 @@ object BuildInfoTests extends TestSuite {
       }
 
       'notCreateEmptySourcefile - workspaceTest(EmptyBuildInfo){ eval =>
-        val Right((result, evalCount)) = eval.apply(EmptyBuildInfo.generatedBuildInfo)
+        val Right(((result, _), evalCount)) = eval.apply(EmptyBuildInfo.generatedBuildInfo)
         assert(
           result.isEmpty &&
             !os.exists(eval.outPath / 'generatedBuildInfo / 'dest / "BuildInfo.scala")
@@ -85,7 +85,7 @@ object BuildInfoTests extends TestSuite {
               |object bar {
               |  def scalaVersion = "2.12.4"
               |}""".stripMargin
-        val Right((result, evalCount)) = eval.apply(BuildInfoSettings.generatedBuildInfo)
+        val Right(((result, _), evalCount)) = eval.apply(BuildInfoSettings.generatedBuildInfo)
         assert(
           result.head.path == eval.outPath / 'generatedBuildInfo / 'dest / "BuildInfo.scala" &&
             os.exists(result.head.path) &&


### PR DESCRIPTION
generatedSources must be a folder,
but till now it was a reference to a generated file
This commit fixes this issue.

There are 2 reasons for this fix:
(1) Because generatedSources must be folders by the definition:
Folders containing source files that are generated
(2) If you use intellij IDEA and build your project from the IDE,
building module, which includes BuildInfo plugin, fails saying:

Error:scalac: Error: /home/vitalii/risk42/repo/risk42-workspace2/out/infinity/foundations/buildInfo/dest/BuildInfo.scala does not exist or is not a directory
scala.reflect.internal.FatalError: /home/vitalii/risk42/repo/risk42-workspace2/out/infinity/foundations/buildInfo/dest/BuildInfo.scala does not exist or is not a directory
	at scala.tools.nsc.settings.MutableSettings$OutputDirs.checkDir(MutableSettings.scala:286)
	at scala.tools.nsc.settings.MutableSettings$OutputDirs.add(MutableSettings.scala:276)
	at xsbt.CachedCompiler0.$anonfun$new$1(CompilerInterface.scala:68)
	at xsbt.CachedCompiler0.$anonfun$new$1$adapted(CompilerInterface.scala:66)
	at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
	at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
	at xsbt.CachedCompiler0.<init>(CompilerInterface.scala:66)
	at xsbt.CompilerInterface.newCompiler(CompilerInterface.scala:22)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    ...