### PR TITLE
Auto-update dependencies: output info in machine-readable format

### DIFF
--- a/scalalib/src/Dependency.scala
+++ b/scalalib/src/Dependency.scala
@@ -18,6 +18,10 @@ object Dependency extends ExternalModule {
         allowPreRelease)
     }
 
+  def showUpdates(ev: Evaluator, allowPreRelease: Boolean = false) = T.command{
+    DependencyUpdatesImpl.showAllUpdates(updates(ev, allowPreRelease)())
+  }
+
   implicit def millScoptEvaluatorReads[T]: EvaluatorScopt[T] =
     new mill.main.EvaluatorScopt[T]()
   lazy val millDiscover: Discover[Dependency.this.type] = Discover[this.type]

--- a/scalalib/src/dependency/DependencyUpdatesImpl.scala
+++ b/scalalib/src/dependency/DependencyUpdatesImpl.scala
@@ -29,7 +29,7 @@ object DependencyUpdatesImpl {
 
   private def showAllUpdates(updates: Seq[ModuleDependenciesUpdates]): Unit =
     updates.foreach { dependencyUpdates =>
-      val module = dependencyUpdates.module.toString
+      val module = dependencyUpdates.modulePath
       val actualUpdates =
         dependencyUpdates.dependencies.filter(_.updates.nonEmpty)
       if (actualUpdates.isEmpty) {

--- a/scalalib/src/dependency/DependencyUpdatesImpl.scala
+++ b/scalalib/src/dependency/DependencyUpdatesImpl.scala
@@ -12,7 +12,7 @@ object DependencyUpdatesImpl {
             ctx: Log with Home,
             rootModule: BaseModule,
             discover: Discover[_],
-            allowPreRelease: Boolean): Unit = {
+            allowPreRelease: Boolean): Seq[ModuleDependenciesUpdates] = {
 
     // 1. Find all available versions for each dependency
     val allDependencyVersions: Seq[ModuleDependenciesVersions] =
@@ -23,11 +23,11 @@ object DependencyUpdatesImpl {
       UpdatesFinder.findUpdates(dependencyVersions, allowPreRelease)
     }
 
-    // 3. Print the results
-    showAllUpdates(allUpdates)
+    // 3. Return the results
+    allUpdates
   }
 
-  private def showAllUpdates(updates: Seq[ModuleDependenciesUpdates]): Unit =
+  def showAllUpdates(updates: Seq[ModuleDependenciesUpdates]): Unit =
     updates.foreach { dependencyUpdates =>
       val module = dependencyUpdates.modulePath
       val actualUpdates =

--- a/scalalib/src/dependency/updates/ModuleDependenciesUpdates.scala
+++ b/scalalib/src/dependency/updates/ModuleDependenciesUpdates.scala
@@ -5,11 +5,23 @@ import mill.scalalib.dependency.versions.Version
 
 import scala.collection.SortedSet
 
-private[dependency] final case class ModuleDependenciesUpdates(
+final case class ModuleDependenciesUpdates(
     modulePath: String,
     dependencies: Seq[DependencyUpdates])
 
-private[dependency] final case class DependencyUpdates(
+object ModuleDependenciesUpdates {
+  implicit val rw: upickle.default.ReadWriter[ModuleDependenciesUpdates] =
+    upickle.default.macroRW
+}
+
+final case class DependencyUpdates(
     dependency: coursier.Dependency,
     currentVersion: Version,
     updates: SortedSet[Version])
+
+object DependencyUpdates {
+  import mill.util.JsonFormatters.depFormat
+
+  implicit val rw: upickle.default.ReadWriter[DependencyUpdates] =
+    upickle.default.macroRW
+}

--- a/scalalib/src/dependency/updates/ModuleDependenciesUpdates.scala
+++ b/scalalib/src/dependency/updates/ModuleDependenciesUpdates.scala
@@ -6,7 +6,7 @@ import mill.scalalib.dependency.versions.Version
 import scala.collection.SortedSet
 
 private[dependency] final case class ModuleDependenciesUpdates(
-    module: JavaModule,
+    modulePath: String,
     dependencies: Seq[DependencyUpdates])
 
 private[dependency] final case class DependencyUpdates(

--- a/scalalib/src/dependency/updates/UpdatesFinder.scala
+++ b/scalalib/src/dependency/updates/UpdatesFinder.scala
@@ -42,7 +42,7 @@ private[dependency] object UpdatesFinder {
       dependencyVersions.dependencies.map { dependencyVersion =>
         findUpdates(dependencyVersion, allowPreRelease)
       }
-    ModuleDependenciesUpdates(dependencyVersions.module, dependencies)
+    ModuleDependenciesUpdates(dependencyVersions.modulePath, dependencies)
   }
 
   def findUpdates(dependencyVersion: DependencyVersions,

--- a/scalalib/src/dependency/versions/ModuleDependenciesVersions.scala
+++ b/scalalib/src/dependency/versions/ModuleDependenciesVersions.scala
@@ -3,7 +3,7 @@ package mill.scalalib.dependency.versions
 import mill.scalalib.JavaModule
 
 private[dependency] final case class ModuleDependenciesVersions(
-    module: JavaModule,
+    modulePath: String,
     dependencies: Seq[DependencyVersions])
 
 private[dependency] final case class DependencyVersions(

--- a/scalalib/src/dependency/versions/Version.scala
+++ b/scalalib/src/dependency/versions/Version.scala
@@ -31,7 +31,7 @@ package mill.scalalib.dependency.versions
 import scala.util.matching.Regex
 import scala.util.matching.Regex.Groups
 
-private[dependency] sealed trait Version {
+sealed trait Version {
   def major: Long
 
   def minor: Long
@@ -39,7 +39,7 @@ private[dependency] sealed trait Version {
   def patch: Long
 }
 
-private[dependency] case class ValidVersion(text: String,
+case class ValidVersion(text: String,
                                             releasePart: List[Long],
                                             preReleasePart: List[String],
                                             buildPart: List[String])
@@ -52,13 +52,21 @@ private[dependency] case class ValidVersion(text: String,
 
   override def toString: String = text
 }
+object ValidVersion {
+  implicit val rw: upickle.default.ReadWriter[ValidVersion] =
+    upickle.default.macroRW
+}
 
-private[dependency] case class InvalidVersion(text: String) extends Version {
+case class InvalidVersion(text: String) extends Version {
   def major: Long = -1
 
   def minor: Long = -1
 
   def patch: Long = -1
+}
+object InvalidVersion {
+  implicit val rw: upickle.default.ReadWriter[InvalidVersion] =
+    upickle.default.macroRW
 }
 
 private[dependency] object ReleaseVersion {
@@ -120,6 +128,8 @@ private[dependency] object Version {
   }
 
   implicit def versionOrdering: Ordering[Version] = VersionOrdering
+  implicit val rw: upickle.default.ReadWriter[Version] =
+    upickle.default.macroRW
 }
 
 private[dependency] object VersionOrdering extends Ordering[Version] {

--- a/scalalib/src/dependency/versions/VersionsFinder.scala
+++ b/scalalib/src/dependency/versions/VersionsFinder.scala
@@ -52,7 +52,7 @@ private[dependency] object VersionsFinder {
           DependencyVersions(dependency, currentVersion, allVersions)
         }
 
-        ModuleDependenciesVersions(javaModule, versions)
+        ModuleDependenciesVersions(javaModule.toString, versions)
     }
 
   private def eval[T](evaluator: Evaluator, e: Task[T]): T =


### PR DESCRIPTION
Mill has a convenient task to check for the availability of newer versions of dependencies `mill.scalalib.Dependency/updates`.

Unfortunately this task only prints the output (in human readable form), but does not persist it in a machine-readable format. This makes it very difficult to reuse the output in other tasks, essentially requiring regex parsing of strings.

The changes proposed here change the `updates` task to expose the underlying data structures representing the upgrade path. An additional task, `showUpdates` is added, implementing the original, human readable, output of updates.