### PR TITLE
Support publishing of extra artifacts

### DIFF
--- a/scalalib/src/PublishModule.scala
+++ b/scalalib/src/PublishModule.scala
@@ -51,6 +51,9 @@ trait PublishModule extends JavaModule { outer =>
     Artifact(pomSettings().organization, artifactId(), publishVersion())
   }
 
+  /**
+    * Extra artifacts to publish.
+    */
   def extraPublish: T[Seq[PublishModule.ExtraPublish]] = T{ Seq.empty[PublishModule.ExtraPublish] }
 
   def publishLocal(): define.Command[Unit] = T.command {
@@ -115,7 +118,12 @@ object PublishModule extends ExternalModule {
     implicit def jsonify: upickle.default.ReadWriter[PublishData] = upickle.default.macroRW
   }
 
-  /** Extra resource to publish. */
+  /** An extra resource artifact to publish.
+    * @param file The artifact file
+    * @param ivyCategory The ivy catogory (e.g. "jars", "zips")
+    * @params The file suffix including the file extension (e.g. "-with-deps.jar", "-dist.zip").
+    *        It will be appended to the artifact id to construct the full file name.
+    */
   case class ExtraPublish(file: PathRef, ivyCategory: String, suffix: String)
   object ExtraPublish {
     implicit def jsonify: upickle.default.ReadWriter[ExtraPublish] = upickle.default.macroRW

--- a/scalalib/src/PublishModule.scala
+++ b/scalalib/src/PublishModule.scala
@@ -121,7 +121,7 @@ object PublishModule extends ExternalModule {
   /** An extra resource artifact to publish.
     * @param file The artifact file
     * @param ivyCategory The ivy catogory (e.g. "jars", "zips")
-    * @params The file suffix including the file extension (e.g. "-with-deps.jar", "-dist.zip").
+    * @param The file suffix including the file extension (e.g. "-with-deps.jar", "-dist.zip").
     *        It will be appended to the artifact id to construct the full file name.
     */
   case class ExtraPublish(file: PathRef, ivyCategory: String, suffix: String)

--- a/scalalib/src/publish/LocalPublisher.scala
+++ b/scalalib/src/publish/LocalPublisher.scala
@@ -1,16 +1,18 @@
 package mill.scalalib.publish
 
-
 object LocalPublisher {
 
   private val root: os.Path = os.home / ".ivy2" / "local"
 
-  def publish(jar: os.Path,
-              sourcesJar: os.Path,
-              docJar: os.Path,
-              pom: os.Path,
-              ivy: os.Path,
-              artifact: Artifact): Unit = {
+  def publish(
+      jar: os.Path,
+      sourcesJar: os.Path,
+      docJar: os.Path,
+      pom: os.Path,
+      ivy: os.Path,
+      artifact: Artifact,
+      extras: Seq[(os.Path, String, String)]
+  ): Unit = {
     val releaseDir = root / artifact.group / artifact.id / artifact.version
     writeFiles(
       jar -> releaseDir / "jars" / s"${artifact.id}.jar",
@@ -19,6 +21,9 @@ object LocalPublisher {
       pom -> releaseDir / "poms" / s"${artifact.id}.pom",
       ivy -> releaseDir / "ivys" / "ivy.xml"
     )
+    writeFiles(extras.map {
+      case (file, ivyCat, suffix ) => (file, releaseDir / ivyCat / s"${artifact.id}${suffix}")
+    }: _*)
   }
 
   private def writeFiles(fromTo: (os.Path, os.Path)*): Unit = {


### PR DESCRIPTION
With the new `PublishModule.extraPublish` you can add additional artifacts/files to be published. 

Use cases: 

* Publish a jar with dependencies
* Publish a distribution archive
* Publish a native binary