### PR TITLE
[Fixes #442] Improve Scalafmt configuration options

### DIFF
--- a/scalalib/src/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/scalafmt/ScalafmtModule.scala
@@ -18,13 +18,23 @@ trait ScalafmtModule extends JavaModule {
 
   def scalafmtVersion: T[String] = "1.5.1"
 
+  def scalafmtGroupId: T[String] = T {
+    val v = scalafmtVersion()
+    if (v.startsWith("0.") || v.startsWith("1.") || v == "2.0.0-RC1")
+      "com.geirsson"
+    else
+      "org.scalameta"
+  }
+
+  def scalafmtScalaVersion: T[String] = "2.12.8"
+
   def scalafmtConfig: Sources = T.sources(os.pwd / ".scalafmt.conf")
 
   def scalafmtDeps: T[Agg[PathRef]] = T {
     Lib.resolveDependencies(
       zincWorker.repositories,
-      Lib.depToDependency(_, "2.12.4"),
-      Seq(ivy"com.geirsson::scalafmt-cli:${scalafmtVersion()}")
+      Lib.depToDependency(_, scalafmtScalaVersion()),
+      Seq(ivy"${scalafmtGroupId()}::scalafmt-cli:${scalafmtVersion()}")
     )
   }
 


### PR DESCRIPTION
See issue #442 .

This change notably makes it easier to use the latest Scalafmt 2.0 RC version (`2.0.0-RC5`), by:

- allowing to set the Scala version used for Scalafmt, and bumping up the default
- allowing to set the Scalafmt group ID, and trying to determine the correct one by default (it changed starting with version `2.0.0-RC2`)

**Notes:**

- Without this change, the alternative is to just override `scalafmtDeps` as a whole.
- In the future, I think it might be interesting to try to use `scalafmt-dynamic` to load a Scalafmt version specified in the `.scalafmt.conf` file (just like what Intellij does now, starting with Intellij 2019.1), but this is much simpler.