### PR TITLE
Remove contrib modules from main distribution

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -573,7 +573,7 @@ def launcherScript(shellJvmArgs: Seq[String],
 }
 
 object dev extends MillModule{
-  def moduleDeps = Seq(scalalib, scalajslib, scalanativelib, contrib.scalapblib, contrib.tut, contrib.scoverage, contrib.bsp)
+  def moduleDeps = Seq(scalalib, scalajslib, scalanativelib)
 
 
   def forkArgs =


### PR DESCRIPTION
They're bloating things up to an unacceptable degree, with the main jar size up to 50mb from 37mb not too long ago.

The whole point of contrib modules is that they're not part of the main distribution, but can be `import $ivy`ed in, so let's make them follow that convention