### PR TITLE
WIP Fix "htmlReport" does not write into dest directory

### DIFF
--- a/contrib/scoverage/worker/1.3.1/src/ScoverageReportWorkerImpl.scala
+++ b/contrib/scoverage/worker/1.3.1/src/ScoverageReportWorkerImpl.scala
@@ -17,7 +17,7 @@ class ScoverageReportWorkerImpl extends ScoverageReportWorkerApi {
     val coverage = deserialize(coverageFileObj)
     coverage(invoked(findMeasurementFiles(dataDir)))
     val sourceFolders = sources.map(_.path.toIO)
-    val folder = new java.io.File(s"${selfDir}/${reportType.folderName}")
+    val folder = new java.io.File(s"${selfDir}/${reportType.folderName}/dest")
     folder.mkdir()
     reportType match {
       case Html =>

--- a/contrib/scoverage/worker/1.4.0/src/ScoverageReportWorkerImpl.scala
+++ b/contrib/scoverage/worker/1.4.0/src/ScoverageReportWorkerImpl.scala
@@ -17,7 +17,7 @@ class ScoverageReportWorkerImpl extends ScoverageReportWorkerApi {
     val coverage = deserialize(coverageFileObj)
     coverage(invoked(findMeasurementFiles(dataDir)))
     val sourceFolders = sources.map(_.path.toIO)
-    val folder = new java.io.File(s"${selfDir}/${reportType.folderName}")
+    val folder = new java.io.File(s"${selfDir}/${reportType.folderName}/dest")
     folder.mkdir()
     reportType match {
       case Html =>


### PR DESCRIPTION
@lefou To fix #651

It's been a bit since I've seen the code. I can't recall why I have duplicated the worker modules for scoverage 1.3.1 and 1.4.0. I want to address it, but I don't think I should mix that address with this bugfix. I'll open a separate patch for that.

Also, going to try to modify the tests to verify these reports are generated in the right directories. I'll dig into the project to look for similar tests that do this, if you know of any modules to check as a starting point let me know :)