### PR TITLE
Allow configuration of JSEnv used for Scala.js tests and runs

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -230,7 +230,9 @@ object scalajslib extends MillModule {
         Agg(
           ivy"org.scala-js::scalajs-tools:1.0.0-M2",
           ivy"org.scala-js::scalajs-sbt-test-adapter:1.0.0-M2",
-          ivy"org.scala-js::scalajs-env-nodejs:1.0.0-M2"
+          ivy"org.scala-js::scalajs-env-nodejs:1.0.0-M2",
+          ivy"org.scala-js::scalajs-env-jsdom-nodejs:1.0.0-M2",
+          ivy"org.scala-js::scalajs-env-phantomjs:1.0.0-M2"
         )
     }
   }

--- a/contrib/bloop/src/mill.contrib.bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill.contrib.bloop/BloopImpl.scala
@@ -8,7 +8,7 @@ import mill.api.Loose
 import mill.define.{Module => MillModule, _}
 import mill.eval.Evaluator
 import mill.scalajslib.ScalaJSModule
-import mill.scalajslib.api.ModuleKind
+import mill.scalajslib.api.{JsEnvConfig, ModuleKind}
 import mill.scalalib._
 import mill.scalanativelib.ScalaNativeModule
 import mill.scalanativelib.api.ReleaseMode
@@ -226,7 +226,10 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
                 case ModuleKind.CommonJSModule =>
                   Config.ModuleKindJS.CommonJSModule
               },
-              emitSourceMaps = m.jsEnvConfig().sourceMap,
+              emitSourceMaps = m.jsEnvConfig() match{
+                case c: JsEnvConfig.NodeJs => c.sourceMap
+                case _ => false
+              },
               jsdom = Some(false),
             ),
             mainClass = module.mainClass()

--- a/contrib/bloop/src/mill.contrib.bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill.contrib.bloop/BloopImpl.scala
@@ -226,7 +226,7 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
                 case ModuleKind.CommonJSModule =>
                   Config.ModuleKindJS.CommonJSModule
               },
-              emitSourceMaps = m.nodeJSConfig().sourceMap,
+              emitSourceMaps = m.jsEnvConfig().sourceMap,
               jsdom = Some(false),
             ),
             mainClass = module.mainClass()

--- a/scalajslib/api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/api/src/ScalaJSWorkerApi.scala
@@ -9,9 +9,9 @@ trait ScalaJSWorkerApi {
            fullOpt: Boolean,
            moduleKind: ModuleKind): Result[File]
 
-  def run(config: NodeJSConfig, linkedFile: File): Unit
+  def run(config: JsEnvConfig, linkedFile: File): Unit
 
