### PR TITLE
[Fixes #442] Switch from scalafmt-cli to scalafmt-dynamic

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -143,7 +143,8 @@ object scalalib extends MillModule {
   def moduleDeps = Seq(main, scalalib.api)
 
   def ivyDeps = Agg(
-    ivy"org.scala-sbt:test-interface:1.0"
+    ivy"org.scala-sbt:test-interface:1.0",
+    ivy"org.scalameta::scalafmt-dynamic:2.0.0-RC6"
   )
 
   def genTask(m: ScalaModule) = T.task{

--- a/docs/pages/2 - Configuring Mill.md
+++ b/docs/pages/2 - Configuring Mill.md
@@ -237,6 +237,12 @@ Now you can reformat code with `mill foo.reformat` command.
 You can also reformat your project's code globally with `mill mill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources` command.
 It will reformat all sources that matches `__.sources` query.
 
+If you add a `.scalafmt.conf` file at the root of you project, it will be used
+to configure formatting. It can contain a `version` key to specify the scalafmt
+version used to format your code. See the
+[scalafmt configuration documentation](https://scalameta.org/scalafmt/docs/configuration.html)
+for details.
+
 ## Common Configuration
 
 ```scala

--- a/scalalib/src/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/scalafmt/ScalafmtModule.scala
@@ -11,22 +11,11 @@ trait ScalafmtModule extends JavaModule {
       .worker()
       .reformat(
         filesToFormat(sources()),
-        scalafmtConfig().head,
-        scalafmtDeps().map(_.path)
+        scalafmtConfig().head
       )
   }
 
-  def scalafmtVersion: T[String] = "1.5.1"
-
   def scalafmtConfig: Sources = T.sources(os.pwd / ".scalafmt.conf")
-
-  def scalafmtDeps: T[Agg[PathRef]] = T {
-    Lib.resolveDependencies(
-      zincWorker.repositories,
-      Lib.depToDependency(_, "2.12.4"),
-      Seq(ivy"com.geirsson::scalafmt-cli:${scalafmtVersion()}")
-    )
-  }
 
   protected def filesToFormat(sources: Seq[PathRef]) = {
     for {
@@ -46,8 +35,7 @@ object ScalafmtModule extends ExternalModule with ScalafmtModule {
         .worker()
         .reformat(
           files,
-          scalafmtConfig().head,
-          scalafmtDeps().map(_.path)
+          scalafmtConfig().head
         )
     }
 


### PR DESCRIPTION
This could replace pull request #590.

I completely removed the `scalafmtVersion` key because it can now be configured directly in the `.scalafmt.conf` configuration file. If a version isn't provided in the configuration file, the fallback is the default value provided by the `scalafmt-dynamic` library (which is the same as the version of the library). Alternatively, we could keep the `scalafmtVersion` key to allow specifying a different fallback version, but then we should probably make it optional to avoid hardcoding our own default when there is already one in `scalafmt-dynamic`?

I have added an empty configuration file in the resources,  used if the project doesn't include one, because `scalafmt-dynamic` requires providing an actual config file even though Scalafmt has a reasonable set of defaults.

Finally, by default, `scalafmt-dynamic` writes messages to `System.err` but we can implement our own `ScalafmtReporter` to handle printing messages ourselves, if there is a reason to prefer that.