### PR TITLE
Added CoursierModule as parent of JavaModule

### DIFF
--- a/scalalib/src/CoursierModule.scala
+++ b/scalalib/src/CoursierModule.scala
@@ -1,0 +1,49 @@
+package mill.scalalib
+
+import coursier.{Dependency, Repository}
+import mill.{Agg, T}
+import mill.define.Task
+import mill.eval.PathRef
+
+/**
+  * This module provides the capability to resolve (transitive) dependencies from (remote) repositories.
+  *
+  * It's mainly used in [[JavaModule]], but can also be used stand-alone,
+  * in which case you must provide repositories by overriding [[CoursierModule.repositories]].
+  */
+trait CoursierModule extends mill.Module {
+
+  def resolveCoursierDependency: Task[Dep => coursier.Dependency] = T.task {
+    Lib.depToDependencyJava(_: Dep)
+  }
+
+  /**
+    * Task that resolves the given dependencies using the repositories defined with [[repositories]].
+    *
+    * @param deps    The dependencies to resolve.
+    * @param sources If `true`, resolve source dependencies instead of binary dependencies (JARs).
+    * @return The [[PathRef]]s to the resolved files.
+    */
+  def resolveDeps(deps: Task[Agg[Dep]], sources: Boolean = false): Task[Agg[PathRef]] = T.task {
+    Lib.resolveDependencies(
+      repositories,
+      resolveCoursierDependency().apply(_),
+      deps(),
+      sources,
+      mapDependencies = Some(mapDependencies()),
+      Some(implicitly[mill.util.Ctx.Log])
+    )
+  }
+
+  /**
+    * Map dependencies before resolving them.
+    * Override this to customize the set of dependencies.
+    */
+  def mapDependencies: Task[Dependency => Dependency] = T.task { d: coursier.Dependency => d }
+
+  /**
+    * The repositories used to resolved dependencies with [[resolveDeps()]].
+    */
+  def repositories: Seq[Repository]
+
+}

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -16,7 +16,11 @@ import mill.api.Loose.Agg
 /**
   * Core configuration required to compile a single Scala compilation target
   */
-trait JavaModule extends mill.Module with TaskModule with GenIdeaModule { outer =>
+trait JavaModule extends mill.Module
+  with TaskModule
+  with GenIdeaModule
+  with CoursierModule { outer =>
+
   def zincWorker: ZincWorkerModule = mill.scalalib.ZincWorkerModule
 
   trait Tests extends TestModule{
@@ -29,9 +33,6 @@ trait JavaModule extends mill.Module with TaskModule with GenIdeaModule { outer 
 
   def resolvePublishDependency: Task[Dep => publish.Dependency] = T.task{
     Artifact.fromDepJava(_: Dep)
-  }
-  def resolveCoursierDependency: Task[Dep => coursier.Dependency] = T.task{
-    Lib.depToDependencyJava(_: Dep)
   }
 
   /**
@@ -132,27 +133,13 @@ trait JavaModule extends mill.Module with TaskModule with GenIdeaModule { outer 
     )().flatten
   }
 
-  def mapDependencies = T.task{ d: coursier.Dependency => d }
-
-  def resolveDeps(deps: Task[Agg[Dep]], sources: Boolean = false) = T.task{
-    resolveDependencies(
-      repositories,
-      resolveCoursierDependency().apply(_),
-      deps(),
-      sources,
-      mapDependencies = Some(mapDependencies()),
-      Some(implicitly[mill.util.Ctx.Log])
-    )
-  }
-
-
   def repositories: Seq[Repository] = zincWorker.repositories
 
   /**
     * What platform suffix to use for publishing, e.g. `_sjs` for Scala.js
     * projects
     */
-  def platformSuffix = T{ "" }
+  def platformSuffix: T[String] = T{ "" }
 
   private val Milestone213 = raw"""2.13.(\d+)-M(\d+)""".r
 


### PR DESCRIPTION
This enables the user to resolve dependencies without defining a Java/Scala module, e.g. in assembly modules.

Fixes https://github.com/lihaoyi/mill/issues/722