### PR TITLE
A hacky fix for the default scalafmt issue, but it works.

### DIFF
--- a/scalalib/src/scalafmt/ScalafmtWorker.scala
+++ b/scalalib/src/scalafmt/ScalafmtWorker.scala
@@ -1,12 +1,14 @@
 package mill.scalalib.scalafmt
 
-import java.nio.file.{Paths => JPaths}
+import java.net.URI
+import java.nio.file.{FileSystems, Files, Paths => JPaths}
 
 import mill._
 import mill.define.{Discover, ExternalModule, Worker}
 import mill.api.Ctx
 import org.scalafmt.interfaces.Scalafmt
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 object ScalafmtWorkerModule extends ExternalModule {
@@ -19,8 +21,9 @@ private[scalafmt] class ScalafmtWorker {
   private val reformatted: mutable.Map[os.Path, Int] = mutable.Map.empty
   private var configSig: Int = 0
 
-  def reformat(input: Seq[PathRef],
-               scalafmtConfig: PathRef)(implicit ctx: Ctx): Unit = {
+  def reformat(input: Seq[PathRef], scalafmtConfig: PathRef)(
+      implicit ctx: Ctx
+  ): Unit = {
     val toFormat =
       if (scalafmtConfig.sig != configSig) input
       else
@@ -28,8 +31,7 @@ private[scalafmt] class ScalafmtWorker {
 
     if (toFormat.nonEmpty) {
       ctx.log.info(s"Formatting ${toFormat.size} Scala sources")
-      reformatAction(toFormat.map(_.path),
-                     scalafmtConfig.path)
+      reformatAction(toFormat.map(_.path), scalafmtConfig.path)
       reformatted ++= toFormat.map { ref =>
         val updRef = PathRef(ref.path)
         updRef.path -> updRef.sig
@@ -42,23 +44,31 @@ private[scalafmt] class ScalafmtWorker {
 
   private val cliFlags = Seq("--non-interactive", "--quiet")
 
-  private def reformatAction(toFormat: Seq[os.Path],
-                             config: os.Path)(implicit ctx: Ctx) = {
+  private def reformatAction(toFormat: Seq[os.Path], config: os.Path)(
+      implicit ctx: Ctx
+  ) = {
     val scalafmt =
       Scalafmt
         .create(this.getClass.getClassLoader)
         .withRespectVersion(false)
 
+    val configExists = os.exists(config)
     val configPath =
-      if (os.exists(config))
+      if (configExists)
         config.toNIO
-      else
-        JPaths.get(getClass.getResource("default.scalafmt.conf").toURI)
+      else {
+        val temp = Files.createTempFile("temp", ".scalafmt.conf").toUri
+        JPaths.get(temp)
+      }
 
     toFormat.foreach { pathToFormat =>
       val code = os.read(pathToFormat)
       val formatteCode = scalafmt.format(configPath, pathToFormat.toNIO, code)
       os.write.over(pathToFormat, formatteCode)
+    }
+
+    if (!configExists) {
+      Files.delete(configPath)
     }
   }
 }


### PR DESCRIPTION
This change fixes issue #676, though in a hacky way. An alternative fix in the case that you can read the mill binary is described [here](https://stackoverflow.com/questions/25032716/getting-filesystemnotfoundexception-from-zipfilesystemprovider-when-creating-a-p/25033217)

Instantiating the zipfs using the instructions here got rid of the error outlined by the stack trace in the original issue, but the filesystem was constantly complaining that the file jar:file:/home/mhammons/mill-release!/mill/scalalib/scalafmt/default.scalafmt.conf doesn't exist.