### PR TITLE
Scoverage buildinfo

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -310,6 +310,12 @@ object contrib extends MillModule {
         (for ((k, v) <- mapping) yield s"-D$k=$v")
     }
 
+    // So we can test with buildinfo in the classpath
+    val test = new Tests(implicitly)
+    class Tests(ctx0: mill.define.Ctx) extends super.Tests(ctx0) {
+      override def moduleDeps = super.moduleDeps :+ contrib.buildinfo
+    }
+
     object api extends MillApiModule {
       def moduleDeps = Seq(scalalib)
     }

--- a/contrib/scoverage/src/ScoverageModule.scala
+++ b/contrib/scoverage/src/ScoverageModule.scala
@@ -87,6 +87,8 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     def selfDir = T { T.ctx().dest / os.up / os.up }
     def dataDir = T { selfDir() / "data" }
 
+    def generatedSources = outer.generatedSources()
+    def allSources = outer.allSources()
     def moduleDeps = outer.moduleDeps
     def sources = outer.sources
     def resources = outer.resources
@@ -102,13 +104,13 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
       ScoverageReportWorkerApi
         .scoverageReportWorker()
         .bridge(toolsClasspath().map(_.path))
-        .htmlReport(sources(), dataDir().toString, selfDir().toString)
+        .htmlReport(allSources(), dataDir().toString, selfDir().toString)
     }
     def xmlReport() = T.command {
       ScoverageReportWorkerApi
         .scoverageReportWorker()
         .bridge(toolsClasspath().map(_.path))
-        .xmlReport(sources(), dataDir().toString, selfDir().toString)
+        .xmlReport(allSources(), dataDir().toString, selfDir().toString)
     }
   }
 

--- a/contrib/scoverage/test/resources/hello-world/core/src/Greet.scala
+++ b/contrib/scoverage/test/resources/hello-world/core/src/Greet.scala
@@ -5,4 +5,6 @@ object Greet {
   }
 
   val foo = Foo // testing module deps
+
+  val scoverageVersionUsed = BuildInfo.scoverageVersion
 }

--- a/contrib/scoverage/test/src/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/HelloWorldTests.scala
@@ -2,6 +2,7 @@ package mill.contrib.scoverage
 
 import mill._
 import mill.api.Result
+import mill.contrib.BuildInfo
 import mill.scalalib._
 import mill.util.{TestEvaluator, TestUtil}
 import utest._
@@ -19,11 +20,15 @@ object HelloWorldTests extends utest.TestSuite {
       def scalaVersion = "2.12.4"
     }
 
-    object core extends ScoverageModule {
+    object core extends ScoverageModule with BuildInfo {
       def scalaVersion = "2.12.4"
       def scoverageVersion = "1.3.1"
 
       def moduleDeps = Seq(other)
+
+      def buildInfoMembers = T {
+        Map("scoverageVersion" -> scoverageVersion())
+      }
 
       object test extends ScoverageTests {
         override def ivyDeps = Agg(ivy"org.scalatest::scalatest:3.0.5")


### PR DESCRIPTION
Fixes #640. @lefou 

@krcz your idea about taking `generatedSources` from outer was correct. I also had to modify the `xmlReport` and `htmlReport` to pass `allSources` instead of just `sources` to the report builder so it can instrument the generated source files.

This should also fix any other tools that generate source files as part of the mill build.