### PR TITLE
Scoverage can output an XML report

### DIFF
--- a/contrib/scoverage/api/src/ScoverageReportWorkerApi.scala
+++ b/contrib/scoverage/api/src/ScoverageReportWorkerApi.scala
@@ -4,4 +4,5 @@ import mill.eval.PathRef
 
 trait ScoverageReportWorkerApi {
   def htmlReport(sources: Seq[PathRef], dataDir: String, selfDir: String): Unit
+  def xmlReport(sources: Seq[PathRef], dataDir: String, selfDir: String): Unit
 }

--- a/contrib/scoverage/src/ScoverageModule.scala
+++ b/contrib/scoverage/src/ScoverageModule.scala
@@ -45,9 +45,11 @@ import mill.moduledefs.Cacher
  *
  * - mill foo.test                   # tests your project and collects metrics on code coverage
  * - mill foo.scoverage.htmlReport   # uses the metrics collected by a previous test run to generate a coverage report in html format
+ * - mill foo.scoverage.xmlReport    # uses the metrics collected by a previous test run to generate a coverage report in xml format
  *
  * The measurement data is available at `out/foo/scoverage/data/`,
- * And the html report is saved in `out/foo/scoverage/htmlReport/`.
+ * the html report is saved in `out/foo/scoverage/htmlReport/`,
+ * and the xml report is saved in `out/foo/scoverage/xmlReport/`.
  */
 trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
   def scoverageVersion: T[String]
@@ -99,6 +101,12 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
         .scoverageReportWorker()
         .bridge(toolsClasspath().map(_.path))
         .htmlReport(sources(), dataDir().toString, selfDir().toString)
+    }
+    def xmlReport() = T.command {
+      ScoverageReportWorkerApi
+        .scoverageReportWorker()
+        .bridge(toolsClasspath().map(_.path))
+        .xmlReport(sources(), dataDir().toString, selfDir().toString)
     }
   }
 

--- a/contrib/scoverage/test/src/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/HelloWorldTests.scala
@@ -99,6 +99,11 @@ object HelloWorldTests extends utest.TestSuite {
             val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage.htmlReport)
             assert(evalCount > 0)
           }
+          "xmlReport" - workspaceTest(HelloWorld) { eval =>
+            val Right((_, _)) = eval.apply(HelloWorld.core.test.compile)
+            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage.xmlReport)
+            assert(evalCount > 0)
+          }
         }
         "test" - {
           "upstreamAssemblyClasspath" - workspaceTest(HelloWorld) { eval =>
@@ -133,6 +138,11 @@ object HelloWorldTests extends utest.TestSuite {
         "htmlReport" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
           val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
           val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage.htmlReport)
+          assert(evalCount > 0)
+        }
+        "xmlReport" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
+          val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
+          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage.xmlReport)
           assert(evalCount > 0)
         }
       }

--- a/contrib/scoverage/worker/1.3.1/src/ScoverageReportWorkerImpl.scala
+++ b/contrib/scoverage/worker/1.3.1/src/ScoverageReportWorkerImpl.scala
@@ -5,16 +5,33 @@ import mill.eval.PathRef
 import _root_.scoverage.Serializer.{ coverageFile, deserialize }
 import _root_.scoverage.IOUtils.{ findMeasurementFiles, invoked }
 import _root_.scoverage.report.ScoverageHtmlWriter
+import _root_.scoverage.report.ScoverageXmlWriter
+
+private sealed trait ReportType { def folderName: String }
+private case object Html extends ReportType { val folderName: String = "htmlReport" }
+private case object Xml extends ReportType { val folderName: String = "xmlReport" }
 
 class ScoverageReportWorkerImpl extends ScoverageReportWorkerApi {
-  def htmlReport(sources: Seq[PathRef], dataDir: String, selfDir: String) = {
+  private def buildReport(sources: Seq[PathRef], dataDir: String, selfDir: String, reportType: ReportType) = {
     val coverageFileObj = coverageFile(dataDir)
     val coverage = deserialize(coverageFileObj)
     coverage(invoked(findMeasurementFiles(dataDir)))
     val sourceFolders = sources.map(_.path.toIO)
-    val htmlFolder = new java.io.File(s"${selfDir}/htmlReport")
-    htmlFolder.mkdir()
-    new ScoverageHtmlWriter(sourceFolders, htmlFolder, None)
-      .write(coverage)
+    val folder = new java.io.File(s"${selfDir}/${reportType.folderName}")
+    folder.mkdir()
+    reportType match {
+      case Html =>
+        new ScoverageHtmlWriter(sourceFolders, folder, None)
+          .write(coverage)
+      case Xml =>
+        new ScoverageXmlWriter(sourceFolders, folder, false)
+            .write(coverage)
+    }
+  }
+  def htmlReport(sources: Seq[PathRef], dataDir: String, selfDir: String) = {
+    buildReport(sources, dataDir, selfDir, Html)
+  }
+  def xmlReport(sources: Seq[PathRef], dataDir: String, selfDir: String) = {
+    buildReport(sources, dataDir, selfDir, Xml)
   }
 }

--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -624,10 +624,12 @@ mill foo.scoverage.compile      # compiles your module with test instrumentation
 
 mill foo.test                   # tests your project and collects metrics on code coverage
 mill foo.scoverage.htmlReport   # uses the metrics collected by a previous test run to generate a coverage report in html format
+mill foo.scoverage.xmlReport    # uses the metrics collected by a previous test run to generate a coverage report in xml format
 ```
 
 The measurement data is available at `out/foo/scoverage/data/`,
-and the html report is saved in `out/foo/scoverage/htmlReport/`.
+the html report is saved in `out/foo/scoverage/htmlReport/`,
+and the xml report is saved in `out/foo/scoverage/xmlReport/`.
 
 
 ## TestNG


### PR DESCRIPTION
* use the _.scoverage.xmlReport task

@nvander1 and @lefou thank-you again for the solution in #615.  

This adds the task to output an XML report, which is required by [codecov for upload](https://docs.codecov.io/reference#section-acceptable-report-formats).  This will work with only a single module, whereas if we have multiple modules in a repo, we will need to add another PR to utilize `scoverage.report.CoverageAggregator`.  I may get to that when I need it, but for now, this is a good start.