### PR TITLE
Refactoring of the version file module

### DIFF
--- a/contrib/versionfile/src/mill/contrib/versionfile/Version.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/Version.scala
@@ -67,4 +67,7 @@ object Version {
 
   implicit val readWriter: ReadWriter[Version] =
     readwriter[String].bimap(_.toString, Version.of)
+
+  implicit val read: scopt.Read[Version] =
+    scopt.Read.reads(Version.of)
 }

--- a/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
@@ -42,8 +42,8 @@ trait VersionFileModule extends Module {
   /** Procs for tagging current version and committing changes. */
   def tag = T {
     Seq (
-      os.proc("git", "tag", currentVersion().toString),
-      os.proc("git", "commit", "-am", generateCommitMessage(currentVersion()))
+      os.proc("git", "commit", "-am", generateCommitMessage(currentVersion())),
+      os.proc("git", "tag", currentVersion().toString)
     )
   }
 

--- a/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
@@ -41,7 +41,10 @@ trait VersionFileModule extends Module {
 
   /** Executes the given processes. */
   def execute(procs: mill.main.Tasks[Seq[os.proc]]) = T.command {
-    for (p <- T.sequence(procs.value)().flatten) p.call()
+    for {
+      procs <- T.sequence(procs.value)()
+      proc  <- procs
+    } yield proc.call()
   }
 
   /** Procs for tagging current version and committing changes. */

--- a/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
@@ -4,8 +4,6 @@ import mill._, scalalib._
 
 trait VersionFileModule extends Module {
 
-  implicit val wd = os.pwd
-
   /** The file containing the current version. */
   def versionFile: define.Source = T.source(millSourcePath / "version")
   /** The current version. */
@@ -15,31 +13,71 @@ trait VersionFileModule extends Module {
   /** The next snapshot version. */
   def nextVersion(bump: String) = T.command { currentVersion().asSnapshot.bump(bump) }
 
+  /** Writes the release version to file. */
   def setReleaseVersion = T {
-    val commitMessage = s"Setting release version to ${releaseVersion()}"
-    
-    T.ctx.log.info(commitMessage)
-
-    os.write.over(
-      versionFile().path,
-      releaseVersion().toString
-    )
-
-    os.proc("git", "commit", "-am", commitMessage).call()
-    os.proc("git", "tag", releaseVersion().toString).call()
+    setVersionTask(releaseVersion)()
   }
 
+  /** Writes the next snapshot version to file. */
   def setNextVersion(bump: String) = T.command {
-    val commitMessage = s"Setting next version to ${nextVersion(bump)()}"
+    setVersionTask(nextVersion(bump))()
+  }
 
-    T.ctx.log.info(commitMessage)
+  /** Writes the given version to file. */
+  def setVersion(version: Version) = T.command {
+    setVersionTask(T.task { version })()
+  }
 
+  protected def setVersionTask(version: T[Version]) = T.task {
+    T.ctx.log.info(generateCommitMessage(version()))
+    writeVersionToFile(versionFile(), version())
+  }
+
+  def writeVersionToFile(versionFile: mill.eval.PathRef, version: Version) =
     os.write.over(
-      versionFile().path,
-      nextVersion(bump)().toString
+      versionFile.path,
+      version.toString
     )
 
-    os.proc("git", "commit", "-am", commitMessage).call()
-    os.proc("git", "push", "origin", "master", "--tags").call()
+  /** Executes the given processes. */
+  def execute(procs: mill.main.Tasks[Seq[os.proc]]) = T.command {
+    for (p <- T.sequence(procs.value)().flatten) p.call()
   }
+
+  /** Procs for tagging current version and committing changes. */
+  def tag = T {
+    Seq (
+      os.proc("git", "tag", currentVersion().toString),
+      os.proc("git", "commit", "-am", generateCommitMessage(currentVersion()))
+    )
+  }
+
+  /** Procs for committing changes and pushing. */
+  def push = T {
+    Seq (
+      os.proc("git", "commit", "-am", generateCommitMessage(currentVersion())),
+      os.proc("git", "push", "origin", "master", "--tags")
+    )
+  }
+
+  def generateCommitMessage(version: Version) =
+    version match {
+      case release: Version.Release => s"Setting release version to $version"
+      case snapshot: Version.Snapshot => s"Setting next version to $version"
+    }
+
+  import upickle.core._
+  import upickle.default._
+
+  implicit val shellableReadWriter: ReadWriter[os.Shellable] =
+    readwriter[Seq[String]].bimap(
+      _.value,
+      os.Shellable(_)
+    )
+
+  implicit val procReadWriter: ReadWriter[os.proc] =
+    readwriter[Seq[os.Shellable]].bimap(
+      _.command,
+      os.proc(_)
+    )
 }

--- a/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
+++ b/contrib/versionfile/src/mill/contrib/versionfile/VersionFileModule.scala
@@ -39,14 +39,6 @@ trait VersionFileModule extends Module {
       version.toString
     )
 
-  /** Executes the given processes. */
-  def execute(procs: mill.main.Tasks[Seq[os.proc]]) = T.command {
-    for {
-      procs <- T.sequence(procs.value)()
-      proc  <- procs
-    } yield proc.call()
-  }
-
   /** Procs for tagging current version and committing changes. */
   def tag = T {
     Seq (
@@ -83,4 +75,19 @@ trait VersionFileModule extends Module {
       _.command,
       os.proc(_)
     )
+}
+
+object VersionFileModule extends define.ExternalModule {
+
+  /** Executes the given processes. */
+  def exec(procs: mill.main.Tasks[Seq[os.proc]]) = T.command {
+    for {
+      procs <- T.sequence(procs.value)()
+      proc  <- procs
+    } yield proc.call()
+  }
+  
+  implicit val millScoptTargetReads = new mill.main.Tasks.Scopt[Seq[os.proc]]()
+
+  lazy val millDiscover: mill.define.Discover[this.type] = mill.define.Discover[this.type]
 }

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -1,3 +1,131 @@
 package mill.contrib.versionfile
 
+import mill.eval.Result
+import mill.util.{TestEvaluator, TestUtil}
+import ammonite.ops.{cp, mkdir, pwd, rm, up, Path}
+import utest.{assert, assertMatch, intercept, test, Tests, TestSuite}
+import utest.framework.TestPath
+import os.write
 
+object VersionFileModuleTests extends TestSuite {
+
+  object TestModule extends TestUtil.BaseModule{
+    case object versionFile extends VersionFileModule
+  }
+
+  def evaluator[T, M <: TestUtil.BaseModule](m: M, vf: M => VersionFileModule, version: Version)
+                                            (implicit tp: TestPath): TestEvaluator = {
+    val eval = new TestEvaluator(m)
+    rm(m.millSourcePath)
+    rm(eval.outPath)
+    write.over(
+      vf(m).millSourcePath / "version", version.toString, createFolders = true
+    )
+    eval
+  }
+
+  def workspaceTest0(versions: Version*)
+         (test: TestEvaluator => Version => Any)
+         (implicit tp: TestPath): Unit = {
+    for (version <- versions)
+      test(evaluator(TestModule, (m: TestModule.type) => m.versionFile, version))(version)
+  }
+
+  def workspaceTest(versions: Version*)(test: TestEvaluator => Any)(implicit tp: TestPath): Unit =
+    workspaceTest0(versions: _*)(eval => _ => test(eval))
+
+  implicit class ResultOps[A](result: Either[Result.Failing[A], (A, Int)]) {
+    def value: Either[Result.Failing[A], A] = result.map(_._1)
+    def count: Either[Result.Failing[A], Int] = result.map(_._2)
+  }
+
+  def tests: Tests = Tests {
+
+    import Bump._
+
+    test("reading") {
+
+      val versions = Seq(Version.Release(1, 2, 3), Version.Snapshot(1, 2, 3))
+
+      test("currentVersion") - workspaceTest0(versions: _*) { eval => expectedVersion =>
+        val out = eval(TestModule.versionFile.currentVersion)
+        assert(out.value == Right(expectedVersion))
+      }
+
+      test("releaseVersion") - workspaceTest(versions: _*) { eval =>
+        val out = eval(TestModule.versionFile.releaseVersion)
+        assertMatch(out) {
+          case Right((Version.Release(1, 2, 3), _)) =>
+        }
+      }
+
+      test("nextVersion") - workspaceTest(versions: _*) { eval =>
+        val out = eval(TestModule.versionFile.nextVersion(minor))
+        assertMatch(out) {
+          case Right((Version.Snapshot(1, 3, 0), _)) =>
+        }
+      }
+
+    }
+
+    test("writing") {
+
+      val versions = Seq(Version.Release(1, 2, 3), Version.Snapshot(1, 2, 3))
+
+      test("setReleaseVersion") - workspaceTest(versions: _*) { eval =>
+        val expected = eval(TestModule.versionFile.releaseVersion)
+        val write    = eval(TestModule.versionFile.setReleaseVersion)
+        val actual   = eval(TestModule.versionFile.currentVersion)
+        assert(expected.value == actual.value)
+      }
+
+      test("setNextVersion") - workspaceTest(versions: _*) { eval =>
+        val bump     = minor
+        val expected = eval(TestModule.versionFile.nextVersion(bump))
+        val write    = eval(TestModule.versionFile.setNextVersion(bump))
+        val actual   = eval(TestModule.versionFile.currentVersion)
+        assert(expected.value == actual.value)
+      }
+
+      test("setVersion") - workspaceTest(versions: _*) { eval =>
+        val expected = Version.Release(1, 2, 4)
+        val write    = eval(TestModule.versionFile.setVersion(expected))
+        val actual   = eval(TestModule.versionFile.currentVersion)
+        assert(actual.value == Right(expected))
+      }
+
+    }
+
+    test("procs") {
+
+      val versions = Seq(Version.Release(1, 2, 3), Version.Snapshot(1, 2, 3))
+      
+      test("tag") - workspaceTest0(versions: _*) { eval => version =>
+        val procs         = eval(TestModule.versionFile.tag)
+        val commitMessage = TestModule.versionFile.generateCommitMessage(version)
+        assert(
+          procs.value == Right(
+            Seq (
+              os.proc("git", "tag", version.toString),
+              os.proc("git", "commit", "-am", commitMessage)
+            )
+          )
+        )
+      }
+      
+      test("push") - workspaceTest0(versions: _*) { eval => version =>
+        val procs         = eval(TestModule.versionFile.push)
+        val commitMessage = TestModule.versionFile.generateCommitMessage(version)
+        assert(
+          procs.value == Right(
+            Seq (
+              os.proc("git", "commit", "-am", commitMessage),
+              os.proc("git", "push", "origin", "master", "--tags")
+            )
+          )
+        )
+      }
+
+    }
+  }
+}

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -9,7 +9,7 @@ import os.write
 
 object VersionFileModuleTests extends TestSuite {
 
-  object TestModule extends TestUtil.BaseModule{
+  object TestModule extends TestUtil.BaseModule {
     case object versionFile extends VersionFileModule
   }
 

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -106,8 +106,8 @@ object VersionFileModuleTests extends TestSuite {
         assert(
           procs.value == Right(
             Seq (
-              os.proc("git", "tag", version.toString),
-              os.proc("git", "commit", "-am", commitMessage)
+              os.proc("git", "commit", "-am", commitMessage),
+              os.proc("git", "tag", version.toString)
             )
           )
         )

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionFileModuleTests.scala
@@ -1,0 +1,3 @@
+package mill.contrib.versionfile
+
+

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionTests.scala
@@ -1,3 +1,129 @@
 package mill.contrib.versionfile
 
+import utest.{assert, assertMatch, intercept, test, Tests, TestSuite}
 
+object VersionTests extends TestSuite {
+  def tests = Tests {
+
+    test("toString") {
+      val snapshot = Version.Snapshot(1, 2, 3)
+      val release  = Version.Release(1, 2, 3)
+
+      assert(
+        snapshot.toString == "1.2.3-SNAPSHOT",
+        release.toString == "1.2.3"
+      )
+    }
+
+    test("parsing") {
+
+      test("x.y.z") {
+        assertMatch(Version.of("1.2.3")) {
+          case Version.Release(1, 2, 3) =>
+        }
+      }
+
+      test("x.y.z-SNAPSHOT") {
+        assertMatch(Version.of("1.2.3-SNAPSHOT")) {
+          case Version.Snapshot(1, 2, 3) =>
+        }
+      }
+
+      test("x.y.z.r") {
+        intercept [MatchError] {
+          Version.of("1.2.3.4")
+        }
+      }
+
+      test("scopt") {
+        assertMatch(Version.read.reads("1.2.3")) {
+          case Version.Release(1, 2, 3) =>
+        }
+      }
+
+      test("upickle") {
+        val in = Version.of("1.2.3")
+        val out = Version.readWriter.visitString(
+          Version.readWriter.write(upickle.default.StringReader, in), 0
+        )
+        assert(in == out)
+      }
+    }
+
+    test("modification") {
+
+      test("to release") {
+        val snapshot = Version.Snapshot(1, 2, 3)
+        val release  = Version.Release(1, 2, 3)
+
+        assert(
+          snapshot.asRelease == release,
+          release.asRelease == release
+        )
+      }
+
+      test("to snapshot") {
+        val snapshot = Version.Snapshot(1, 2, 3)
+        val release  = Version.Release(1, 2, 3)
+
+        assert(
+          release.asSnapshot == snapshot,
+          snapshot.asSnapshot == snapshot
+        )
+      }
+
+      test("bumping") {
+
+        import Bump._
+
+        test("patch snapshot") {
+          val snapshot = Version.Snapshot(1, 2, 3)
+
+          assertMatch(snapshot.bump(patch)) {
+            case Version.Snapshot(1, 2, 4) =>
+          }
+        }
+
+        test("minor snapshot") {
+          val snapshot = Version.Snapshot(1, 2, 3)
+
+          assertMatch(snapshot.bump(minor)) {
+            case Version.Snapshot(1, 3, 0) =>
+          }
+        }
+
+        test("major snapshot") {
+          val snapshot = Version.Snapshot(1, 2, 3)
+
+          assertMatch(snapshot.bump(major)) {
+            case Version.Snapshot(2, 0, 0) =>
+          }
+        }
+
+        test("patch release") {
+          val release = Version.Release(1, 2, 3)
+
+          assertMatch(release.bump(patch)) {
+            case Version.Release(1, 2, 4) =>
+          }
+        }
+
+        test("minor release") {
+          val release = Version.Release(1, 2, 3)
+
+          assertMatch(release.bump(minor)) {
+            case Version.Release(1, 3, 0) =>
+          }
+        }
+
+        test("major release") {
+          val release = Version.Release(1, 2, 3)
+
+          assertMatch(release.bump(major)) {
+            case Version.Release(2, 0, 0) =>
+          }
+        }
+      }
+    }
+  }
+}

--- a/contrib/versionfile/test/src/mill/contrib/versionfile/VersionTests.scala
+++ b/contrib/versionfile/test/src/mill/contrib/versionfile/VersionTests.scala
@@ -1,0 +1,3 @@
+package mill.contrib.versionfile
+
+


### PR DESCRIPTION
Refactored the module, to make it more testable. As a result, it's more modular than the previous iteration. The git tagging/pushing and writing the versions to file are now separated into different tasks, making it easier to use just the parts you want and extend as you want.

Most likely all the git related stuff here will be moved to its own module at some point. Will probably do that when adding the support for pure git tagging that was mentioned in the previous pull request, as that seems like a better place for that stuff to reside.