### PR TITLE
Upgrade SemanticDB and Bloop supported versions

### DIFF
--- a/contrib/bloop/src/mill.contrib.bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill.contrib.bloop/BloopImpl.scala
@@ -133,21 +133,16 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
   //////////////////////////////////////////////////////////////////////////////
 
   // Version of the semanticDB plugin.
-  def semanticDBVersion: String = "4.1.4"
+  def semanticDBVersion: String = "4.1.12"
 
   // Scala versions supported by semantic db. Needs to be updated when
   // bumping semanticDBVersion.
   // See [https://github.com/scalameta/metals/blob/333ab6fc00fb3542bcabd0dac51b91b72798768a/build.sbt#L121]
   def semanticDBSupported = Set(
+    "2.13.0",
     "2.12.8",
     "2.12.7",
-    "2.12.6",
-    "2.12.5",
-    "2.12.4",
-    "2.11.12",
-    "2.11.11",
-    "2.11.10",
-    "2.11.9"
+    "2.11.12"
   )
 
   // Recommended for metals usage.


### PR DESCRIPTION
The list is updated according to https://mvnrepository.com/artifact/org.scalameta/semanticdb-scalac