### PR TITLE
Fix scoverage: inherit repositories from outer project

### DIFF
--- a/contrib/scoverage/src/ScoverageModule.scala
+++ b/contrib/scoverage/src/ScoverageModule.scala
@@ -91,6 +91,7 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     def sources = outer.sources
     def resources = outer.resources
     def scalaVersion = outer.scalaVersion()
+    def repositories = outer.repositories
     def compileIvyDeps = outer.compileIvyDeps()
     def ivyDeps = outer.ivyDeps() ++ Agg(outer.scoverageRuntimeDep())
     def scalacPluginIvyDeps = outer.scalacPluginIvyDeps() ++ Agg(outer.scoveragePluginDep())


### PR DESCRIPTION
`ScoverageModule` submodule inherits `ivyDeps` from the outer project, not inheriting `repositories`, which creates problems with resolving when package is in custom repository (#620).