### PR TITLE
Ease the declaration of optional dependencies + handle them in maven and ivy publications

### DIFF
--- a/scalalib/src/Dep.scala
+++ b/scalalib/src/Dep.scala
@@ -31,6 +31,9 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
   def withConfiguration(configuration: String): Dep = copy(
     dep = dep.copy(configuration = coursier.core.Configuration(configuration))
   )
+  def optional(optional: Boolean = true): Dep = copy(
+    dep = dep.copy(optional = optional)
+  )
 
   /**
     * If scalaVersion is a Dotty version, replace the cross-version suffix

--- a/scalalib/src/publish/Ivy.scala
+++ b/scalalib/src/publish/Ivy.scala
@@ -42,18 +42,21 @@ object Ivy {
 
   private def renderDependency(dep: Dependency) = {
     if (dep.exclusions.isEmpty)
-      <dependency org={dep.artifact.group} name={dep.artifact.id} rev={dep.artifact.version} conf={s"${scopeToConf(dep.scope)}->${dep.configuration.getOrElse("default(compile)")}"} />
+      <dependency org={dep.artifact.group} name={dep.artifact.id} rev={dep.artifact.version} conf={s"${depIvyConf(dep)}->${dep.configuration.getOrElse("default(compile)")}"} />
     else
-      <dependency org={dep.artifact.group} name={dep.artifact.id} rev={dep.artifact.version} conf={s"${scopeToConf(dep.scope)}->${dep.configuration.getOrElse("default(compile)")}"}>
+      <dependency org={dep.artifact.group} name={dep.artifact.id} rev={dep.artifact.version} conf={s"${depIvyConf(dep)}->${dep.configuration.getOrElse("default(compile)")}"}>
         {dep.exclusions.map(ex => <exclude org={ex._1} name={ex._2} matcher="exact"/>)}
       </dependency>
   }
 
-  private def scopeToConf(s: Scope): String = s match {
-    case Scope.Compile  => "compile"
-    case Scope.Provided => "provided"
-    case Scope.Test     => "test"
-    case Scope.Runtime  => "runtime"
+  private def depIvyConf(d: Dependency): String = {
+    if (d.optional) "optional"
+    else d.scope match {
+      case Scope.Compile  => "compile"
+      case Scope.Provided => "provided"
+      case Scope.Test     => "test"
+      case Scope.Runtime  => "runtime"
+    }
   }
 
 }

--- a/scalalib/src/publish/Pom.scala
+++ b/scalalib/src/publish/Pom.scala
@@ -90,12 +90,16 @@ object Pom {
       case Scope.Test     => <scope>test</scope>
       case Scope.Runtime  => <scope>runtime</scope>
     }
+
+    val optional = if (d.optional) <optional>true</optional> else NodeSeq.Empty
+
     if (d.exclusions.isEmpty)
       <dependency>
         <groupId>{d.artifact.group}</groupId>
         <artifactId>{d.artifact.id}</artifactId>
         <version>{d.artifact.version}</version>
         {scope}
+        {optional}
       </dependency>
     else
       <dependency>
@@ -111,6 +115,7 @@ object Pom {
           )}
         </exclusions>
         {scope}
+        {optional}
       </dependency>
   }
 

--- a/scalalib/src/publish/settings.scala
+++ b/scalalib/src/publish/settings.scala
@@ -28,7 +28,8 @@ object Artifact {
         dep.dep.version
       ),
       Scope.Compile,
-      if (dep.dep.configuration == "") None else Some(dep.dep.configuration.value),
+      dep.dep.optional,
+      if (dep.dep.configuration.isEmpty) None else Some(dep.dep.configuration.value),
       dep.dep.exclusions.toList.map{case (a, b) => (a.value, b.value)}
     )
   }
@@ -45,6 +46,7 @@ object Scope {
 case class Dependency(
     artifact: Artifact,
     scope: Scope,
+    optional: Boolean = false,
     configuration: Option[String] = None,
     exclusions: Seq[(String, String)] = Nil
 )


### PR DESCRIPTION
Usage (see #603):
```scala
ivy"org.slf4j:slf4j-api:1.7.25".optional() // or .optional(true)
```

Regarding the publications:
- Optional dependencies are added to the `optional` ivy group. Is more work necessary here?
- `<optional>true</optional>` is added to optional maven dependencies
