### PR TITLE
Scoverage multiple source folders

### DIFF
--- a/contrib/scoverage/test/resources/hello-world-sbt/core/src/main/java/Baz.java
+++ b/contrib/scoverage/test/resources/hello-world-sbt/core/src/main/java/Baz.java
@@ -1,0 +1,2 @@
+public class Baz {
+}

--- a/contrib/scoverage/test/resources/hello-world-sbt/core/src/main/scala/Foo.scala
+++ b/contrib/scoverage/test/resources/hello-world-sbt/core/src/main/scala/Foo.scala
@@ -1,0 +1,1 @@
+object Foo

--- a/contrib/scoverage/test/resources/hello-world-sbt/core/src/test/FooTest.scala
+++ b/contrib/scoverage/test/resources/hello-world-sbt/core/src/test/FooTest.scala
@@ -1,0 +1,5 @@
+import org.scalatest._
+
+class FooTest extends WordSpec {
+  "Foo" should "Baz" in { assert(true) }
+}

--- a/contrib/scoverage/test/resources/hello-world/core/test/src/GreetSpec.scala
+++ b/contrib/scoverage/test/resources/hello-world/core/test/src/GreetSpec.scala
@@ -1,0 +1,9 @@
+import org.scalatest._
+
+class GreetSpec extends WordSpec with Matchers {
+  "Greet" should {
+    "work" in {
+      Greet.greet("Nik", None) shouldBe("Hello, Nik!")
+    }
+  }
+}

--- a/contrib/scoverage/worker/1.3.1/src/ScoverageReportWorkerImpl.scala
+++ b/contrib/scoverage/worker/1.3.1/src/ScoverageReportWorkerImpl.scala
@@ -11,8 +11,7 @@ class ScoverageReportWorkerImpl extends ScoverageReportWorkerApi {
     val coverageFileObj = coverageFile(dataDir)
     val coverage = deserialize(coverageFileObj)
     coverage(invoked(findMeasurementFiles(dataDir)))
-    val Seq(PathRef(sourceFolderPath, _, _)) = sources
-    val sourceFolders = Seq(sourceFolderPath.toIO)
+    val sourceFolders = sources.map(_.path.toIO)
     val htmlFolder = new java.io.File(s"${selfDir}/htmlReport")
     htmlFolder.mkdir()
     new ScoverageHtmlWriter(sourceFolders, htmlFolder, None)


### PR DESCRIPTION
Previously, the scoverage report worker would fail on a match error if more than one source directory existed, as found in #613 by @nh13.

