### PR TITLE
Non overlapping foreign module paths for #743

### DIFF
--- a/main/core/src/define/BaseModule.scala
+++ b/main/core/src/define/BaseModule.scala
@@ -7,7 +7,7 @@ object BaseModule{
 
 abstract class BaseModule(millSourcePath0: os.Path,
                           external0: Boolean = false,
-                          foreign0 : Boolean = false)
+                          foreign0 : Option[Segments] = None)
                          (implicit millModuleEnclosing0: sourcecode.Enclosing,
                           millModuleLine0: sourcecode.Line,
                           millName0: sourcecode.Name,
@@ -41,7 +41,7 @@ abstract class BaseModule(millSourcePath0: os.Path,
 abstract class ExternalModule(implicit millModuleEnclosing0: sourcecode.Enclosing,
                               millModuleLine0: sourcecode.Line,
                               millName0: sourcecode.Name)
-  extends BaseModule(ammonite.ops.pwd, external0 = true, foreign0 = false)(
+  extends BaseModule(ammonite.ops.pwd, external0 = true, foreign0 = None)(
     implicitly, implicitly, implicitly, implicitly, Caller(())
   ){
 

--- a/main/core/src/define/Ctx.scala
+++ b/main/core/src/define/Ctx.scala
@@ -66,14 +66,14 @@ case class Ctx(enclosing: String,
                segments: Segments,
                overrides: Int,
                external: Boolean,
-               foreign: Boolean,
+               foreign: Option[Segments],
                fileName: String,
                enclosingCls: Class[_]){
 }
 
 object Ctx{
   case class External(value: Boolean)
-  case class Foreign(value : Boolean)
+  case class Foreign(value : Option[Segments])
   implicit def make(implicit millModuleEnclosing0: sourcecode.Enclosing,
                     millModuleLine0: sourcecode.Line,
                     millName0: sourcecode.Name,

--- a/main/core/src/eval/Evaluator.scala
+++ b/main/core/src/eval/Evaluator.scala
@@ -229,22 +229,13 @@ case class Evaluator(home: os.Path,
   }
 
   def destSegments(labelledTask : Labelled[_]) : Segments = {
-    import labelledTask.task.ctx
-    if (ctx.foreign) {
-      val prefix = "foreign-modules"
-      // Computing a path in "out" that uniquely reflects the location
-      // of the foreign module relatively to the current build.
-      val relative = labelledTask.task
-        .ctx.millSourcePath
-        .relativeTo(rootModule.millSourcePath)
-      // Encoding the number of `/..`
-      val ups = if (relative.ups > 0) Segments.labels(s"up-${relative.ups}")
-                else Segments()
-      Segments.labels(prefix)
-        .++(ups)
-        .++(Segments.labels(relative.segments: _*))
-        .++(labelledTask.segments.last)
-    } else labelledTask.segments
+    labelledTask.task.ctx.foreign match {
+      case Some(foreignSegments) =>
+        foreignSegments ++ labelledTask.segments
+
+      case None =>
+        labelledTask.segments
+    }
   }
 
 

--- a/main/src/main/MainRunner.scala
+++ b/main/src/main/MainRunner.scala
@@ -10,6 +10,7 @@ import mill.util.PrintLogger
 
 import scala.annotation.tailrec
 import ammonite.runtime.ImportHook
+import mill.define.Segments
 
 /**
   * Customized version of [[ammonite.MainRunner]], allowing us to run Mill
@@ -139,19 +140,29 @@ class MainRunner(val config: ammonite.main.Cli.Config,
               extraCode: String): (String, String, Int) = {
       import source.pkgName
       val wrapName = indexedWrapperName.backticked
-      val path = source
-        .path
-        .map(path => path.toNIO.getParent)
-        .getOrElse(config.wd.toNIO)
+      val path = source.path
+        .map(_ / os.up)
+        .getOrElse(config.wd)
       val literalPath = pprint.Util.literalize(path.toString)
-      val external = !(path.compareTo(config.wd.toNIO) == 0)
+      val foreign = if (path != config.wd) {
+        // Computing a path in "out" that uniquely reflects the location
+        // of the foreign module relatively to the current build.
+        val relative = path.relativeTo(config.wd)
+        // Encoding the number of `/..`
+        val ups = if (relative.ups > 0) Seq(s"up-${relative.ups}") else Seq()
+        val segs = Seq("foreign-modules") ++ ups ++ relative.segments
+        val segsList = segs.map(pprint.Util.literalize(_)).mkString(", ")
+        s"Some(mill.define.Segments.labels($segsList))"
+      }
+      else "None"
+
       val top = s"""
         |package ${pkgName.head.encoded}
         |package ${Util.encodeScalaSourcePath(pkgName.tail)}
         |$imports
         |import mill._
         |object $wrapName
-        |extends mill.define.BaseModule(os.Path($literalPath), foreign0 = $external)(
+        |extends mill.define.BaseModule(os.Path($literalPath), foreign0 = $foreign)(
         |  implicitly, implicitly, implicitly, implicitly, mill.define.Caller(())
         |)
         |with $wrapName{

--- a/main/test/resources/examples/foreign/outer/build.sc
+++ b/main/test/resources/examples/foreign/outer/build.sc
@@ -13,3 +13,18 @@ object sub extends PathAware with DestAware {
   object sub extends PathAware with DestAware
 }
 
+object sourcepathmod extends mill.Module {
+  def selfDest = T { T.ctx().dest / os.up / os.up }
+
+  object jvm extends mill.Module {
+    def selfDest = T { T.ctx().dest / os.up / os.up }
+    def millSourcePath = sourcepathmod.millSourcePath
+    def sources = T.sources( millSourcePath / "src", millSourcePath / "src-jvm" )
+  }
+
+  object js extends mill.Module {
+    def selfDest = T { T.ctx().dest / os.up / os.up }
+    def millSourcePath = sourcepathmod.millSourcePath
+    def sources = T.sources( millSourcePath / "src", millSourcePath / "src-js" )
+  }
+}

--- a/main/test/resources/examples/foreign/project/build.sc
+++ b/main/test/resources/examples/foreign/project/build.sc
@@ -3,8 +3,11 @@ import $file.inner.build
 
 import mill._
 
-def assertPaths(p1 : os.Path, p2 : os.Path) : Unit = if (p1 != p2) throw new Exception(
+def assertPathsEqual(p1 : os.Path, p2 : os.Path) : Unit = if (p1 != p2) throw new Exception(
   s"Paths were not equal : \n- $p1 \n- $p2"
+)
+def assertPathsNotEqual(p1 : os.Path, p2 : os.Path) : Unit = if (p1 == p2) throw new Exception(
+  s"Paths were equal : \n- $p1 \n- $p2"
 )
 
 object sub extends PathAware with DestAware {
@@ -18,55 +21,58 @@ object sub extends PathAware with DestAware {
 def checkProjectPaths = T {
   val thisPath : os.Path = millSourcePath
   assert(thisPath.last == "project")
-  assertPaths(sub.selfPath(), thisPath / 'sub)
-  assertPaths(sub.sub.selfPath(), thisPath / 'sub / 'sub)
-  assertPaths(sub.sub2.selfPath(), thisPath / 'sub / 'sub2)
+  assertPathsEqual(sub.selfPath(), thisPath / 'sub)
+  assertPathsEqual(sub.sub.selfPath(), thisPath / 'sub / 'sub)
+  assertPathsEqual(sub.sub2.selfPath(), thisPath / 'sub / 'sub2)
 }
 
 def checkInnerPaths = T {
   val thisPath : os.Path = millSourcePath
-  assertPaths(inner.build.millSourcePath, thisPath / 'inner )
-  assertPaths(inner.build.sub.selfPath(), thisPath / 'inner / 'sub)
-  assertPaths(inner.build.sub.sub.selfPath(), thisPath / 'inner / 'sub / 'sub)
+  assertPathsEqual(inner.build.millSourcePath, thisPath / 'inner )
+  assertPathsEqual(inner.build.sub.selfPath(), thisPath / 'inner / 'sub)
+  assertPathsEqual(inner.build.sub.sub.selfPath(), thisPath / 'inner / 'sub / 'sub)
 }
 
 def checkOuterPaths = T {
   val thisPath : os.Path = millSourcePath
-  assertPaths(^.outer.build.millSourcePath, thisPath / os.up / 'outer )
-  assertPaths(^.outer.build.sub.selfPath(), thisPath / os.up / 'outer / 'sub)
-  assertPaths(^.outer.build.sub.sub.selfPath(), thisPath / os.up / 'outer / 'sub / 'sub)
+  assertPathsEqual(^.outer.build.millSourcePath, thisPath / os.up / 'outer )
+  assertPathsEqual(^.outer.build.sub.selfPath(), thisPath / os.up / 'outer / 'sub)
+  assertPathsEqual(^.outer.build.sub.sub.selfPath(), thisPath / os.up / 'outer / 'sub / 'sub)
+
+  // covers the case where millSourcePath is modified in a submodule
+  assertPathsNotEqual(^.outer.build.sourcepathmod.jvm.selfDest(), ^.outer.build.sourcepathmod.js.selfDest())
 }
 
 def checkOuterInnerPaths = T {
   val thisPath : os.Path = millSourcePath
-  assertPaths(^.outer.inner.build.millSourcePath, thisPath / os.up / 'outer / 'inner )
-  assertPaths(^.outer.inner.build.sub.selfPath(), thisPath / os.up / 'outer / 'inner /'sub)
-  assertPaths(^.outer.inner.build.sub.sub.selfPath(), thisPath / os.up / 'outer / 'inner / 'sub / 'sub)
+  assertPathsEqual(^.outer.inner.build.millSourcePath, thisPath / os.up / 'outer / 'inner )
+  assertPathsEqual(^.outer.inner.build.sub.selfPath(), thisPath / os.up / 'outer / 'inner /'sub)
+  assertPathsEqual(^.outer.inner.build.sub.sub.selfPath(), thisPath / os.up / 'outer / 'inner / 'sub / 'sub)
 }
 
 def checkProjectDests = T {
   val outPath : os.Path = millSourcePath / 'out
-  assertPaths(sub.selfDest(), outPath / 'sub)
-  assertPaths(sub.sub.selfDest(), outPath / 'sub / 'sub)
-  assertPaths(sub.sub2.selfDest(), outPath / 'sub / 'sub2)
+  assertPathsEqual(sub.selfDest(), outPath / 'sub)
+  assertPathsEqual(sub.sub.selfDest(), outPath / 'sub / 'sub)
+  assertPathsEqual(sub.sub2.selfDest(), outPath / 'sub / 'sub2)
 }
 
 def checkInnerDests = T {
   val foreignOut : os.Path = millSourcePath / 'out / "foreign-modules"
-  assertPaths(inner.build.sub.selfDest(), foreignOut / 'inner / 'sub)
-  assertPaths(inner.build.sub.sub.selfDest(), foreignOut / 'inner / 'sub / 'sub)
+  assertPathsEqual(inner.build.sub.selfDest(), foreignOut / 'inner / 'sub)
+  assertPathsEqual(inner.build.sub.sub.selfDest(), foreignOut / 'inner / 'sub / 'sub)
 }
 
 def checkOuterDests = T {
   val foreignOut : os.Path = millSourcePath / 'out / "foreign-modules"
-  assertPaths(^.outer.build.sub.selfDest(), foreignOut / "up-1" / 'outer/ 'sub )
-  assertPaths(^.outer.build.sub.sub.selfDest(), foreignOut / "up-1" / 'outer/ 'sub / 'sub)
+  assertPathsEqual(^.outer.build.sub.selfDest(), foreignOut / "up-1" / 'outer/ 'sub )
+  assertPathsEqual(^.outer.build.sub.sub.selfDest(), foreignOut / "up-1" / 'outer/ 'sub / 'sub)
 }
 
 def checkOuterInnerDests = T {
   val foreignOut : os.Path = millSourcePath / 'out / "foreign-modules"
-  assertPaths(^.outer.inner.build.sub.selfDest(), foreignOut / "up-1" / 'outer/ 'inner / 'sub)
-  assertPaths(^.outer.inner.build.sub.sub.selfDest(), foreignOut / "up-1" / 'outer/ 'inner / 'sub / 'sub)
+  assertPathsEqual(^.outer.inner.build.sub.selfDest(), foreignOut / "up-1" / 'outer/ 'inner / 'sub)
+  assertPathsEqual(^.outer.inner.build.sub.sub.selfDest(), foreignOut / "up-1" / 'outer/ 'inner / 'sub / 'sub)
 }
 
 


### PR DESCRIPTION
Calculates foreign modules paths so that they do not overlap when millSourcePath is overridden

Precalculates `Ctx.foreign` which is now a Option[Segments] based on relative path to the foreign module rather than using `millSourcePath` which would not be unique where `millSourcePath`is overridden (eg when have have `commonlib.js` & `commonlib.jvm` which share a root source path)

Fixes #743 
