### PR TITLE
Properly support Dotty >= 0.18.1

### DIFF
--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -64,11 +64,12 @@ object Util {
       .getOrElse(throw new Exception(s"Cannot find $mavenStylePath or $ivyStylePath in ${classPath.mkString("[", ", ", "]")}"))
   }
 
-  private val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
-  private val MinorSnapshotVersion = raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
-  private val DottyVersion = raw"""(0|3)\.(\d+)\.(\d+).*""".r
-  private val DottyNightlyVersion = raw"""(0|3)\.(\d+)\.(\d+)-bin-(.*)-NIGHTLY""".r
-  private val TypelevelVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-typelevel.*""".r
+  val PartialVersion = raw"""(\d+)\.(\d+)\.*""".r
+  val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
+  val MinorSnapshotVersion = raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
+  val DottyVersion = raw"""(0|3)\.(\d+)\.(\d+).*""".r
+  val DottyNightlyVersion = raw"""(0|3)\.(\d+)\.(\d+)-bin-(.*)-NIGHTLY""".r
+  val TypelevelVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-typelevel.*""".r
 
 
   def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {

--- a/scalalib/test/resources/dotty213/foo/src/Main.scala
+++ b/scalalib/test/resources/dotty213/foo/src/Main.scala
@@ -1,0 +1,6 @@
+object Main {
+  def main(args: Array[String]): Unit = {
+    assert(collection.immutable.ArraySeq(1).toString == "ArraySeq(1)")
+    assert(scala.xml.Node.EmptyNamespace == "")
+  }
+}

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -270,6 +270,13 @@ object HelloWorldTests extends TestSuite {
     }
   }
 
+  object Dotty213 extends HelloBase {
+    object foo extends ScalaModule {
+      def scalaVersion = "0.18.1-RC1"
+      def ivyDeps = Agg(ivy"org.scala-lang.modules::scala-xml:1.2.0".withDottyCompat(scalaVersion()))
+    }
+  }
+
   val resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-world"
 
   def jarMainClass(jar: JarFile): Option[String] = {
@@ -934,6 +941,14 @@ object HelloWorldTests extends TestSuite {
         val Right((_, evalCount)) = eval.apply(HelloDotty.foo.run())
         assert(evalCount > 0)
       }
+    }
+
+    'dotty213 - workspaceTest(
+      Dotty213,
+      resourcePath = os.pwd / 'scalalib / 'test / 'resources / "dotty213"
+    ){ eval =>
+      val Right((_, evalCount)) = eval.apply(Dotty213.foo.run())
+      assert(evalCount > 0)
     }
   }
 }


### PR DESCRIPTION
Dotty now uses the 2.13 standard library, so `withDottyCompat` needs to
use the correct suffix depending on the Dotty version.