### PR TITLE
Add task to only check formatting of Scala files

### DIFF
--- a/docs/pages/2 - Configuring Mill.md
+++ b/docs/pages/2 - Configuring Mill.md
@@ -259,9 +259,10 @@ object foo extends ScalaModule with ScalafmtModule {
 }
 ```
 
-Now you can reformat code with `mill foo.reformat` command.
+Now you can reformat code with `mill foo.reformat` command, or only check for misformatted files with `mill checkFormat`.
 
-You can also reformat your project's code globally with `mill mill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources` command.
+You can also reformat your project's code globally with `mill mill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources` command,
+or only check the code's format with `mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources`.
 It will reformat all sources that matches `__.sources` query.
 
 If you add a `.scalafmt.conf` file at the root of you project, it will be used

--- a/scalalib/src/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/scalafmt/ScalafmtModule.scala
@@ -15,6 +15,15 @@ trait ScalafmtModule extends JavaModule {
       )
   }
 
+  def checkFormat(): Command[Unit] = T.command {
+    ScalafmtWorkerModule
+      .worker()
+      .checkFormat(
+        filesToFormat(sources()),
+        scalafmtConfig().head
+      )
+  }
+
   def scalafmtConfig: Sources = T.sources(os.pwd / ".scalafmt.conf")
 
   protected def filesToFormat(sources: Seq[PathRef]) = {
@@ -34,6 +43,17 @@ object ScalafmtModule extends ExternalModule with ScalafmtModule {
       ScalafmtWorkerModule
         .worker()
         .reformat(
+          files,
+          scalafmtConfig().head
+        )
+    }
+
+  def checkFormatAll(sources: mill.main.Tasks[Seq[PathRef]]): Command[Unit] =
+    T.command {
+      val files = Task.sequence(sources.value)().flatMap(filesToFormat)
+      ScalafmtWorkerModule
+        .worker()
+        .checkFormat(
           files,
           scalafmtConfig().head
         )


### PR DESCRIPTION
Adds a new task 'checkFormat' to the scalafmt module that only checks if all files are formatted. It is basically equivalent to the `--test` flag that can be passed to scalafmt on the command line, and can come in very handy in CI scripts.

Caching is preserved wrt to the 'reformat' action, so that only unformatted or changed files are checked.