### PR TITLE
Swap back to CI_SCRIPT env var in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,12 @@ matrix:
     env: CI_SCRIPT=ci/test-mill-dev.sh
     jdk: oraclejdk10
   - stage: build
-    env: CI_SCRIPT=ci/test-mill-bootstrap-0.sh
+    env: CI_SCRIPT=ci/test-mill-dev.sh
     jdk: oraclejdk11
+
+  - stage: build
+    env: CI_SCRIPT=ci/test-mill-bootstrap-0.sh
+    jdk: oraclejdk8
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-bootstrap-1.sh
@@ -27,21 +31,21 @@ matrix:
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-0.sh
-    jdk: oraclejdk9
-  - stage: build
-    env: CI_SCRIPT=ci/test-mill-1.sh
     jdk: oraclejdk10
   - stage: build
-    env: CI_SCRIPT=ci/test-mill-2.sh
+    env: CI_SCRIPT=ci/test-mill-1.sh
     jdk: oraclejdk11
+  - stage: build
+    env: CI_SCRIPT=ci/test-mill-2.sh
+    jdk: oraclejdk8
 
 
   - stage: release
     env: CI_SCRIPT="ci/on-master.py ci/release.sh"
-    jdk: oraclejdk8
+    jdk: oraclejdk9
   - stage: release
     env: CI_SCRIPT="ci/on-master.py ci/publish-docs.sh"
-    jdk: oraclejdk8
+    jdk: oraclejdk10
 
 script:
   - "$CI_SCRIPT"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,49 +8,47 @@ git:
 matrix:
   include:
   - stage: build
-    name: Test Mill Release with some integration tests on Java 8
-    script: ci/test-mill-release.sh
+    env: CI_SCRIPT=ci/test-mill-release.sh
     jdk: oraclejdk8
   - stage: build
-    name: Test Mill Release with some integration tests on Java 9
-    script: ci/test-mill-release.sh
+    env: CI_SCRIPT=ci/test-mill-release.sh
     jdk: oraclejdk9
 
   - stage: build
-    name: Run dev.assembly and the use it to build main tests on Java 8
-    script: ci/test-mill-dev.sh
+    env: CI_SCRIPT=ci/test-mill-dev.sh
     jdk: oraclejdk8
   - stage: build
-    name: Run dev.assembly and the use it to build main tests on Java 9
-    script: ci/test-mill-dev.sh
+    env: CI_SCRIPT=ci/test-mill-dev.sh
     jdk: oraclejdk9
 
   - stage: build
-    script: ci/test-mill-bootstrap.sh
+    env: CI_SCRIPT=ci/test-mill-bootstrap-0.sh
     jdk: oraclejdk9
 
   - stage: build
-    name: Run mill tests
-    script: ci/test-mill-0.sh
+    env: CI_SCRIPT=ci/test-mill-bootstrap-1.sh
+    jdk: oraclejdk9
+
+  - stage: build
+    env: CI_SCRIPT=ci/test-mill-0.sh
     jdk: oraclejdk8
   - stage: build
-    name: Run mill integration tests (part 1)
-    script: ci/test-mill-1.sh
+    env: CI_SCRIPT=ci/test-mill-1.sh
     jdk: oraclejdk8
   - stage: build
-    name: Run mill integration tests (part 2)
-    script: ci/test-mill-2.sh
+    env: CI_SCRIPT=ci/test-mill-2.sh
     jdk: oraclejdk9
 
 
   - stage: release
-    name: Publish mill to Maven Central and Github Releases
-    script: "ci/on-master.py ci/release.sh"
+    env: CI_SCRIPT="ci/on-master.py ci/release.sh"
     jdk: oraclejdk8
   - stage: release
-    name: Publish mill documentation site
-    script: "ci/on-master.py ci/publish-docs.sh"
+    env: CI_SCRIPT="ci/on-master.py ci/publish-docs.sh"
     jdk: oraclejdk8
+
+script:
+  - "$CI_SCRIPT"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-dev.sh
-    jdk: oraclejdk10
+    jdk: openjdk10
   - stage: build
     env: CI_SCRIPT=ci/test-mill-dev.sh
     jdk: oraclejdk11
@@ -31,7 +31,7 @@ matrix:
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-0.sh
-    jdk: oraclejdk10
+    jdk: openjdk10
   - stage: build
     env: CI_SCRIPT=ci/test-mill-1.sh
     jdk: oraclejdk11
@@ -45,7 +45,7 @@ matrix:
     jdk: oraclejdk9
   - stage: release
     env: CI_SCRIPT="ci/on-master.py ci/publish-docs.sh"
