### PR TITLE
Make FileLogger use Files.newOutputStream from nio

### DIFF
--- a/main/core/src/util/Loggers.scala
+++ b/main/core/src/util/Loggers.scala
@@ -1,6 +1,8 @@
 package mill.util
 
 import java.io._
+import java.nio.file.Files
+
 import mill.api.Logger
 
 object DummyLogger extends Logger {
@@ -108,7 +110,7 @@ case class FileLogger(colored: Boolean, file: os.Path, debugEnabled: Boolean) ex
   lazy val outputStream = {
     if (!outputStreamUsed) os.remove.all(file)
     outputStreamUsed = true
-    new PrintStream(new FileOutputStream(file.toIO.getAbsolutePath))
+    new PrintStream(Files.newOutputStream(file.toNIO))
   }
 
   lazy val errorStream = outputStream


### PR DESCRIPTION
Fixes #665 and #605 which caused by `FileLogger`s in loggers surrounding task evaluation holding the log file and clean task attempts to delete log file. While Windows implementation of `FileOutputStream` does not allow open and delete file at the same time, `Files.newOutputStream` does (JDK only set the FILE_SHARE_DELETE flag in latter version).