### PR TITLE
Add T.source to listen to a single source file/folder

### DIFF
--- a/main/core/src/define/Task.scala
+++ b/main/core/src/define/Task.scala
@@ -158,7 +158,7 @@ object Target extends TargetGenerated with Applicative.Applyer[Task, Task, Resul
                   (ctx: c.Expr[mill.define.Ctx]): c.Expr[Source] = {
     import c.universe._
     mill.moduledefs.Cacher.impl0[Source](c)(
-      reify(new Source(task(value.splice.map(PathRef(_))), ctx.splice))
+      reify(new Source(makeT(Nil, _ => value.splice.map(PathRef(_))), ctx.splice))
     )
   }
 
@@ -170,7 +170,7 @@ object Target extends TargetGenerated with Applicative.Applyer[Task, Task, Resul
                   (ctx: c.Expr[mill.define.Ctx]): c.Expr[Source] = {
     import c.universe._
     mill.moduledefs.Cacher.impl0[Source](c)(
-      reify(new Source(task(value.splice), ctx.splice))
+      reify(new Source(makeT(Nil, _ => value.splice), ctx.splice))
     )
   }
   def input[T](value: Result[T])

--- a/main/core/src/define/Task.scala
+++ b/main/core/src/define/Task.scala
@@ -150,6 +150,29 @@ object Target extends TargetGenerated with Applicative.Applyer[Task, Task, Resul
       )
     )
   }
+  def source(value: Result[os.Path])
+            (implicit ctx: mill.define.Ctx): Source = macro sourceImpl1
+
+  def sourceImpl1(c: Context)
+                  (value: c.Expr[Result[os.Path]])
+                  (ctx: c.Expr[mill.define.Ctx]): c.Expr[Source] = {
+    import c.universe._
+    mill.moduledefs.Cacher.impl0[Source](c)(
+      reify(new Source(task(value.splice.map(PathRef(_))), ctx.splice))
+    )
+  }
+
+  def source(value: Result[PathRef])
+            (implicit ctx: mill.define.Ctx): Source = macro sourceImpl2
+
+  def sourceImpl2(c: Context)
+                  (value: c.Expr[Result[PathRef]])
+                  (ctx: c.Expr[mill.define.Ctx]): c.Expr[Source] = {
+    import c.universe._
+    mill.moduledefs.Cacher.impl0[Source](c)(
+      reify(new Source(task(value.splice), ctx.splice))
+    )
+  }
   def input[T](value: Result[T])
               (implicit rw: RW[T],
                 ctx: mill.define.Ctx): Input[T] = macro inputImpl[T]
@@ -297,6 +320,11 @@ class Sources(t: Task[Seq[PathRef]],
     upickle.default.SeqLikeReader[Seq, PathRef],
     upickle.default.SeqLikeWriter[Seq, PathRef]
   )
+)
+class Source(t: Task[PathRef], ctx0: mill.define.Ctx) extends Input[PathRef](
+  t,
+  ctx0,
+  PathRef.jsonFormatter
 )
 object Task {
 

--- a/main/test/src/eval/JavaCompileJarTests.scala
+++ b/main/test/src/eval/JavaCompileJarTests.scala
@@ -29,19 +29,25 @@ object JavaCompileJarTests extends TestSuite{
 
       object Build extends TestUtil.BaseModule{
         def sourceRootPath = javacDestPath / 'src
+        def readmePath = javacDestPath / "readme.md"
         def resourceRootPath = javacDestPath / 'resources
 
         // sourceRoot -> allSources -> classFiles
         //                                |
         //                                v
         //           resourceRoot ---->  jar
+        //                                ^
+        //           readmePath---------- |
+        def readme = T.source{ readmePath }
         def sourceRoot = T.sources{ sourceRootPath }
         def resourceRoot = T.sources{ resourceRootPath }
         def allSources = T{ sourceRoot().flatMap(p => os.walk(p.path)).map(PathRef(_)) }
         def classFiles = T{ compileAll(allSources()) }
-        def jar = T{ Jvm.createJar(Loose.Agg(classFiles().path) ++ resourceRoot().map(_.path)) }
+        def jar = T{
+          Jvm.createJar(Loose.Agg(classFiles().path, readme().path) ++ resourceRoot().map(_.path))
+        }
         // Test createJar() with optional file filter.
-        def filterJar(fileFilter: (os.Path, os.RelPath) => Boolean) = T{ Jvm.createJar(Loose.Agg(classFiles().path) ++ resourceRoot().map(_.path), JarManifest.Default, fileFilter) }
+        def filterJar(fileFilter: (os.Path, os.RelPath) => Boolean) = T{ Jvm.createJar(Loose.Agg(classFiles().path, readme().path) ++ resourceRoot().map(_.path), JarManifest.Default, fileFilter) }
 
         def run(mainClsName: String) = T.command{
           os.proc('java, "-Duser.language=en", "-cp", classFiles().path, mainClsName)
@@ -90,6 +96,10 @@ object JavaCompileJarTests extends TestSuite{
       append(resourceRootPath / "hello.txt", " ")
       check(targets = Agg(jar), expected = Agg(jar))
 
+      // Touching the readme.md, defined as `T.source`, forces a jar rebuid
+      append(readmePath, " ")
+      check(targets = Agg(jar), expected = Agg(jar))
+
       // You can swap evaluators halfway without any ill effects
       evaluator = new TestEvaluator(Build)
 
@@ -115,6 +125,7 @@ object JavaCompileJarTests extends TestSuite{
           |test/BarTwo.class
           |test/Foo.class
           |test/FooTwo.class
+          |readme.md
           |hello.txt
           |""".stripMargin
       assert(jarContents.linesIterator.toSeq == expectedJarContents.linesIterator.toSeq)


### PR DESCRIPTION
https://github.com/lihaoyi/mill/issues/546

Largely copy-pasted from `T.sources`, with all the `Seq`-related stuff removed

Not super heavily tested, but I stuffed a single usage into `JavacCompileJavaTests` to make sure it at least gets some coverage. Seems to work.

Review by @lefou 