### PR TITLE
Add `scalaPBProtocPath` option to scalapblib

### DIFF
--- a/contrib/scalapblib/src/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/ScalaPBModule.scala
@@ -29,6 +29,8 @@ trait ScalaPBModule extends ScalaModule {
 
   def scalaPBSingleLineToProtoString: T[Boolean] = T { false }
 
+  def scalaPBProtocPath: T[Option[String]] = T { None }
+
   def scalaPBSources: Sources = T.sources {
     millSourcePath / 'protobuf
   }
@@ -63,6 +65,7 @@ trait ScalaPBModule extends ScalaModule {
     ScalaPBWorkerApi.scalaPBWorker
       .compile(
         scalaPBClasspath().map(_.path),
+        scalaPBProtocPath(),
         scalaPBSources().map(_.path),
         scalaPBOptions(),
         T.ctx().dest)

--- a/contrib/scalapblib/test/src/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/TutorialTests.scala
@@ -24,6 +24,12 @@ object TutorialTests extends TestSuite {
     }
   }
 
+  object TutorialWithProtoc extends TutorialBase {
+    object core extends TutorialModule {
+      override def scalaPBProtocPath = Some("/dev/null")
+    }
+  }
+
   val resourcePath: os.Path = os.pwd / 'contrib / 'scalapblib / 'test / 'protobuf / 'tutorial
 
   def protobufOutPath(eval: TestEvaluator): os.Path =
@@ -107,6 +113,16 @@ object TutorialTests extends TestSuite {
 
       //   assert(unchangedEvalCount == 0)
       // }
+    }
+
+    'useExternalProtocCompiler - {
+      /* This ensure that the `scalaPBProtocPath` is properly used.
+       * As the given path is incorrect, the compilation should fail.
+       */
+      'calledWithWrongProtocFile - workspaceTest(TutorialWithProtoc) { eval =>
+        val result = eval.apply(TutorialWithProtoc.core.compileScalaPB)
+        assert(result.isLeft)
+      }
     }
   }
 }

--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -564,6 +564,8 @@ example/
 
 * scalaPBSingleLineToProtoString - A `Boolean` option which determines whether the generated `.toString` methods should use a single line format.
 
+* scalaPBProtocPath - A `Option[Path]` option which determines the protoc compiler to use. If `None`, a java embedded protoc will be used, if set to `Some` path, the given binary is used.
+
 If you'd like to configure the options that are passed to the ScalaPB compiler directly, you can override the `scalaPBOptions` task, for example:
 
 ```scala


### PR DESCRIPTION
Add an option to ScalaPBModule to allow setting the protoc compiler. This is useful for systems that can't run the jar embedded protoc.