### PR TITLE
Fix typo on scoverage docs

### DIFF
--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -599,7 +599,7 @@ module. Additionally, you must define a submodule that extends the
 
 ```scala
 // You have to replace VERSION
-import $ivy.`com.lihaoyi::mill-contrib-buildinfo:VERSION`
+import $ivy.`com.lihaoyi::mill-contrib-scoverage:VERSION`
 import mill.contrib.scoverage.ScoverageModule
 
 object foo extends ScoverageModule  {


### PR DESCRIPTION
The example on the documentation page imported the buildinfo package instead of scoverage.