-  def getFramework(config: NodeJSConfig,
+  def getFramework(config: JsEnvConfig,
                    frameworkName: String,
                    linkedFile: File): (() => Unit, sbt.testing.Framework)
 
@@ -30,12 +30,27 @@ object ModuleKind{
 }
 
 
-object NodeJSConfig {
-  import upickle.default.{ReadWriter => RW, macroRW}
-  implicit def rw: RW[NodeJSConfig] = macroRW
-}
+sealed trait JsEnvConfig
+object JsEnvConfig{
 
-final case class NodeJSConfig(executable: String = "node",
-                              args: List[String] = Nil,
-                              env: Map[String, String] = Map.empty,
-                              sourceMap: Boolean = true)
+
+  import upickle.default.{ReadWriter => RW, macroRW}
+  implicit def rwNodeJs: RW[NodeJs] = macroRW
+  implicit def rwJsDom: RW[JsDom] = macroRW
+  implicit def rwPhantom: RW[Phantom] = macroRW
+  implicit def rw: RW[JsEnvConfig] = macroRW
+
+  final case class NodeJs(executable: String = "node",
+                          args: List[String] = Nil,
+                          env: Map[String, String] = Map.empty,
+                          sourceMap: Boolean = true) extends JsEnvConfig
+
+  final case class JsDom(executable: String = "node",
+                         args: List[String] = Nil,
+                         env: Map[String, String] = Map.empty) extends JsEnvConfig
+
+  final case class Phantom(executable: String,
+                           args: List[String],
+                           env: Map[String, String],
+                           autoExit: Boolean) extends JsEnvConfig
+}

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -41,13 +41,18 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       ivy"org.scala-js::scalajs-sbt-test-adapter:${scalaJSVersion()}"
     )
     val envDep = scalaJSBinaryVersion() match {
-      case v if v.startsWith("0.6") => ivy"org.scala-js::scalajs-js-envs:${scalaJSVersion()}"
-      case v if v.startsWith("1.0") => ivy"org.scala-js::scalajs-env-nodejs:${scalaJSVersion()}"
+      case v if v.startsWith("0.6") => Seq(ivy"org.scala-js::scalajs-js-envs:${scalaJSVersion()}")
+      case v if v.startsWith("1.0") =>
+        Seq(
+          ivy"org.scala-js::scalajs-env-nodejs:${scalaJSVersion()}",
+          ivy"org.scala-js::scalajs-env-jsdom-nodejs:${scalaJSVersion()}",
+          ivy"org.scala-js::scalajs-env-phantomjs:${scalaJSVersion()}"
+        )
     }
     resolveDependencies(
       repositories,
       Lib.depToDependency(_, "2.12.4", ""),
-      commonDeps :+ envDep,
+      commonDeps ++ envDep,
       ctx = Some(implicitly[mill.util.Ctx.Log])
     )
   }
@@ -147,7 +152,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   override def platformSuffix = s"_sjs${artifactScalaJSVersion()}"
 
-  def jsEnvConfig = T { JsEnvConfig.NodeJs() }
+  def jsEnvConfig: T[JsEnvConfig] = T { JsEnvConfig.NodeJs() }
 
   def moduleKind: T[ModuleKind] = T { ModuleKind.NoModule }
 }

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -84,7 +84,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       case Right(_) =>
         ScalaJSWorkerApi.scalaJSWorker().run(
           toolsClasspath().map(_.path),
-          nodeJSConfig(),
+          jsEnvConfig(),
           fastOpt().path.toIO
         )
         Result.Success(())
@@ -147,7 +147,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 
   override def platformSuffix = s"_sjs${artifactScalaJSVersion()}"
 
-  def nodeJSConfig = T { NodeJSConfig() }
+  def jsEnvConfig = T { JsEnvConfig.NodeJs() }
 
   def moduleKind: T[ModuleKind] = T { ModuleKind.NoModule }
 }
@@ -178,7 +178,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
   override def test(args: String*) = T.command {
     val (close, framework) = mill.scalajslib.ScalaJSWorkerApi.scalaJSWorker().getFramework(
         toolsClasspath().map(_.path),
-        nodeJSConfig(),
+        jsEnvConfig(),
         testFrameworks().head,
         fastOptTest().path.toIO
       )

--- a/scalajslib/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/ScalaJSWorkerApi.scala
@@ -50,13 +50,13 @@ class ScalaJSWorker {
     ).map(os.Path(_))
   }
 
