### PR TITLE
make coursier download dependency sources

### DIFF
--- a/contrib/bsp/src/mill/contrib/bsp/MillBuildServer.scala
+++ b/contrib/bsp/src/mill/contrib/bsp/MillBuildServer.scala
@@ -154,17 +154,17 @@ class MillBuildServer(evaluator: Evaluator,
       for (targetId <- dependencySourcesParams.getTargets.asScala) {
         val millModule = targetIdToModule(targetId)
         var sources = evaluateInformativeTask(evaluator,
-                                              millModule.resolveDeps(millModule.transitiveIvyDeps),
+                                              millModule.resolveDeps(millModule.transitiveIvyDeps, true),
                                               Agg.empty[PathRef]) ++
           evaluateInformativeTask(evaluator,
-                                  millModule.resolveDeps(millModule.compileIvyDeps),
+                                  millModule.resolveDeps(millModule.compileIvyDeps, true),
                                   Agg.empty[PathRef]) ++
           evaluateInformativeTask(evaluator,
                                   millModule.unmanagedClasspath,
                                   Agg.empty[PathRef])
         millModule match {
           case _: ScalaModule => sources ++= evaluateInformativeTask(evaluator,
-                                                                     millModule.resolveDeps(millModule.asInstanceOf[ScalaModule].scalaLibraryIvyDeps),
+                                                                     millModule.resolveDeps(millModule.asInstanceOf[ScalaModule].scalaLibraryIvyDeps, true),
                                                                      Agg.empty[PathRef])
           case _: JavaModule => sources ++= List()
         }


### PR DESCRIPTION
Before this PR, invoking bsp won't download sources from maven center, since `resolveDeps` is set to `false` by default, this PR will ask mill to download all sources(including mill sources) to fix this issue.
I think this should also be handled by Intellij too, since sbt has configurations to let user decide downloading source or not, bsp in Intellij didn't give this option to user. 