### PR TITLE
Newline before closing the wrapped code (#545)

### DIFF
--- a/main/src/main/MainRunner.scala
+++ b/main/src/main/MainRunner.scala
@@ -11,7 +11,6 @@ import mill.util.PrintLogger
 import scala.annotation.tailrec
 import ammonite.runtime.ImportHook
 
-
 /**
   * Customized version of [[ammonite.MainRunner]], allowing us to run Mill
   * `build.sc` scripts with mill-specific tweaks such as a custom
@@ -62,7 +61,6 @@ class MainRunner(val config: ammonite.main.Cli.Config,
       watchLoop2(isRepl, printing, run)
     }
   }
-
 
   override def runScript(scriptPath: os.Path, scriptArgs: List[String]) =
     watchLoop2(
@@ -169,7 +167,7 @@ class MainRunner(val config: ammonite.main.Cli.Config,
         |
         |sealed trait $wrapName extends mill.main.MainModule{
         |""".stripMargin
-      val bottom = "}"
+      val bottom = "\n}"
 
       (top, bottom, 1)
     }


### PR DESCRIPTION
Here is an extremely small PR for `MainRunner.CustomCodeWrapper`.

It seems to work with the scratch project, but there might be some other wrapping logic that need to be fixed and that I haven't found yet.