-  def run(toolsClasspath: Agg[os.Path], config: NodeJSConfig, linkedFile: File)
+  def run(toolsClasspath: Agg[os.Path], config: JsEnvConfig, linkedFile: File)
          (implicit ctx: Ctx.Home): Unit = {
     bridge(toolsClasspath).run(config, linkedFile)
   }
 
   def getFramework(toolsClasspath: Agg[os.Path],
-                   config: NodeJSConfig,
+                   config: JsEnvConfig,
                    frameworkName: String,
                    linkedFile: File)
                   (implicit ctx: Ctx.Home): (() => Unit, sbt.testing.Framework) = {

--- a/scalajslib/test/src/NodeJSConfigTests.scala
+++ b/scalajslib/test/src/NodeJSConfigTests.scala
@@ -33,7 +33,7 @@ object NodeJSConfigTests extends TestSuite {
     class BuildModule(val crossScalaVersion: String, nodeArgs: List[String]) extends HelloJSWorldModule {
       override def artifactName = "hello-js-world"
       def scalaJSVersion = NodeJSConfigTests.scalaJSVersion
-      override def nodeJSConfig = T { NodeJSConfig(args = nodeArgs) }
+      override def jsEnvConfig = T { JsEnvConfig.NodeJs(args = nodeArgs) }
     }
 
     object buildUTest extends Cross[BuildModuleUtest](matrix:_*)
@@ -45,7 +45,7 @@ object NodeJSConfigTests extends TestSuite {
         override def ivyDeps = Agg(
           ivy"com.lihaoyi::utest::$utestVersion"
         )
-        override def nodeJSConfig = T { NodeJSConfig(args = nodeArgs) }
+        override def jsEnvConfig = T { JsEnvConfig.NodeJs(args = nodeArgs) }
       }
     }
 

--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -11,9 +11,8 @@ import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker, Semantics, ModuleKind => ScalaJSModuleKind}
 import org.scalajs.core.tools.logging.ScalaConsoleLogger
 import org.scalajs.jsenv._
-import org.scalajs.jsenv.nodejs._
 import org.scalajs.testadapter.TestAdapter
-import mill.scalajslib.api.{ModuleKind, NodeJSConfig}
+import mill.scalajslib.api.{ModuleKind, JsEnvConfig}
 class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
   def link(sources: Array[File],
            libraries: Array[File],
@@ -49,16 +48,16 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
     }
   }
 
-  def run(config: NodeJSConfig, linkedFile: File): Unit = {
-    nodeJSEnv(config)
+  def run(config: JsEnvConfig, linkedFile: File): Unit = {
+    jsEnv(config)
       .jsRunner(FileVirtualJSFile(linkedFile))
       .run(new ScalaConsoleLogger, ConsoleJSConsole)
   }
 
-  def getFramework(config: NodeJSConfig,
+  def getFramework(config: JsEnvConfig,
                    frameworkName: String,
                    linkedFile: File): (() => Unit, sbt.testing.Framework) = {
-    val env = nodeJSEnv(config).loadLibs(
+    val env = jsEnv(config).loadLibs(
       Seq(ResolvedJSDependency.minimal(new FileVirtualJSFile(linkedFile)))
     )
 
@@ -76,12 +75,30 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
     )
   }
 
-  def nodeJSEnv(config: NodeJSConfig): NodeJSEnv = {
-    new NodeJSEnv(
-      NodeJSEnv.Config()
-        .withExecutable(config.executable)
-        .withArgs(config.args)
-        .withEnv(config.env)
-        .withSourceMap(config.sourceMap))
+  def jsEnv(config: JsEnvConfig): ComJSEnv = config match{
+    case config: JsEnvConfig.NodeJs =>
+      new org.scalajs.jsenv.nodejs.NodeJSEnv(
+        org.scalajs.jsenv.nodejs.NodeJSEnv.Config()
+          .withExecutable(config.executable)
+          .withArgs(config.args)
+          .withEnv(config.env)
+          .withSourceMap(config.sourceMap)
+      )
+
+    case config: JsEnvConfig.JsDom =>
+      new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(
+        org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv.Config()
+          .withExecutable(config.executable)
+          .withArgs(config.args)
+          .withEnv(config.env)
+      )
+    case config: JsEnvConfig.Phantom =>
+      new org.scalajs.jsenv.phantomjs.PhantomJSEnv(
+        org.scalajs.jsenv.phantomjs.PhantomJSEnv.Config()
+          .withExecutable(config.executable)
+          .withArgs(config.args)
+          .withEnv(config.env)
+          .withAutoExit(config.autoExit)
+      )
   }
 }


### PR DESCRIPTION
This is required to port Scalatags to Mill, since Scalatags needs a PhantomJSEnv to run its tests