### PR TITLE
Add all JAR version attributes to JavaModule

### DIFF
--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -6,7 +6,7 @@ import mill.define.Task
 import mill.define.TaskModule
 import mill.eval.{PathRef, Result}
 import mill.modules.{Assembly, Jvm}
-import mill.modules.Jvm.{createAssembly, createJar}
+import mill.modules.Jvm.{PackageVersionInfo, createAssembly, createJar}
 import Lib._
 import mill.scalalib.publish.{Artifact, Scope}
 import mill.api.Loose.Agg
@@ -38,6 +38,14 @@ trait JavaModule extends mill.Module with TaskModule { outer =>
     * class to use if one exists
     */
   def mainClass: T[Option[String]] = None
+
+  /** The implementation and specification metadata for the jar.
+    *
+    * See the following for more information:
+    *
+    *   - https://docs.oracle.com/javase/tutorial/deployment/jar/packageman.html
+    */
+  def packageVersionInfo: T[PackageVersionInfo] = T{ PackageVersionInfo.empty }
 
   def finalMainClassOpt: T[Either[String, String]] = T{
     mainClass() match{
@@ -267,7 +275,8 @@ trait JavaModule extends mill.Module with TaskModule { outer =>
     createAssembly(
       upstreamAssemblyClasspath().map(_.path),
       mainClass(),
-      assemblyRules = assemblyRules
+      assemblyRules = assemblyRules,
+      packageVersionInfo = packageVersionInfo()
     )
   }
 
@@ -281,7 +290,8 @@ trait JavaModule extends mill.Module with TaskModule { outer =>
       finalMainClassOpt().toOption,
       prependShellScript(),
       Some(upstreamAssembly().path),
-      assemblyRules
+      assemblyRules,
+      packageVersionInfo = packageVersionInfo()
     )
   }
 
@@ -292,7 +302,8 @@ trait JavaModule extends mill.Module with TaskModule { outer =>
   def jar = T{
     createJar(
       localClasspath().map(_.path).filter(os.exists),
-      mainClass()
+      mainClass(),
+      packageVersionInfo = packageVersionInfo()
     )
   }
 

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -33,7 +33,7 @@ object HelloWorldTests extends TestSuite {
   }
 
   trait HelloWorldModuleWithPackageVersionInfo extends HelloWorldModule {
-    def packageVersionInfo = PackageVersionInfo(
+    def packageVersionInfo = new PackageVersionInfo(
       specificationTitle = Some("Scala Utility Classes"),
       specificationVersion = Some("1.2"),
       specificationVendor = Some("Example Tech, Inc."),


### PR DESCRIPTION
For one of my projects, I need to set the package version information in my JAR file's manifest. Would you be open to enabling that feature within Mill?

This is my first attempt at contributing to Mill so please let me know how I can improve this PR!

See this link for more information on Jar Package Version Information:

- https://docs.oracle.com/javase/tutorial/deployment/jar/packageman.html

Thank you for your time, and also for providing such an excellent build tool.

How this can be used:

```scala
import mill._, scalalib._
import mill.modules.Jvm.PackageVersionInfo

object commons extends ScalaModule {
  def scalaVersion = "2.12.4"
  
  override def packageVersionInfo = new PackageVersionInfo(
    specificationTitle = Some("Scala Utility Classes"),
    specificationVersion = Some("1.2"),
    specificationVendor = Some("Example Tech, Inc."),
    implementationTitle = Some("scala.util"),
    implementationVersion = Some("build57"),
    implementationVendor = Some("Example Tech, Inc.")
   )
}
```