### PR TITLE
 Use dedicated output dir for mill-build module in IntelliJ IDEA

### DIFF
--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -451,7 +451,7 @@ case class GenIdeaImpl(evaluator: Evaluator,
   def rootXmlTemplate(libNames: Strict.Agg[String]) = {
     <module type="JAVA_MODULE" version={"" + ideaConfigVersion}>
       <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../out"/>
+        <output url="file://$MODULE_DIR$/../out/ideaOutputDir-mill-build"/>
         <content url="file://$MODULE_DIR$/..">
           <excludeFolder url="file://$MODULE_DIR$/../project" />
           <excludeFolder url="file://$MODULE_DIR$/../target" />

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -455,6 +455,7 @@ case class GenIdeaImpl(evaluator: Evaluator,
         <content url="file://$MODULE_DIR$/..">
           <excludeFolder url="file://$MODULE_DIR$/../project" />
           <excludeFolder url="file://$MODULE_DIR$/../target" />
+          <excludeFolder url="file://$MODULE_DIR$/../out" />
         </content>
         <exclude-output/>
         <orderEntry type="inheritedJdk" />

--- a/scalalib/test/resources/gen-idea-extended-hello-world/idea_modules/mill-build.iml
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/idea_modules/mill-build.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../out"/>
+        <output url="file://$MODULE_DIR$/../out/ideaCompileOutput-mill-build"/>
         <content url="file://$MODULE_DIR$/..">
             <excludeFolder url="file://$MODULE_DIR$/../project"/>
             <excludeFolder url="file://$MODULE_DIR$/../target"/>

--- a/scalalib/test/resources/gen-idea-extended-hello-world/idea_modules/mill-build.iml
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/idea_modules/mill-build.iml
@@ -4,6 +4,7 @@
         <content url="file://$MODULE_DIR$/..">
             <excludeFolder url="file://$MODULE_DIR$/../project"/>
             <excludeFolder url="file://$MODULE_DIR$/../target"/>
+            <excludeFolder url="file://$MODULE_DIR$/../out"/>
         </content>
         <exclude-output/>
         <orderEntry type="inheritedJdk"/>

--- a/scalalib/test/resources/gen-idea-hello-world/idea_modules/mill-build.iml
+++ b/scalalib/test/resources/gen-idea-hello-world/idea_modules/mill-build.iml
@@ -1,6 +1,6 @@
 <module type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager">
-        <output url="file://$MODULE_DIR$/../out"/>
+        <output url="file://$MODULE_DIR$/../out/ideaCompileOutput-mill-build"/>
         <content url="file://$MODULE_DIR$/..">
             <excludeFolder url="file://$MODULE_DIR$/../project"/>
             <excludeFolder url="file://$MODULE_DIR$/../target"/>

--- a/scalalib/test/resources/gen-idea-hello-world/idea_modules/mill-build.iml
+++ b/scalalib/test/resources/gen-idea-hello-world/idea_modules/mill-build.iml
@@ -4,6 +4,7 @@
         <content url="file://$MODULE_DIR$/..">
             <excludeFolder url="file://$MODULE_DIR$/../project"/>
             <excludeFolder url="file://$MODULE_DIR$/../target"/>
+            <excludeFolder url="file://$MODULE_DIR$/../out"/>
         </content>
         <exclude-output/>
         <orderEntry type="inheritedJdk"/>


### PR DESCRIPTION
This fixes issues with missing generated sources in IntelliJ IDEA after a rebuild.

It completes #694 