### PR TITLE
Use the binary version of the compiler bridge when available

### DIFF
--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -45,7 +45,7 @@ object CompilationResult {
 // analysisFile is represented by os.Path, so we won't break caches after file changes
 case class CompilationResult(analysisFile: os.Path, classes: PathRef)
 
-object Util{
+object Util {
   def isDotty(scalaVersion: String) =
     scalaVersion.startsWith("0.")
 
@@ -66,16 +66,22 @@ object Util{
   private val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
   private val MinorSnapshotVersion = raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
   private val DottyVersion = raw"""0\.(\d+)\.(\d+).*""".r
+  private val DottyNightlyVersion = raw"""0\.(\d+)\.(\d+)-bin-(.*)-NIGHTLY""".r
   private val TypelevelVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-typelevel.*""".r
 
 
-  def scalaBinaryVersion(scalaVersion: String) = {
-    scalaVersion match {
+  def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
       case ReleaseVersion(major, minor, _) => s"$major.$minor"
       case MinorSnapshotVersion(major, minor, _) => s"$major.$minor"
       case DottyVersion(minor, _) => s"0.$minor"
       case TypelevelVersion(major, minor, _) => s"$major.$minor"
       case _ => scalaVersion
-    }
+  }
+
+  /** @return true if the compiler bridge can be downloaded as an already compiled jar */
+  def isBinaryBridgeAvailable(scalaVersion: String) = scalaVersion match {
+      case DottyNightlyVersion(minor, _, _) => minor.toInt >= 14 // 0.14.0-bin or more (not 0.13.0-bin)
+      case DottyVersion(minor, _) => minor.toInt >= 13 // 0.13.0-RC1 or more
+      case _ => false
   }
 }

--- a/scalalib/src/ZincWorkerModule.scala
+++ b/scalalib/src/ZincWorkerModule.scala
@@ -7,15 +7,15 @@ import mill.T
 import mill.api.KeyedLockedCache
 import mill.define.{Discover, Worker}
 import mill.scalalib.Lib.resolveDependencies
-import mill.scalalib.api.Util.isDotty
+import mill.scalalib.api.Util.{isDotty, isBinaryBridgeAvailable}
 import mill.scalalib.api.ZincWorkerApi
 import mill.api.Loose
 import mill.util.JsonFormatters._
 
-object ZincWorkerModule extends mill.define.ExternalModule with ZincWorkerModule{
+object ZincWorkerModule extends mill.define.ExternalModule with ZincWorkerModule {
   lazy val millDiscover = Discover[this.type]
 }
-trait ZincWorkerModule extends mill.Module{
+trait ZincWorkerModule extends mill.Module {
   def repositories = Seq(
     coursier.LocalRepositories.ivy2Local,
     MavenRepository("https://repo1.maven.org/maven2"),
@@ -37,7 +37,8 @@ trait ZincWorkerModule extends mill.Module{
     )
   }
 
-  def worker: Worker[mill.scalalib.api.ZincWorkerApi] = T.worker{
+  def worker: Worker[mill.scalalib.api.ZincWorkerApi] = T.worker {
+    val cp = compilerInterfaceClasspath()
     val cl = mill.api.ClassLoader.create(
       classpath().map(_.path.toNIO.toUri.toURL).toVector,
       getClass.getClassLoader
@@ -46,7 +47,7 @@ trait ZincWorkerModule extends mill.Module{
     val instance = cls.getConstructor(
       classOf[
         Either[
-          (ZincWorkerApi.Ctx, Array[os.Path], (String, String) => os.Path),
+          (ZincWorkerApi.Ctx, (String, String) => (Option[Array[os.Path]], os.Path)),
           String => os.Path
         ]
       ],
@@ -58,8 +59,7 @@ trait ZincWorkerModule extends mill.Module{
       .newInstance(
         Left((
           T.ctx(),
-          compilerInterfaceClasspath().map(_.path).toArray,
-          (x: String, y: String) => scalaCompilerBridgeSourceJar(x, y).asSuccess.get.value
+          (x: String, y: String) => scalaCompilerBridgeJar(x, y, cp).asSuccess.get.value
         )),
         mill.scalalib.api.Util.grepJar(_, "scala-library", _, sources = false),
         mill.scalalib.api.Util.grepJar(_, "scala-compiler", _, sources = false),
@@ -69,8 +69,9 @@ trait ZincWorkerModule extends mill.Module{
     instance.asInstanceOf[mill.scalalib.api.ZincWorkerApi]
   }
 
-  def scalaCompilerBridgeSourceJar(scalaVersion: String,
-                                   scalaOrganization: String) = {
+  def scalaCompilerBridgeJar(scalaVersion: String,
+                             scalaOrganization: String,
+                             compileClassPath: Agg[mill.eval.PathRef]) = {
     val (scalaVersion0, scalaBinaryVersion0) = scalaVersion match {
       case s if s.startsWith("2.13.") => ("2.13.0-M2", "2.13.0-M2")
       case _ => (scalaVersion, mill.scalalib.api.Util.scalaBinaryVersion(scalaVersion))
@@ -88,15 +89,18 @@ trait ZincWorkerModule extends mill.Module{
         val version = Versions.zinc
         (ivy"$org::$name:$version", s"${name}_$scalaBinaryVersion0", version)
       }
+    val useSources = !isBinaryBridgeAvailable(scalaVersion)
 
     resolveDependencies(
       repositories,
-      Lib.depToDependency(_, scalaVersion0, ""),
+      Lib.depToDependency(_, scalaVersion0),
       Seq(bridgeDep),
-      sources = true
-    ).map(deps =>
-      mill.scalalib.api.Util.grepJar(deps.map(_.path), bridgeName, bridgeVersion, sources = true)
-    )
+      useSources
+    ).map{deps =>
+      val cp = if (useSources) Some(compileClassPath.map(_.path).toArray) else None
+      val res = mill.scalalib.api.Util.grepJar(deps.map(_.path), bridgeName, bridgeVersion, useSources)
+      (cp, res)
+    }
   }
 
   def compilerInterfaceClasspath = T{

--- a/scalalib/test/resources/hello-dotty/boo/src/Main.scala
+++ b/scalalib/test/resources/hello-dotty/boo/src/Main.scala
@@ -1,0 +1,17 @@
+import cats._, cats.data._, cats.implicits._
+
+trait Context
+
+object Main {
+  def foo(f: given Int => Int): Int = {
+    given x as Int = 1
+    f
+  }
+
+  def main(args: Array[String]): Unit = {
+    val x = Applicative[List].pure(1)
+    assert(x == List(1))
+    val value = foo(given x => x + 1)
+    assert(value == 2)
+  }
+}

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -264,6 +264,10 @@ object HelloWorldTests extends TestSuite {
       def scalaVersion = "0.9.0-RC1"
       def ivyDeps = Agg(ivy"org.typelevel::cats-core:1.2.0".withDottyCompat(scalaVersion()))
      }
+    object boo extends ScalaModule {
+      def scalaVersion = "0.16.0-RC3"
+      def ivyDeps = Agg(ivy"org.typelevel::cats-core:1.6.1".withDottyCompat(scalaVersion()))
+    }
   }
 
   val resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world"


### PR DESCRIPTION
Implement #591: for Dotty 0.13.0-RC1 or more recent, use the normal (non-src) compiler bridge jar.
I've checked that no sources are unpacked/compiled with Dotty `0.16.0-RC3`.
