### PR TITLE
Add support for Scala.js 0.6.29+ and 1.0.0-RC1.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -18,11 +18,11 @@ object Deps {
   }
 
   object Scalajs_1_0 {
-    val scalajsEnvJsdomNodejs =  ivy"org.scala-js::scalajs-env-jsdom-nodejs:1.0.0-M2"
-    val scalajsEnvNodejs =  ivy"org.scala-js::scalajs-env-nodejs:1.0.0-M2"
-    val scalajsEnvPhantomjs =  ivy"org.scala-js::scalajs-env-phantomjs:1.0.0-M2"
-    val scalajsSbtTestAdapter = ivy"org.scala-js::scalajs-sbt-test-adapter:1.0.0-M2"
-    val scalajsTools = ivy"org.scala-js::scalajs-tools:1.0.0-M2"
+    val scalajsEnvJsdomNodejs =  ivy"org.scala-js::scalajs-env-jsdom-nodejs:1.0.0-RC1"
+    val scalajsEnvNodejs =  ivy"org.scala-js::scalajs-env-nodejs:1.0.0-RC1"
+    val scalajsEnvPhantomjs =  ivy"org.scala-js::scalajs-env-phantomjs:1.0.0-RC1"
+    val scalajsSbtTestAdapter = ivy"org.scala-js::scalajs-sbt-test-adapter:1.0.0-RC1"
+    val scalajsLinker = ivy"org.scala-js::scalajs-linker:1.0.0-RC1"
   }
 
   val acyclic = ivy"com.lihaoyi::acyclic:0.1.7"
