### PR TITLE
Allow to run tests with a two-level classloader setup

### DIFF
--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -221,7 +221,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule { testOute
 
   // generate a main class for the tests
   def makeTestMain = T{
-    val frameworkInstances = TestRunner.frameworks(testFrameworks()) _
+    val frameworkInstances = TestRunner.frameworks(testFrameworks())
 
     val testClasses =
       Jvm.inprocess(runClasspath().map(_.path), classLoaderOverrideSbtTesting = true, isolated = true, closeContextClassLoaderWhenDone = true,


### PR DESCRIPTION
This PR allows to run tests via a two-level classloader setup (some JARs are loaded by a first classloader, and others by a second classloader, with the first one as parent).

This can be enabled by passing a Java property `test.base.classpath` to the JVM running the tests, with something like this in a test build definition:
```scala
def forkArgs = super.forkArgs() ++ Seq(
  "-Dtest.base.classpath=" + moduleInTopLoader()
    .runClasspath()
    .map(_.path.toIO.getAbsolutePath)
    .mkString(java.io.File.pathSeparator)
)
```
The list of JARs to load in the first classloader is passed via this Java property. The remaining test JARs are loaded by the second classloader.

Context for this is [this Ammonite PR](https://github.com/lihaoyi/Ammonite/pull/941), that adds classloader isolation capabilities to Ammonite. During the Ammonite tests, things accessible from the test sessions code (Ammonite APIs, …) are loaded by the first classloader, the rest (core of Ammonite, test helpers, …) is loaded by the second loader.