### PR TITLE
Bump library versions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -25,9 +25,10 @@ object Deps {
     val scalajsLinker = ivy"org.scala-js::scalajs-linker:1.0.0-RC1"
   }
 
-  val acyclic = ivy"com.lihaoyi::acyclic:0.1.7"
-  val ammonite = ivy"com.lihaoyi:::ammonite:1.6.9"
+  val acyclic = ivy"com.lihaoyi::acyclic:0.2.0"
+  val ammonite = ivy"com.lihaoyi:::ammonite:1.9.2"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.2.5"
+  val coursier = ivy"io.get-coursier::coursier:2.0.0-RC5-3"
   val flywayCore = ivy"org.flywaydb:flyway-core:6.0.1"
   val graphvizJava = ivy"guru.nidi:graphviz-java:0.8.3"
   val ipcsocket = ivy"org.scala-sbt.ipcsocket:ipcsocket:1.0.0"
@@ -43,17 +44,17 @@ object Deps {
   val jnaPlatform = ivy"net.java.dev.jna:jna-platform:4.5.0"
   val junitInterface = ivy"com.novocode:junit-interface:0.11"
   val lambdaTest = ivy"de.tototec:de.tobiasroeser.lambdatest:0.7.0"
-  val osLib = ivy"com.lihaoyi::os-lib:0.2.6"
+  val osLib = ivy"com.lihaoyi::os-lib:0.5.0"
   val testng = ivy"org.testng:testng:6.11"
   val sbtTestInterface = ivy"org.scala-sbt:test-interface:1.0"
   def scalaCompiler(scalaVersion: String) = ivy"org.scala-lang:scala-compiler:${scalaVersion}"
   val scalafmtDynamic = ivy"org.scalameta::scalafmt-dynamic:2.0.0-RC6"
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
   def scalacScoveragePlugin = ivy"org.scoverage::scalac-scoverage-plugin:1.4.0"
-  val sourcecode = ivy"com.lihaoyi::sourcecode:0.1.4"
-  val ujsonCirce = ivy"com.lihaoyi::ujson-circe:0.7.4"
-  val upickle = ivy"com.lihaoyi::upickle:0.7.1"
-  val utest = ivy"com.lihaoyi::utest:0.6.4"
+  val sourcecode = ivy"com.lihaoyi::sourcecode:0.1.7"
+  val ujsonCirce = ivy"com.lihaoyi::ujson-circe:0.9.0"
+  val upickle = ivy"com.lihaoyi::upickle:0.9.0"
+  val utest = ivy"com.lihaoyi::utest:0.7.1"
   val zinc = ivy"org.scala-sbt::zinc:1.2.5"
   val bsp = ivy"ch.epfl.scala:bsp4j:2.0.0-M4"
 }
@@ -130,7 +131,8 @@ object main extends MillModule {
   object api extends MillApiModule{
     def ivyDeps = Agg(
       Deps.osLib,
-      Deps.upickle
+      Deps.upickle,
+      Deps.sbtTestInterface
     )
   }
   object core extends MillModule {
@@ -144,7 +146,8 @@ object main extends MillModule {
       Deps.ammonite,
       // Necessary so we can share the JNA classes throughout the build process
       Deps.jna,
-      Deps.jnaPlatform
+      Deps.jnaPlatform,
+      Deps.coursier
     )
 
     def generatedSources = T {

--- a/contrib/bloop/src/mill.contrib.bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill.contrib.bloop/BloopImpl.scala
@@ -281,8 +281,8 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
         r.dependencies
           .map(
             d =>
-              d.copy(attributes =
-                d.attributes.copy(classifier = coursier.Classifier("sources"))))
+              d.withAttributes(
+                d.attributes.withClassifier(coursier.Classifier("sources"))))
           .toSeq
       )
 
@@ -295,7 +295,7 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
         resolvedSources <- source(resolved).process.run(fetch)
         all = resolved.dependencyArtifacts ++ resolvedSources.dependencyArtifacts
         gathered <- Gather[Task].gather(all.distinct.map {
-          case (dep, art) =>
+          case (dep, pub, art) =>
             coursier.cache.Cache.default.file(art).run.map(dep -> _)
         })
       } yield

--- a/contrib/playlib/api/src/RouteCompilerWorkerApi.scala
+++ b/contrib/playlib/api/src/RouteCompilerWorkerApi.scala
@@ -2,19 +2,18 @@ package mill
 package playlib
 package api
 
