### PR TITLE
Configurable read and connect timeouts for Sonatype publishing

### DIFF
--- a/scalalib/src/PublishModule.scala
+++ b/scalalib/src/PublishModule.scala
@@ -83,6 +83,8 @@ trait PublishModule extends JavaModule { outer =>
               gpgPassphrase: String = null,
               gpgKeyName: String = null,
               signed: Boolean = true,
+              readTimeout: Int = 1000,
+              connectTimeout: Int = 5000,
               release: Boolean): define.Command[Unit] = T.command {
     val PublishModule.PublishData(artifactInfo, artifacts) = publishArtifacts()
     new SonatypePublisher(
@@ -92,6 +94,8 @@ trait PublishModule extends JavaModule { outer =>
       Option(gpgPassphrase),
       Option(gpgKeyName),
       signed,
+      readTimeout,
+      connectTimeout,
       T.ctx().log
     ).publish(artifacts.map{case (a, b) => (a.path, b)}, artifactInfo, release)
   }
@@ -107,6 +111,8 @@ object PublishModule extends ExternalModule {
   def publishAll(sonatypeCreds: String,
                  gpgPassphrase: String = null,
                  publishArtifacts: mill.main.Tasks[PublishModule.PublishData],
+                 readTimeout: Int = 1000,
+                 connectTimeout: Int = 5000,
                  release: Boolean = false,
                  gpgKeyName: String = null,
                  sonatypeUri: String = "https://oss.sonatype.org/service/local",
@@ -123,6 +129,8 @@ object PublishModule extends ExternalModule {
       Option(gpgPassphrase),
       Option(gpgKeyName),
       signed,
+      readTimeout,
+      connectTimeout,
       T.ctx().log
     ).publishAll(
       release,

--- a/scalalib/src/publish/SonatypeHttpApi.scala
+++ b/scalalib/src/publish/SonatypeHttpApi.scala
@@ -7,8 +7,13 @@ import java.util.Base64
 import scala.concurrent.duration._
 
 
-class SonatypeHttpApi(uri: String, credentials: String) {
-  val http = requests.Session(connectTimeout = 5000, readTimeout = 1000, maxRedirects = 0)
+class SonatypeHttpApi(
+  uri: String,
+  credentials: String,
+  readTimeout: Int,
+  connectTimeout: Int
+) {
+  val http = requests.Session(readTimeout = readTimeout, connectTimeout = connectTimeout, maxRedirects = 0)
 
   private val base64Creds = base64(credentials)
 
@@ -48,7 +53,6 @@ class SonatypeHttpApi(uri: String, credentials: String) {
   def getStagingRepoState(stagingRepoId: String): String = {
     val response = http.get(
       s"${uri}/staging/repository/${stagingRepoId}",
-      readTimeout = 60000,
       headers = commonHeaders
     )
     ujson.read(response.data.text)("type").str.toString

--- a/scalalib/src/publish/SonatypePublisher.scala
+++ b/scalalib/src/publish/SonatypePublisher.scala
@@ -12,9 +12,11 @@ class SonatypePublisher(uri: String,
                         gpgPassphrase: Option[String],
                         gpgKeyName: Option[String],
                         signed: Boolean,
+                        readTimeout: Int,
+                        connectTimeout: Int,
                         log: Logger) {
 
-  private val api = new SonatypeHttpApi(uri, credentials)
+  private val api = new SonatypeHttpApi(uri, credentials, readTimeout = readTimeout, connectTimeout = connectTimeout)
 
   def publish(fileMapping: Seq[(os.Path, String)], artifact: Artifact, release: Boolean): Unit = {
     publishAll(release, fileMapping -> artifact)


### PR DESCRIPTION
As mentioned on gitter right now it never succeeds because the default timeouts for the first part `getStagingProfileUri` are too short.

I can't really test it properly because you have to publish a non-SNAPSHOT for this path to be hit..