@@ -310,7 +310,7 @@ object scalajslib extends MillModule {
         )
       case "1.0" =>
         Agg(
-          Deps.Scalajs_1_0.scalajsTools,
+          Deps.Scalajs_1_0.scalajsLinker,
           Deps.Scalajs_1_0.scalajsSbtTestAdapter,
           Deps.Scalajs_1_0.scalajsEnvNodejs,
           Deps.Scalajs_1_0.scalajsEnvJsdomNodejs,

--- a/scalajslib/api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/api/src/ScalaJSWorkerApi.scala
@@ -6,6 +6,7 @@ trait ScalaJSWorkerApi {
            libraries: Array[File],
            dest: File,
            main: String,
+           testBridgeInit: Boolean,
            fullOpt: Boolean,
            moduleKind: ModuleKind): Result[File]
 

--- a/scalajslib/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/ScalaJSWorkerApi.scala
@@ -35,6 +35,7 @@ class ScalaJSWorker {
            libraries: Agg[os.Path],
            dest: File,
            main: Option[String],
+           testBridgeInit: Boolean,
            fullOpt: Boolean,
            moduleKind: ModuleKind)
           (implicit ctx: Ctx.Home): Result[os.Path] = {
@@ -43,6 +44,7 @@ class ScalaJSWorker {
       libraries.items.map(_.toIO).toArray,
       dest,
       main.orNull,
+      testBridgeInit,
       fullOpt,
       moduleKind
     ).map(os.Path(_))

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -24,8 +24,8 @@ object HelloJSWorldTests extends TestSuite {
 
   object HelloJSWorld extends TestUtil.BaseModule {
     val matrix = for {
-      scala <- Seq("2.11.8", "2.12.3", "2.12.4")
-      scalaJS <- Seq("0.6.22", "1.0.0-M2")
+      scala <- Seq("2.11.12", "2.12.3", "2.12.4")
+      scalaJS <- Seq("0.6.22", "0.6.31", "1.0.0-RC1")
     } yield (scala, scalaJS)
 
     object helloJsWorld extends Cross[BuildModule](matrix:_*)
@@ -62,7 +62,7 @@ object HelloJSWorldTests extends TestSuite {
         override def sources = T.sources{ millSourcePath / 'src / 'scalatest }
         def testFrameworks = Seq("org.scalatest.tools.Framework")
         override def ivyDeps = Agg(
-          ivy"org.scalatest::scalatest::3.0.4"
+          ivy"org.scalatest::scalatest::3.1.0"
         )
       }
     }
@@ -100,8 +100,8 @@ object HelloJSWorldTests extends TestSuite {
 
       'fromScratch_2124_0622 - testCompileFromScratch("2.12.4", "0.6.22")
       'fromScratch_2123_0622 - testCompileFromScratch("2.12.3", "0.6.22")
-      'fromScratch_2118_0622 - TestUtil.disableInJava9OrAbove(testCompileFromScratch("2.11.8", "0.6.22"))
-      'fromScratch_2124_100M2 - testCompileFromScratch("2.12.4", "1.0.0-M2")
+      'fromScratch_21112_0622 - TestUtil.disableInJava9OrAbove(testCompileFromScratch("2.11.12", "0.6.22"))
+      'fromScratch_2124_100RC1 - testCompileFromScratch("2.12.4", "1.0.0-RC1")
     }
 
     def testRun(scalaVersion: String,
@@ -119,14 +119,14 @@ object HelloJSWorldTests extends TestSuite {
     'fullOpt - {
       'run_2124_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "0.6.22", FullOpt))
       'run_2123_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.3", "0.6.22", FullOpt))
-      'run_2118_0622 - TestUtil.disableInJava9OrAbove(testRun("2.11.8", "0.6.22", FullOpt))
-      'run_2124_100M2 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "1.0.0-M2", FullOpt))
+      'run_21112_0622 - TestUtil.disableInJava9OrAbove(testRun("2.11.12", "0.6.22", FullOpt))
+      'run_2124_100RC1 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "1.0.0-RC1", FullOpt))
     }
     'fastOpt - {
       'run_2124_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "0.6.22", FastOpt))
       'run_2123_0622 - TestUtil.disableInJava9OrAbove(testRun("2.12.3", "0.6.22", FastOpt))
-      'run_2118_0622 - TestUtil.disableInJava9OrAbove(testRun("2.11.8", "0.6.22", FastOpt))
-      'run_2124_100M2 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "1.0.0-M2", FastOpt))
+      'run_21112_0622 - TestUtil.disableInJava9OrAbove(testRun("2.11.12", "0.6.22", FastOpt))
+      'run_2124_100RC1 - TestUtil.disableInJava9OrAbove(testRun("2.12.4", "1.0.0-RC1", FastOpt))
     }
     'jar - {
       'containsSJSIRs - {
@@ -144,7 +144,7 @@ object HelloJSWorldTests extends TestSuite {
         assert(result.id == artifactId)
       }
       'artifactId_0622 - testArtifactId("2.12.4", "0.6.22", "hello-js-world_sjs0.6_2.12")
-      'artifactId_100M2 - testArtifactId("2.12.4", "1.0.0-M2", "hello-js-world_sjs1.0.0-M2_2.12")
+      'artifactId_100RC1 - testArtifactId("2.12.4", "1.0.0-RC1", "hello-js-world_sjs1.0-RC1_2.12")
     }
     'test - {
       def runTests(testTask: define.Command[(String, Seq[TestRunner.Result])]): Map[String, Map[String, TestRunner.Result]] = {
@@ -190,16 +190,19 @@ object HelloJSWorldTests extends TestSuite {
         )
       }
 
-      'utest_2118_0622 - TestUtil.disableInJava9OrAbove(checkUtest("2.11.8", "0.6.22"))
+      'utest_21112_0622 - TestUtil.disableInJava9OrAbove(checkUtest("2.11.12", "0.6.22"))
       'utest_2124_0622 - checkUtest("2.12.4", "0.6.22")
-      'utest_2118_100M2 - TestUtil.disableInJava9OrAbove(checkUtest("2.11.8", "1.0.0-M2"))
-      'utest_2124_100M2 - checkUtest("2.12.4", "1.0.0-M2")
+      'utest_21112_0631 - TestUtil.disableInJava9OrAbove(checkUtest("2.11.12", "0.6.31"))
+      'utest_2124_0631 - checkUtest("2.12.4", "0.6.31")
+//      No utest artifact for Scala.js 1.0.0-RC1 published yet
+//      'utest_21112_100RC1 - TestUtil.disableInJava9OrAbove(checkUtest("2.11.12", "1.0.0-RC1"))
+//      'utest_2124_100RC1 - checkUtest("2.12.4", "1.0.0-RC1")
 
-      'scalaTest_2118_0622 - TestUtil.disableInJava9OrAbove(checkScalaTest("2.11.8", "0.6.22"))
-      'scalaTest_2124_0622 - checkScalaTest("2.12.4", "0.6.22")
-//      No scalatest artifact for scala.js 1.0.0-M2 published yet
-//      'scalaTest_2118_100M2 - checkScalaTest("2.11.8", "1.0.0-M2")
-//      'scalaTest_2124_100M2 - checkScalaTest("2.12.4", "1.0.0-M2")
+      // No test for ScalaTest with 0.6.22 because ScalaTest 3.1.0 requires Scala.js 0.6.29+
+      'scalaTest_21112_0631 - TestUtil.disableInJava9OrAbove(checkScalaTest("2.11.12", "0.6.31"))
+      'scalaTest_2124_0631 - checkScalaTest("2.12.4", "0.6.31")
+      'scalaTest_21112_100RC1 - checkScalaTest("2.11.12", "1.0.0-RC1")
+      'scalaTest_2124_100RC1 - checkScalaTest("2.12.4", "1.0.0-RC1")
     }
 
     def checkRun(scalaVersion: String, scalaJSVersion: String): Unit = {
@@ -215,15 +218,16 @@ object HelloJSWorldTests extends TestSuite {
       assert(
         evalCount > 0,
         log.contains("node"),
-        log.contains("Scala.js")
+        // In Scala.js 1.x, println's are sent to the stdout, not to the logger
+        !scalaJSVersion.startsWith("0.6.") || log.contains("Scala.js")
       )
     }
 
     'run - {
-      'run_2118_0622  - TestUtil.disableInJava9OrAbove(checkRun("2.11.8", "0.6.22"))
+      'run_21112_0622  - TestUtil.disableInJava9OrAbove(checkRun("2.11.12", "0.6.22"))
       'run_2124_0622  - checkRun("2.12.4", "0.6.22")
-      'run_2118_100M2 - TestUtil.disableInJava9OrAbove(checkRun("2.11.8", "1.0.0-M2"))
-      'run_2124_100M2 - checkRun("2.12.4", "1.0.0-M2")
+      'run_21112_100RC1 - TestUtil.disableInJava9OrAbove(checkRun("2.11.12", "1.0.0-RC1"))
+      'run_2124_100RC1 - checkRun("2.12.4", "1.0.0-RC1")
     }
   }
 