-import ammonite.ops.Path
 import mill.api.Result
 import mill.scalalib.api.CompilationResult
 
 
 private[playlib] trait RouteCompilerWorkerApi {
-  def compile(files: Seq[Path],
+  def compile(files: Seq[os.Path],
               additionalImports: Seq[String],
               forwardsRouter: Boolean,
               reverseRouter: Boolean,
               namespaceReverseRouter: Boolean,
               generatorType:RouteCompilerType,
-              dest: Path)(implicit ctx: mill.api.Ctx):Result[CompilationResult]
+              dest: os.Path)(implicit ctx: mill.api.Ctx):Result[CompilationResult]
 
 
 }

--- a/contrib/playlib/src/mill/playlib/RouteCompilerWorkerApi.scala
+++ b/contrib/playlib/src/mill/playlib/RouteCompilerWorkerApi.scala
@@ -1,7 +1,6 @@
 package mill
 package playlib
 
-import ammonite.ops.Path
 import mill.api.{Ctx, Result}
 import mill.define.{Discover, ExternalModule, Worker}
 import mill.playlib.api.RouteCompilerType
@@ -34,14 +33,14 @@ private[playlib] class RouteCompilerWorker {
   }
 
 
-  def compile(routerClasspath: Agg[Path],
-              files: Seq[Path],
+  def compile(routerClasspath: Agg[os.Path],
+              files: Seq[os.Path],
               additionalImports: Seq[String],
               forwardsRouter: Boolean,
               reverseRouter: Boolean,
               namespaceReverseRouter: Boolean,
               generatorType: RouteCompilerType,
-              dest: Path)(implicit ctx: Ctx)
+              dest: os.Path)(implicit ctx: Ctx)
   : Result[CompilationResult] = {
     //the routes file must come last as it can include the routers generated
     //by the others

--- a/contrib/playlib/worker/2.6/src/RouteCompilerWorker.scala
+++ b/contrib/playlib/worker/2.6/src/RouteCompilerWorker.scala
@@ -4,7 +4,6 @@ package worker
 
 import java.io.File
 
-import ammonite.ops.Path
 import mill.api.{Ctx, Result}
 import mill.eval.PathRef
 import mill.playlib.api.{RouteCompilerType, RouteCompilerWorkerApi}
@@ -16,13 +15,13 @@ import play.routes.compiler._
 
 private[playlib] class RouteCompilerWorker extends RouteCompilerWorkerApi {
 
-  override def compile(files: Seq[Path],
+  override def compile(files: Seq[os.Path],
                        additionalImports: Seq[String],
                        forwardsRouter: Boolean,
                        reverseRouter: Boolean,
                        namespaceReverseRouter: Boolean,
                        generatorType: RouteCompilerType,
-                       dest: Path)
+                       dest: os.Path)
                       (implicit ctx: mill.api.Ctx): mill.api.Result[CompilationResult] = {
     generatorType match {
       case RouteCompilerType.InjectedGenerator =>
@@ -38,12 +37,12 @@ private[playlib] class RouteCompilerWorker extends RouteCompilerWorkerApi {
     }
   }
 
-  private def compileWithPlay(files: Seq[Path],
+  private def compileWithPlay(files: Seq[os.Path],
                               additionalImports: Seq[String],
                               forwardsRouter: Boolean,
                               reverseRouter: Boolean,
                               namespaceReverseRouter: Boolean,
-                              dest: Path,
+                              dest: os.Path,
                               ctx: Ctx,
                               routesGenerator: RoutesGenerator): Either[Seq[compiler.RoutesCompilationError], Seq[File]] = {
     val seed: Either[Seq[compiler.RoutesCompilationError], List[File]] = Right(List.empty[File])
@@ -55,12 +54,12 @@ private[playlib] class RouteCompilerWorker extends RouteCompilerWorkerApi {
     }
   }
 
-  private def compileWithPlay(file: Path,
+  private def compileWithPlay(file: os.Path,
                               additionalImports: Seq[String],
                               forwardsRouter: Boolean,
                               reverseRouter: Boolean,
                               namespaceReverseRouter: Boolean,
-                              dest: Path,
+                              dest: os.Path,
                               ctx: Ctx,
                               routesGenerator: RoutesGenerator): Either[Seq[compiler.RoutesCompilationError], Seq[File]] = {
     ctx.log.debug(s"compiling $file with play generator $routesGenerator")

--- a/contrib/playlib/worker/2.7/src/RouteCompilerWorker.scala
+++ b/contrib/playlib/worker/2.7/src/RouteCompilerWorker.scala
@@ -4,7 +4,6 @@ package worker
 
 import java.io.File
 
-import ammonite.ops.Path
 import mill.api.{Ctx, Result}
 import mill.eval.PathRef
 import mill.playlib.api.{RouteCompilerType, RouteCompilerWorkerApi}
@@ -16,13 +15,13 @@ import play.routes.compiler.{InjectedRoutesGenerator, RoutesCompilationError, Ro
 
 private[playlib] class RouteCompilerWorker extends RouteCompilerWorkerApi {
 
-  override def compile(files: Seq[Path],
+  override def compile(files: Seq[os.Path],
                        additionalImports: Seq[String],
                        forwardsRouter: Boolean,
                        reverseRouter: Boolean,
                        namespaceReverseRouter: Boolean,
                        generatorType: RouteCompilerType,
-                       dest: Path)
+                       dest: os.Path)
                       (implicit ctx: mill.api.Ctx): mill.api.Result[CompilationResult] = {
     generatorType match {
       case RouteCompilerType.InjectedGenerator =>
@@ -37,12 +36,12 @@ private[playlib] class RouteCompilerWorker extends RouteCompilerWorkerApi {
   // the following code is duplicated between play worker versions because it depends on play types
   // which are not guaranteed to stay the same between versions even though they are currently
   // identical
-  private def compileWithPlay(files: Seq[Path],
+  private def compileWithPlay(files: Seq[os.Path],
                               additionalImports: Seq[String],
                               forwardsRouter: Boolean,
                               reverseRouter: Boolean,
                               namespaceReverseRouter: Boolean,
-                              dest: Path,
+                              dest: os.Path,
                               ctx: Ctx,
                               routesGenerator: RoutesGenerator): Either[Seq[compiler.RoutesCompilationError], Seq[File]] = {
     val seed: Either[Seq[compiler.RoutesCompilationError], List[File]] = Right(List.empty[File])
@@ -54,7 +53,7 @@ private[playlib] class RouteCompilerWorker extends RouteCompilerWorkerApi {
     }
   }
 
-  private def compileWithPlay(file: Path, additionalImports: Seq[String], forwardsRouter: Boolean, reverseRouter: Boolean, namespaceReverseRouter: Boolean, dest: Path, ctx: Ctx, routesGenerator: RoutesGenerator) = {
+  private def compileWithPlay(file: os.Path, additionalImports: Seq[String], forwardsRouter: Boolean, reverseRouter: Boolean, namespaceReverseRouter: Boolean, dest: os.Path, ctx: Ctx, routesGenerator: RoutesGenerator) = {
     ctx.log.debug(s"compiling file $file with play generator $routesGenerator")
     val result =
       RoutesCompiler.compile(

--- a/contrib/scalapblib/test/src/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/TutorialTests.scala
@@ -48,11 +48,11 @@ object TutorialTests extends TestSuite {
   }
 
   def compiledSourcefiles: Seq[os.RelPath] = Seq[os.RelPath](
-    "AddressBook.scala",
-    "Person.scala",
-    "TutorialProto.scala",
-    "Include.scala",
-    "IncludeProto.scala"
+    os.rel / "AddressBook.scala",
+    os.rel / "Person.scala",
+    os.rel / "TutorialProto.scala",
+    os.rel / "Include.scala",
+    os.rel / "IncludeProto.scala"
   )
 
   def tests: Tests = Tests {

--- a/contrib/twirllib/test/src/HelloWorldTests.scala
+++ b/contrib/twirllib/test/src/HelloWorldTests.scala
@@ -51,8 +51,8 @@ object HelloWorldTests extends TestSuite {
   }
 
   def compileClassfiles: Seq[os.RelPath] = Seq[os.RelPath](
-    "hello.template.scala",
-    "wrapper.template.scala"
+    os.rel / "hello.template.scala",
+    os.rel / "wrapper.template.scala"
   )
 
   def expectedDefaultImports: Seq[String] = Seq(

--- a/integration/test/resources/better-files/build.sc
+++ b/integration/test/resources/better-files/build.sc
@@ -79,7 +79,7 @@ object benchmarks extends BetterFilesModule{
   def unmanagedClasspath = Agg(
     mill.modules.Util.download(
       "https://github.com/williamfiset/FastJavaIO/releases/download/v1.0/fastjavaio.jar",
-      "fastjavaio.jar"
+      os.rel / "fastjavaio.jar"
     )
   )
 }

--- a/main/api/src/mill/api/IO.scala
+++ b/main/api/src/mill/api/IO.scala
@@ -15,7 +15,7 @@ object IO extends StreamSupport {
    * @param ctx The target context
    * @return The [[PathRef]] to the unpacked folder.
    */
-  def unpackZip(src: os.Path, dest: os.RelPath = "unpacked")(implicit ctx: Ctx.Dest): PathRef = {
+  def unpackZip(src: os.Path, dest: os.RelPath = os.rel / "unpacked")(implicit ctx: Ctx.Dest): PathRef = {
 
     val byteStream = os.read.inputStream(src)
     val zipStream = new java.util.zip.ZipInputStream(byteStream)

--- a/main/core/src/util/JsonFormatters.scala
+++ b/main/core/src/util/JsonFormatters.scala
@@ -3,6 +3,9 @@ package mill.util
 import upickle.default.{ReadWriter => RW}
 
 trait JsonFormatters extends mill.api.JsonFormatters{
+  implicit lazy val publicationFormat: RW[coursier.core.Publication] = upickle.default.macroRW
+  implicit lazy val extensionFormat: RW[coursier.core.Extension] = upickle.default.macroRW
+
   implicit lazy val modFormat: RW[coursier.Module] = upickle.default.macroRW
   implicit lazy val depFormat: RW[coursier.Dependency]= upickle.default.macroRW
   implicit lazy val attrFormat: RW[coursier.Attributes] = upickle.default.macroRW

--- a/main/src/modules/Util.scala
+++ b/main/src/modules/Util.scala
@@ -23,7 +23,7 @@ object Util {
       .dropWhile(_.isEmpty)
       .reverse
   }
-  def download(url: String, dest: os.RelPath = "download")(implicit ctx: Ctx.Dest) = {
+  def download(url: String, dest: os.RelPath = os.rel / "download")(implicit ctx: Ctx.Dest) = {
     val out = ctx.dest / dest
 
     val website = new java.net.URI(url).toURL
@@ -41,11 +41,11 @@ object Util {
     }
   }
 
-  def downloadUnpackZip(url: String, dest: os.RelPath = "unpacked")
+  def downloadUnpackZip(url: String, dest: os.RelPath = os.rel / "unpacked")
                        (implicit ctx: Ctx.Dest) = {
 
     val tmpName = if (dest == os.rel / "tmp.zip") "tmp2.zip" else "tmp.zip"
-    val downloaded = download(url, tmpName)
+    val downloaded = download(url, os.rel / tmpName)
     IO.unpackZip(downloaded.path, dest)
   }
 

--- a/main/test/src/eval/JavaCompileJarTests.scala
+++ b/main/test/src/eval/JavaCompileJarTests.scala
@@ -44,7 +44,8 @@ object JavaCompileJarTests extends TestSuite{
         def filterJar(fileFilter: (os.Path, os.RelPath) => Boolean) = T{ Jvm.createJar(Loose.Agg(classFiles().path) ++ resourceRoot().map(_.path), JarManifest.Default, fileFilter) }
 
         def run(mainClsName: String) = T.command{
-          os.proc('java, "-Duser.language=en", "-cp", classFiles().path, mainClsName).call()
+          os.proc('java, "-Duser.language=en", "-cp", classFiles().path, mainClsName)
+            .call(stderr = os.Pipe)
         }
       }
 

--- a/main/test/src/main/ForeignBuildsTest.scala
+++ b/main/test/src/main/ForeignBuildsTest.scala
@@ -7,7 +7,7 @@ object ForeignBuildsTest extends ScriptTestSuite(fork = false) {
   def workspaceSlug = "foreign-builds"
   def scriptSourcePath =
     os.pwd / 'main / 'test / 'resources / 'examples / 'foreign
-  override def buildPath = os.rel / 'project / "build.sc"
+  override def buildPath = os.sub / 'project / "build.sc"
 
   val tests = Tests {
     initWorkspace()

--- a/main/test/src/main/ForeignConflictTest.scala
+++ b/main/test/src/main/ForeignConflictTest.scala
@@ -8,7 +8,7 @@ object ForeignConflictTest extends ScriptTestSuite(fork = false) {
   def workspaceSlug = "foreign-conflict"
   def scriptSourcePath =
     os.pwd / 'main / 'test / 'resources / 'examples / 'foreign
-  override def buildPath = os.rel / 'conflict / "build.sc"
+  override def buildPath = os.sub / 'conflict / "build.sc"
 
   val tests = Tests {
     initWorkspace()

--- a/main/test/src/util/ScriptTestSuite.scala
+++ b/main/test/src/util/ScriptTestSuite.scala
@@ -7,7 +7,7 @@ import utest._
 abstract class ScriptTestSuite(fork: Boolean) extends TestSuite{
   def workspaceSlug: String
   def scriptSourcePath: os.Path
-  def buildPath: os.RelPath = "build.sc"
+  def buildPath: os.SubPath = os.sub / "build.sc"
 
   val workspacePath = os.pwd / 'target / 'workspace / workspaceSlug
   val wd = workspacePath / buildPath / os.up

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -49,12 +49,11 @@ trait ScalaModule extends JavaModule { outer =>
       else
         Set("scala-library", "scala-compiler", "scala-reflect")
     if (!artifacts(d.module.name.value)) d
-    else d.copy(
-      module = d.module.copy(
-        organization = coursier.Organization(scalaOrganization())
-      ),
-      version = scalaVersion()
-    )
+    else d.withModule(
+      d.module.withOrganization(
+        coursier.Organization(scalaOrganization())
+      )
+    ).withVersion(scalaVersion())
   }
 
   override def resolveCoursierDependency: Task[Dep => coursier.Dependency] = T.task{

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -297,13 +297,13 @@ object HelloWorldTests extends TestSuite {
   }
 
   def compileClassfiles = Seq[os.RelPath](
-    "Main.class",
-    "Main$.class",
-    "Main0.class",
-    "Main0$.class",
-    "Main$delayedInit$body.class",
-    "Person.class",
-    "Person$.class"
+    os.rel / "Main.class",
+    os.rel / "Main$.class",
+    os.rel / "Main0.class",
+    os.rel / "Main0$.class",
+    os.rel / "Main$delayedInit$body.class",
+    os.rel / "Person.class",
+    os.rel / "Person$.class"
   )
 
   def workspaceTest[T](m: TestUtil.BaseModule, resourcePath: os.Path = resourcePath)
@@ -635,7 +635,7 @@ object HelloWorldTests extends TestSuite {
 
         val otherFiles = Seq[os.RelPath](
           os.rel / "META-INF" / "MANIFEST.MF",
-          "reference.conf"
+          os.rel / "reference.conf"
         )
         val expectedFiles = compileClassfiles ++ otherFiles
 

--- a/scalalib/test/src/dependency/metadata/MetadataLoaderFactoryTests.scala
+++ b/scalalib/test/src/dependency/metadata/MetadataLoaderFactoryTests.scala
@@ -29,7 +29,7 @@
 package mill.scalalib.dependency.metadata
 
 import coursier.Fetch
-import coursier.core.{Artifact, Classifier, Dependency, Module, Project, Repository}
+import coursier.core.{Classifier, Dependency, Module, Project, Repository, ArtifactSource}
 import coursier.ivy.IvyRepository
 import coursier.maven.MavenRepository
 import coursier.util.{EitherT, Monad}
@@ -58,7 +58,7 @@ object MetadataLoaderFactoryTests extends TestSuite {
 
   case class CustomRepository() extends Repository {
     override def find[F[_]](module: Module, version: String, fetch: coursier.Repository.Fetch[F])
-                           (implicit F: Monad[F]): EitherT[F, String, (Artifact.Source, Project)] =
+                           (implicit F: Monad[F]): EitherT[F, String, (ArtifactSource, Project)] =
       ???
 
     override def artifacts(dependency: Dependency,


### PR DESCRIPTION
This attempts to do so without bumping the Scala version, since that might take more work and/or more time to wait for third-party libraries to upgrade

Ammonite, Coursier, uPickle, OS-Lib, FastParse/Requests/Geny (transitively)