-    jdk: oraclejdk10
+    jdk: openjdk10
 
 script:
   - "$CI_SCRIPT"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     jdk: oraclejdk8
   - stage: build
     env: CI_SCRIPT=ci/test-mill-release.sh
-    jdk: oraclejdk9
+    jdk: opendk9
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-dev.sh
@@ -23,7 +23,7 @@ matrix:
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-bootstrap-0.sh
-    jdk: oraclejdk8
+    jdk: openjdk8
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-bootstrap-1.sh
@@ -34,7 +34,7 @@ matrix:
     jdk: openjdk10
   - stage: build
     env: CI_SCRIPT=ci/test-mill-1.sh
-    jdk: oraclejdk11
+    jdk: openjdk11
   - stage: build
     env: CI_SCRIPT=ci/test-mill-2.sh
     jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,14 @@ matrix:
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-dev.sh
-    jdk: oraclejdk8
+    jdk: oraclejdk10
   - stage: build
     env: CI_SCRIPT=ci/test-mill-dev.sh
-    jdk: oraclejdk9
+    jdk: oraclejdk11
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-bootstrap-0.sh
-    jdk: oraclejdk9
+    jdk: oraclejdk8
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-bootstrap-1.sh
@@ -31,13 +31,13 @@ matrix:
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-0.sh
-    jdk: oraclejdk8
+    jdk: oraclejdk10
   - stage: build
     env: CI_SCRIPT=ci/test-mill-1.sh
-    jdk: oraclejdk8
+    jdk: oraclejdk11
   - stage: build
     env: CI_SCRIPT=ci/test-mill-2.sh
-    jdk: oraclejdk9
+    jdk: oraclejdk8
 
 
   - stage: release

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,8 @@ matrix:
     env: CI_SCRIPT=ci/test-mill-dev.sh
     jdk: oraclejdk10
   - stage: build
-    env: CI_SCRIPT=ci/test-mill-dev.sh
-    jdk: oraclejdk11
-
-  - stage: build
     env: CI_SCRIPT=ci/test-mill-bootstrap-0.sh
-    jdk: oraclejdk8
+    jdk: oraclejdk11
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-bootstrap-1.sh
@@ -31,13 +27,13 @@ matrix:
 
   - stage: build
     env: CI_SCRIPT=ci/test-mill-0.sh
-    jdk: oraclejdk10
+    jdk: oraclejdk9
   - stage: build
     env: CI_SCRIPT=ci/test-mill-1.sh
-    jdk: oraclejdk11
+    jdk: oraclejdk10
   - stage: build
     env: CI_SCRIPT=ci/test-mill-2.sh
-    jdk: oraclejdk8
+    jdk: oraclejdk11
 
 
   - stage: release

--- a/ci/test-mill-bootstrap-0.sh
+++ b/ci/test-mill-bootstrap-0.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Starting from scratch...
+git clean -xdf
+
+# First build
+./mill -i all __.publishLocal launcher
+cp out/launcher/dest/mill ~/mill-1
+
+# Clean up
+git clean -xdf
+
+rm -rf ~/.mill
+
+# Differentiate first and second builds
+echo "Build 2" > info.txt && git add info.txt && git commit -m "Add info.txt"
+
+# Second build
+~/mill-1 -i all __.publishLocal launcher
+cp out/launcher/dest/mill ~/mill-2
+
+# Clean up
+git clean -xdf
+
+rm -rf ~/.mill
+
+# Use second build to run tests using Mill
+~/mill-2 -i all {main,scalalib,scalajslib}.test

--- a/ci/test-mill-bootstrap-1.sh
+++ b/ci/test-mill-bootstrap-1.sh
@@ -27,4 +27,4 @@ git clean -xdf
 rm -rf ~/.mill
 
 # Use second build to run tests using Mill
-~/mill-2 -i all {main,scalalib,scalajslib,contrib.twirllib,contrib.playlib,contrib.scalapblib,contrib.scoverage}.test
+~/mill-2 -i all contrib.{twirllib,playlib,scalapblib,scoverage}.test

--- a/ci/test-mill-dev.sh
+++ b/ci/test-mill-dev.sh
@@ -13,5 +13,5 @@ rm -rf ~/.mill
 # Second build & run tests
 out/dev/assembly/dest/mill -i main.test.compile
 
-#out/dev/assembly/dest/mill -i all {main,scalalib,scalajslib,contrib.twirllib,contrib.scalapblib}.test
+out/dev/assembly/dest/mill -i all {main,scalalib,scalajslib,contrib.twirllib,contrib.scalapblib}.test
 


### PR DESCRIPTION
This makes the travis UI print what script is being run, making it easier to trace than having to look up a name mapping

Also broke up `test-mill-bootstrap` into two jobs since it's kinda slow, and added more JDK versions to the matrix