--- a/scalajslib/test/src/ScalaJsUtils.scala
+++ b/scalajslib/test/src/ScalaJsUtils.scala
@@ -4,6 +4,10 @@ import java.io.{FileReader, StringWriter}
 import javax.script.{ScriptContext, ScriptEngineManager}
 
 object ScalaJsUtils {
+  /* TODO Using Nashorn means that we do not support ECMAScript 2015, which
+   * forces ScalaJSWorkerImpl to always use ES 5.1. We should a different
+   * engine, perhaps Scala.js' own JSEnv, to perform these tests.
+   */
   def runJS(path: os.Path): String = {
     val engineManager = new ScriptEngineManager(null)
     val engine = engineManager.getEngineByName("nashorn")

--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -20,6 +20,7 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
            libraries: Array[File],
            dest: File,
            main: String,
+           testBridgeInit: Boolean, // ignored in 0.6
            fullOpt: Boolean,
            moduleKind: ModuleKind) = {
 

--- a/scalajslib/worker/1.0/src/Run.scala
+++ b/scalajslib/worker/1.0/src/Run.scala
@@ -1,0 +1,51 @@
+package mill
+package scalajslib
+package worker
+
+import org.scalajs.jsenv._
+
+import scala.concurrent._
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/* Copy-pasted from sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Run.scala
+ * in scala-js/scala-js.
+ */
+private[worker] object Run {
+  /** Starts and waits for a run on the given [[JSEnv]] interruptibly.
+   *
+   *  Interruption can be triggered by typing anything into stdin.
+   */
+  def runInterruptible(jsEnv: JSEnv, input: Seq[Input], config: RunConfig): Unit = {
+    val readPromise = Promise[Unit]()
+    val readThread = new Thread {
+      override def run(): Unit = {
+        try {
+          while (System.in.available() == 0) {
+            Thread.sleep(50)
+          }
+
+          System.in.read()
+        } catch {
+          case _: InterruptedException =>
+        } finally {
+          readPromise.success(())
+        }
+      }
+    }
+
+    val run = jsEnv.start(input, config)
+    try {
+      readThread.start()
+
+      val fut = Future.firstCompletedOf(List(readPromise.future, run.future))
+      Await.result(fut, Duration.Inf)
+    } finally {
+      run.close()
+    }
+
+    readThread.interrupt()
+    readThread.join()
+    Await.result(run.future, Duration.Inf)
+  }
+}

--- a/scalajslib/worker/1.0/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1.0/src/ScalaJSWorkerImpl.scala
@@ -2,23 +2,30 @@ package mill
 package scalajslib
 package worker
 
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
 import java.io.File
 
 import mill.api.Result
 import mill.scalajslib.api.{JsEnvConfig, ModuleKind}
-import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.linker.{ModuleInitializer, Semantics, StandardLinker, ModuleKind => ScalaJSModuleKind}
-import org.scalajs.core.tools.logging.ScalaConsoleLogger
-import org.scalajs.jsenv.ConsoleJSConsole
-import org.scalajs.testadapter.TestAdapter
+import org.scalajs.linker.{PathIRContainer, PathIRFile, PathOutputFile, StandardImpl}
+import org.scalajs.linker.interface.{ModuleKind => ScalaJSModuleKind, _}
+import org.scalajs.logging.ScalaConsoleLogger
+import org.scalajs.jsenv.{Input, JSEnv, RunConfig}
+import org.scalajs.jsenv.nodejs._
+import org.scalajs.jsenv.nodejs.NodeJSEnv.SourceMap
+import org.scalajs.testing.adapter.TestAdapter
+import org.scalajs.testing.adapter.{TestAdapterInitializer => TAI}
 
 class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
   def link(sources: Array[File],
            libraries: Array[File],
            dest: File,
            main: String,
+           testBridgeInit: Boolean,
            fullOpt: Boolean,
            moduleKind: ModuleKind) = {
+    import scala.concurrent.ExecutionContext.Implicits.global
     val semantics = fullOpt match {
         case true => Semantics.Defaults.optimized
         case false => Semantics.Defaults
@@ -27,32 +34,50 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
       case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
       case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
     }
-    val config = StandardLinker.Config()
+    /* TODO We currently force ECMAScript 5.1, because the *tests* of
+     * scalajslib use Nashorn (see ScalaJsUtils.scala) which does not support
+     * ES 2015. This should at least be turned into a configuration option, but
+     * also we should change ScalaJsUtils to support ES 2015, for example by
+     * using Scala.js' own NodeJSEnv to perform the tests.
+     */
+    val config = StandardConfig()
       .withOptimizer(fullOpt)
       .withClosureCompilerIfAvailable(fullOpt)
       .withSemantics(semantics)
       .withModuleKind(scalaJSModuleKind)
-    val linker = StandardLinker(config)
-    val cache = new IRFileCache().newCache
-    val sourceIRs = sources.map(FileVirtualScalaJSIRFile)
-    val irContainers = FileScalaJSIRContainer.fromClasspath(libraries)
-    val libraryIRs = cache.cached(irContainers)
-    val destFile = AtomicWritableFileVirtualJSFile(dest)
+      .withESFeatures(_.withUseECMAScript2015(false))
+    val linker = StandardImpl.linker(config)
+    val cache = StandardImpl.irFileCache().newCache
+    val sourceIRsFuture = Future.sequence(sources.toSeq.map(f => PathIRFile(f.toPath())))
+    val irContainersPairs = PathIRContainer.fromClasspath(libraries.map(_.toPath()))
+    val libraryIRsFuture = irContainersPairs.flatMap(pair => cache.cached(pair._1))
+    val linkerOutput = LinkerOutput(PathOutputFile(dest.toPath()))
     val logger = new ScalaConsoleLogger
-    val initializer = Option(main).map { cls => ModuleInitializer.mainMethodWithArgs(cls, "main") }
+    val mainInitializer = Option(main).map { cls => ModuleInitializer.mainMethodWithArgs(cls, "main") }
+    val testInitializer =
+      if (testBridgeInit) Some(ModuleInitializer.mainMethod(TAI.ModuleClassName, TAI.MainMethodName))
+      else None
+    val moduleInitializers = mainInitializer.toList ::: testInitializer.toList
 
-    try {
-      linker.link(sourceIRs ++ libraryIRs, initializer.toSeq, destFile, logger)
+    val resultFuture = (for {
+      sourceIRs <- sourceIRsFuture
+      libraryIRs <- libraryIRsFuture
+      _ <- linker.link(sourceIRs ++ libraryIRs, moduleInitializers, linkerOutput, logger)
+    } yield {
       Result.Success(dest)
-    }catch {case e: org.scalajs.core.tools.linker.LinkingException =>
-      Result.Failure(e.getMessage)
+    }).recover {
+      case e: org.scalajs.linker.interface.LinkingException =>
+        Result.Failure(e.getMessage)
     }
+
+    Await.result(resultFuture, Duration.Inf)
   }
 
   def run(config: JsEnvConfig, linkedFile: File): Unit = {
-    jsEnv(config)
-      .jsRunner(Seq(FileVirtualJSFile(linkedFile)))
-      .run(new ScalaConsoleLogger, ConsoleJSConsole)
+    val env = jsEnv(config)
+    val input = jsEnvInput(linkedFile)
+    val runConfig = RunConfig().withLogger(new ScalaConsoleLogger)
+    Run.runInterruptible(env, input, runConfig)
   }
 
   def getFramework(config: JsEnvConfig,
@@ -60,10 +85,10 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
                    linkedFile: File,
                    moduleKind: ModuleKind) : (() => Unit, sbt.testing.Framework) = {
     val env = jsEnv(config)
+    val input = jsEnvInput(linkedFile)
     val tconfig = TestAdapter.Config().withLogger(new ScalaConsoleLogger)
 
-    val adapter =
-      new TestAdapter(env, Seq(FileVirtualJSFile(linkedFile)), tconfig)
+    val adapter = new TestAdapter(env, input, tconfig)
 
     (
       () => adapter.close(),
@@ -75,14 +100,21 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
     )
   }
 
-  def jsEnv(config: JsEnvConfig): org.scalajs.jsenv.ComJSEnv = config match{
+  def jsEnv(config: JsEnvConfig): JSEnv = config match{
     case config: JsEnvConfig.NodeJs =>
+      /* In Mill, `config.sourceMap = true` means that `source-map-support`
+       * should be used *if available*, as it is what was used to mean in
+       * Scala.js 0.6.x. Scala.js 1.x has 3 states: enable, enable-if-available
+       * and disable. The former (enable) *fails* if it cannot load the
+       * `source-map-support` module. We must therefore adapt the boolean to
+       * one of the two last states.
+       */
       new org.scalajs.jsenv.nodejs.NodeJSEnv(
         org.scalajs.jsenv.nodejs.NodeJSEnv.Config()
           .withExecutable(config.executable)
           .withArgs(config.args)
           .withEnv(config.env)
-          .withSourceMap(config.sourceMap)
+          .withSourceMap(if (config.sourceMap) SourceMap.EnableIfAvailable else SourceMap.Disable)
       )
 
     case config: JsEnvConfig.JsDom =>
@@ -98,7 +130,9 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
           .withExecutable(config.executable)
           .withArgs(config.args)
           .withEnv(config.env)
-          .withAutoExit(config.autoExit)
       )
   }
+
+  def jsEnvInput(linkedFile: File): Seq[Input] =
+    Seq(Input.Script(linkedFile.toPath()))
 }

--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -85,6 +85,26 @@ object Util {
       case _ => scalaVersion
   }
 
+  private val ScalaJSFullVersion = """^([0-9]+)\.([0-9]+)\.([0-9]+)(-.*)?$""".r
+
+  def scalaJSBinaryVersion(scalaJSVersion: String) = scalaJSVersion match {
+      case _ if scalaJSVersion.startsWith("0.6.") =>
+        "0.6"
+      case ScalaJSFullVersion(major, minor, patch, suffix) =>
+        if (suffix != null && minor == "0" && patch == "0")
+          s"$major.$minor$suffix"
+        else
+          major
+  }
+
+  /* Starting from Scala.js 0.6.29 and in 1.x, test artifacts must depend on
+   * scalajs-test-bridge instead of scalajs-test-interface.
+   */
+  def scalaJSUsesTestBridge(scalaJSVersion: String): Boolean = scalaJSVersion match {
+      case ScalaJSFullVersion("0", "6", patch, _) => patch.toInt >= 29
+      case _ => true
+  }
+
   /** @return true if the compiler bridge can be downloaded as an already compiled jar */
   def isBinaryBridgeAvailable(scalaVersion: String) = scalaVersion match {
       case DottyNightlyVersion(major, minor, _, _) => major.toInt > 0 || minor.toInt >= 14 // 0.14.0-bin or more (not 0.13.0-bin)


### PR DESCRIPTION
Drop support for the obsolete Scala.js 1.0.0-M2.

Starting from Scala.js 0.6.29, test artifacts must depend on `scalajs-test-bridge` instead of `scalajs-test-interface`, as the JS bridge has been moved to that artifact. This is the only change required for 0.6.29+.

In Scala.js 1.x, in addition to depending on `scalajs-test-bridge`, test artifacts must include a module initializer that initializes the bridge. This required the addition of a `testBridgeInit: Boolean` parameter to the `link` methods scattered here and there. The parameter is ignored in 0.6.

The support for 1.0.0-RC1 is suboptimal: we need to force emitting ECMAScript 5.1 code instead of the new default ES 2015. The only reason is that the tests of Mill itself rely on Nashorn to execute some Scala.js outputs, and Nashorn does not support ES 2015. Since there was no configuration mechanism for the ES mode, I decided to always force ES 5.1. It would be better to introduce a configuration option for that in the future.

---

I also believe that this implementation will support 1.0.0 final and later releases, but of course it is hard to test, so I cannot guarantee that.