### PR TITLE
Fix open file handle leak by upgrading upstream dependency upickle

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -67,7 +67,7 @@ object Deps {
   def scalacScoveragePlugin = ivy"org.scoverage::scalac-scoverage-plugin:1.4.0"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.2.0"
   val ujsonCirce = ivy"com.lihaoyi::ujson-circe:0.9.8"
-  val upickle = ivy"com.lihaoyi::upickle:0.9.8"
+  val upickle = ivy"com.lihaoyi::upickle:1.0.0"
   val utest = ivy"com.lihaoyi::utest:0.7.3"
   val zinc = ivy"org.scala-sbt::zinc:1.2.5"
   val bsp = ivy"ch.epfl.scala:bsp4j:2.0.0-M4"


### PR DESCRIPTION
Fixes https://github.com/lihaoyi/mill/issues/754

Bump upickle to 1.0.0