### PR TITLE
Fix Windows launcher

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -641,7 +641,7 @@ object dev extends MillModule{
 
   def prependShellScript = T{
     val (millArgs, otherArgs) = forkArgs().partition(arg => arg.startsWith("-DMILL") && !arg.startsWith("-DMILL_VERSION"))
-    // Pass dev.assembly VM options via file in Windows due to small max args limit
+    // Pass Mill options via file, due to small max args limit in Windows
     val vmOptionsFile = T.ctx.dest / "mill.properties"
     val millOptionsContent = millArgs.map(_.drop(2).replace("\\", "/")).mkString("\r\n") // drop -D prefix, replace \ with /
     os.write(vmOptionsFile, millOptionsContent)

--- a/build.sc
+++ b/build.sc
@@ -791,4 +791,3 @@ def uploadToGithub(authKey: String) = T.command{
 
   upload.apply(launcher().path, releaseTag, label, authKey)
 }
-

--- a/build.sc
+++ b/build.sc
@@ -643,9 +643,9 @@ object dev extends MillModule{
     val (millArgs, otherArgs) = forkArgs().partition(arg => arg.startsWith("-DMILL") && !arg.startsWith("-DMILL_VERSION"))
     // Pass dev.assembly VM options via file in Windows due to small max args limit
     val vmOptionsFile = T.ctx.dest / "mill.properties"
-    val millOptionsPath = // drop -D prefix, replace \ with /
-      os.write(vmOptionsFile, millArgs.map(_.drop(2).replace("\\", "/")).mkString("\r\n"))
-    val jvmArgs = otherArgs ++ List(s"-DMILL_OPTIONS_PATH=$millOptionsPath")
+    val millOptionsContent = millArgs.map(_.drop(2).replace("\\", "/")).mkString("\r\n") // drop -D prefix, replace \ with /
+    os.write(vmOptionsFile, millOptionsContent)
+    val jvmArgs = otherArgs ++ List(s"-DMILL_OPTIONS_PATH=$vmOptionsFile")
     val classpath = Agg(pathingJar().path.toString)
     launcherScript(
       jvmArgs,

--- a/build.sc
+++ b/build.sc
@@ -646,12 +646,12 @@ object dev extends MillModule{
     val millOptionsContent = millArgs.map(_.drop(2).replace("\\", "/")).mkString("\r\n") // drop -D prefix, replace \ with /
     os.write(vmOptionsFile, millOptionsContent)
     val jvmArgs = otherArgs ++ List(s"-DMILL_OPTIONS_PATH=$vmOptionsFile")
-    val classpath = Agg(pathingJar().path.toString)
+    val classpath = runClasspath().map(_.path.toString)
     launcherScript(
       jvmArgs,
       jvmArgs,
       classpath,
-      classpath
+      Agg(pathingJar().path.toString) // TODO not working yet on Windows! see #791
     )
   }
 

--- a/build.sc
+++ b/build.sc
@@ -702,7 +702,7 @@ def assembly = T{
     "-Djna.nosys=true"
   )
   val shellArgs = Seq("-DMILL_CLASSPATH=$0") ++ commonArgs
-  val cmdArgs = Seq("-DMILL_CLASSPATH=%~dpnx0") ++ commonArgs
+  val cmdArgs = Seq("-DMILL_CLASSPATH=%0") ++ commonArgs
   os.move(
     createAssembly(
       devRunClasspath,

--- a/build.sc
+++ b/build.sc
@@ -791,3 +791,4 @@ def uploadToGithub(authKey: String) = T.command{
 
   upload.apply(launcher().path, releaseTag, label, authKey)
 }
+

--- a/build.sc
+++ b/build.sc
@@ -661,7 +661,7 @@ object dev extends MillModule{
     val isWin = scala.util.Properties.isWin
     val classpath = runClasspath().map{ pathRef =>
       val path = if (isWin) "/" + pathRef.path.toString.replace("\\", "/") 
-                  else pathRef.path.toString
+                 else pathRef.path.toString
       if (path.endsWith(".jar")) path
       else path + "/"
     }.mkString(" ")

--- a/contrib/bsp/src/mill/contrib/BSP.scala
+++ b/contrib/bsp/src/mill/contrib/BSP.scala
@@ -69,7 +69,7 @@ object BSP extends ExternalModule {
 
   // creates a Json with the BSP connection details
   def createBspConnectionJson(): String = {
-    val millPath = scala.sys.props.get("MILL_CLASSPATH").getOrElse(System.getProperty("MILL_CLASSPATH"))
+    val millPath = Option(mill.modules.Util.millProperty("MILL_CLASSPATH")).getOrElse(System.getProperty("MILL_CLASSPATH"))
     val millVersion = scala.sys.props.get("MILL_VERSION").getOrElse(System.getProperty("MILL_VERSION"))
     write(BspConfigJson("mill-bsp",
                         List(whichJava,

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -19,32 +19,43 @@ public class MillClientMain {
 	public static final int ExitServerCodeWhenVersionMismatch() { return 101; }
 
     static void initServer(String lockBase, boolean setJnaNoSys) throws IOException,URISyntaxException{
-        String[] selfJars = System.getProperty("MILL_CLASSPATH").split(",");
-
-        List<String> l = new ArrayList<>();
+        
+        String selfJars = "";
         List<String> vmOptions = new ArrayList<>();
-        l.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
-        final Properties props = System.getProperties();
-        for(final String k: props.stringPropertyNames()){
-            if (k.startsWith("MILL_") && !"MILL_CLASSPATH".equals(k)) {
-                vmOptions.add("-D" + k + "=" + props.getProperty(k));
+        String millOptionsPath = System.getProperty("MILL_OPTIONS_PATH");
+        if(millOptionsPath != null) {
+            // read MILL_CLASSPATH from file MILL_OPTIONS_PATH
+            Properties millProps = new Properties();
+            millProps.load(new FileInputStream(millOptionsPath));
+            for(final String k: millProps.stringPropertyNames()){
+                String propValue = millProps.getProperty(k);
+                if("MILL_CLASSPATH".equals(k)){
+                    selfJars = propValue;
+                }
             }
+        } else {
+            // read MILL_CLASSPATH from file sys props
+            selfJars = System.getProperty("MILL_CLASSPATH");
+        }
+
+        final Properties sysProps = System.getProperties();
+        for(final String k: sysProps.stringPropertyNames()){
+            if (k.startsWith("MILL_") && !"MILL_CLASSPATH".equals(k)) {
+                vmOptions.add("-D" + k + "=" + sysProps.getProperty(k));
+            }
+        }
+        if(selfJars == null || selfJars.trim().isEmpty()) {
+            throw new RuntimeException("MILL_CLASSPATH is empty!");
         }
         if (setJnaNoSys) {
             vmOptions.add("-Djna.nosys=true");
         }
-        if(!Util.isWindows){
-            l.addAll(vmOptions);
-        } else {
-            final File vmOptionsFile = new File(lockBase, "vmoptions");
-            try (PrintWriter out = new PrintWriter(vmOptionsFile)) {
-                for(String opt: vmOptions)
-                out.println(opt);
-            }
-            l.add("-XX:VMOptionsFile=" + vmOptionsFile.getCanonicalPath());
-        }
+
+        List<String> l = new ArrayList<>();
+        l.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+        l.addAll(vmOptions);
         l.add("-cp");
-        l.add(String.join(File.pathSeparator, selfJars));
+        l.add(String.join(File.pathSeparator, selfJars.split(",")));
         l.add("mill.main.MillServerMain");
         l.add(lockBase);
 

--- a/main/src/modules/Jvm.scala
+++ b/main/src/modules/Jvm.scala
@@ -347,8 +347,10 @@ object Jvm {
       Seq(
         "",
         ":BOF",
+        "setlocal",
         "@echo off",
         cmdCommands.replaceAll("\r\n|\n", "\r\n"),
+        "endlocal",
         "exit /B %errorlevel%",
         ""
       ).mkString("\r\n")

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -73,7 +73,7 @@ case class GenIdeaImpl(evaluator: Evaluator,
 
     val buildLibraryPaths: immutable.Seq[Path] =
       if (!fetchMillModules) Nil
-      else sys.props.get("MILL_BUILD_LIBRARIES") match {
+      else Option(mill.modules.Util.millProperty("MILL_BUILD_LIBRARIES")) match {
         case Some(found) => found.split(',').map(os.Path(_)).distinct.toList
         case None =>
           val repos = modules.foldLeft(Set.empty[Repository]) { _ ++ _._2.repositories } ++ Set(LocalRepositories.ivy2Local, Repositories.central)


### PR DESCRIPTION
There are 2 problems this PR tries to fix:
1. production version of Mill, built by `assembly` task
2. development version of Mill, built by `dev.launcher` task

These problems manifest with java 1.8.  
In Hotspots 9+ there exists an option `-XX:VMOptionsFile`...

## Production version (`assembly`)

### Problem
- Download latest Mill (0.6.1-25-360107-assembly) and rename it to `mill.bat`
- unzip "example-1.zip" project from docs
- run it with downloaded Mill as `mill foo.compile`
First time you run it you'll get this message:
> Error: Could not create the Java Virtual Machine.
> Error: A fatal exception has occurred. Program will exit.
> Unrecognized VM option 'VMOptionsFile=C:\projects\TODO\mill\winfix\example-1\out\mill-worker-+9h7erhXUQxlj6SW7zBIF3jvnFg=-1\vmoptions'

If you kill it and **try again, it just hangs**...  
I couldnt attach VisualVM for some reason to debug further. 
I guess it cant start a server and pipe between client-server breaks!?

### Fix
Remove `-XX:VMOptionsFile` stuff.  
This is enough to get working Mill for Windows users! (even on java 1.8)

### Testing
Build Mill with `publish-local.sh` commands.  
Then use built Mill version on projects. See that it works. 😄 

## Development version (`dev.launcher`)
Here is where it gets interesting.

### Problem
- Clone Mill repository and build its dev version with `mill -i dev.launcher`
- try to run some command with it, you'll get:
>dev.launcher java.lang.Error: dev.launcher in Windows is only supported using Java 9 or above
>ammonite.$file.build$dev$.windowsVmOptions(build.sc:628)
(this was using the "mill.vmoptions" file passed via `-XX:VMOptionsFile`)

Why? Because `-XX:VMOptionsFile` doesnt exist in java 1.8...  
Why is it needed in first place? Because Windows has command-line **limitation of only ~8000 characters**!  
Most lengthy operations are `MILL_STUFF` and classpath, of course (lot of JARs from Coursier local repo...)

### Fix
1. introduce `MILL_OPTIONS_PATH=$path/mill.properties` to bypass long `-DMILL_..` props
2. introduce a Pathing JAR (see [here](http://todayguesswhat.blogspot.com/2011/03/jar-manifestmf-class-path-referencing.html) for more details) to bypass long `-cp` parameter

### Testing
Build `dev.launcher` and see it works in client-server mode.  
Only thing that isnt working on Windows is `-i` mode of `dev.launcher`:
>scala.reflect.internal.MissingRequirementError: object scala in compiler mirror not found...

---
Minor NOTE: Once you do `-i` it stays during that shell session (`SETLOCAL` wasn't used), so if you run `mill` after that it will still use interactive mode... This PR fixes that also.