### PR TITLE
scoverage: Add console reporter

### DIFF
--- a/contrib/scoverage/api/src/ScoverageReportWorkerApi.scala
+++ b/contrib/scoverage/api/src/ScoverageReportWorkerApi.scala
@@ -5,14 +5,16 @@ import mill.api.Ctx
 trait ScoverageReportWorkerApi {
   import ScoverageReportWorkerApi._
 
-  def report(reportType: ReportType, sources: Seq[os.Path], dataDir: os.Path)(implicit ctx: Ctx.Dest): Unit
+  def report(reportType: ReportType, sources: Seq[os.Path], dataDir: os.Path)(implicit ctx: Ctx): Unit
 }
 
 object ScoverageReportWorkerApi {
-  sealed trait ReportType { def folderName: String }
+  sealed trait ReportType
+  sealed trait FileReportType extends ReportType { def folderName: String }
   object ReportType {
-    final case object Html extends ReportType { val folderName: String = "htmlReport" }
-    final case object Xml extends ReportType { val folderName: String = "xmlReport" }
+    final case object Html extends FileReportType { val folderName: String = "htmlReport" }
+    final case object Xml extends FileReportType { val folderName: String = "xmlReport" }
+    final case object Console extends ReportType
   }
 }
 

--- a/contrib/scoverage/src/ScoverageModule.scala
+++ b/contrib/scoverage/src/ScoverageModule.scala
@@ -87,6 +87,13 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
   }
 
   object scoverage extends ScalaModule {
+    private def doReport(reportType: ReportType) = T.task {
+      ScoverageReportWorker
+        .scoverageReportWorker()
+        .bridge(toolsClasspath().map(_.path))
+        .report(reportType, allSources().map(_.path), dataDir().path)
+    }
+
     /**
       * The persistent data dir used to store scoverage coverage data.
       * Use to store coverage data at compile-time and by the various report targets.
@@ -111,18 +118,9 @@ trait ScoverageModule extends ScalaModule { outer: ScalaModule =>
     /** Add the scoverage specific plugin settings (`dataDir`). */
     override def scalacOptions = T{ outer.scalacOptions() ++ Seq(s"-P:scoverage:dataDir:${dataDir().path.toIO.getPath()}") }
 
-    def htmlReport() = T.command {
-      ScoverageReportWorker
-        .scoverageReportWorker()
-        .bridge(toolsClasspath().map(_.path))
-        .report(ReportType.Html, allSources().map(_.path), dataDir().path)
-    }
-    def xmlReport() = T.command {
-      ScoverageReportWorker
-        .scoverageReportWorker()
-        .bridge(toolsClasspath().map(_.path))
-        .report(ReportType.Xml, allSources().map(_.path), dataDir().path)
-    }
+    def htmlReport() = T.command { doReport(ReportType.Html) }
+    def xmlReport() = T.command { doReport(ReportType.Xml) }
+    def consoleReport() = T.command { doReport(ReportType.Console) }
   }
 
   trait ScoverageTests extends outer.Tests {

--- a/contrib/scoverage/test/src/HelloWorldTests.scala
+++ b/contrib/scoverage/test/src/HelloWorldTests.scala
@@ -125,6 +125,11 @@ object HelloWorldTests extends utest.TestSuite {
             val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage.xmlReport)
             assert(evalCount > 0)
           }
+          "console" - workspaceTest(HelloWorld) { eval =>
+            val Right((_, _)) = eval.apply(HelloWorld.core.test.compile)
+            val Right((result, evalCount)) = eval.apply(HelloWorld.core.scoverage.consoleReport)
+            assert(evalCount > 0)
+          }
         }
         "test" - {
           "upstreamAssemblyClasspath" - workspaceTest(HelloWorld) { eval =>
@@ -165,6 +170,11 @@ object HelloWorldTests extends utest.TestSuite {
         "xmlReport" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
           val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
           val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage.xmlReport)
+          assert(evalCount > 0)
+        }
+        "console" - workspaceTest(HelloWorldSbt, sbtResourcePath) { eval =>
+          val Right((_, _)) = eval.apply(HelloWorldSbt.core.test.compile)
+          val Right((result, evalCount)) = eval.apply(HelloWorldSbt.core.scoverage.consoleReport)
           assert(evalCount > 0)
         }
       }

--- a/contrib/scoverage/worker/src/ScoverageReportWorkerImpl.scala
+++ b/contrib/scoverage/worker/src/ScoverageReportWorkerImpl.scala
@@ -10,7 +10,7 @@ import mill.contrib.scoverage.api.ScoverageReportWorkerApi.ReportType
 
 class ScoverageReportWorkerImpl extends ScoverageReportWorkerApi {
 
-  override def report(reportType: ReportType, sources: Seq[os.Path], dataDir: os.Path)(implicit  ctx: Ctx.Dest): Unit = {
+  override def report(reportType: ReportType, sources: Seq[os.Path], dataDir: os.Path)(implicit  ctx: Ctx): Unit = {
     val coverageFileObj = coverageFile(dataDir.toIO)
     val coverage = deserialize(coverageFileObj)
     coverage(invoked(findMeasurementFiles(dataDir.toIO)))
@@ -24,6 +24,9 @@ class ScoverageReportWorkerImpl extends ScoverageReportWorkerApi {
       case ReportType.Xml =>
         new ScoverageXmlWriter(sourceFolders, folder.toIO, false)
             .write(coverage)
+      case ReportType.Console =>
+        ctx.log.info(s"Statement coverage.: ${coverage.statementCoverageFormatted}%")
+        ctx.log.info(s"Branch coverage....: ${coverage.branchCoverageFormatted}%")
     }
   }
 }


### PR DESCRIPTION
Fixes lihaoyi/mill#763

This just outputs a coverage summary report. Useful for CI systems which don't support HTML/XML reports but have support for parsing stdout.