### PR TITLE
Fix gpg signing during sonatype publishing to work with gpg versions: 2.1+

### DIFF
--- a/scalalib/src/publish/SonatypePublisher.scala
+++ b/scalalib/src/publish/SonatypePublisher.scala
@@ -159,7 +159,7 @@ class SonatypePublisher(uri: String,
     val optionFlag = (flag: String, ov: Option[String]) => ov.map(flag :: _ :: Nil).getOrElse(Nil)
     val command = "gpg" ::
       optionFlag("--passphrase", maybePassphrase) ++ optionFlag("-u", maybeKeyName) ++
-        Seq("--batch", "--yes", "-a", "-b", fileName)
+        Seq("--batch", "--yes", "--pinentry-mode", "loopback", "-a", "-b", fileName)
 
     os.proc(command.map(v => v: Shellable))
       .call(stdin = os.Inherit, stdout = os.Inherit, stderr = os.Inherit)


### PR DESCRIPTION
Sets flag `--pinentry-mode` to `loopback`, to prevent `gpg` from interactively asking for
the gpg passphrase. This flag is necessary for newer versions of  `gpg`.

The flag has been available in `gpg` since version `1.4.0 `, so this patch should be compatible with `gpg` versions `1.4.0` and up.

See: https://www.gnupg.org/%28de%29/documentation/manuals/gpgme/Pinentry-Mode.html