### PR TITLE
More robust MILL_CLASSPATH on Windows

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -710,7 +710,7 @@ def assembly = T{
     "-Djna.nosys=true"
   )
   val shellArgs = Seq("-DMILL_CLASSPATH=$0") ++ commonArgs
-  val cmdArgs = Seq("-DMILL_CLASSPATH=%0") ++ commonArgs
+  val cmdArgs = Seq(""""-DMILL_CLASSPATH=%~dpnx0"""") ++ commonArgs
   os.move(
     createAssembly(
       devRunClasspath,


### PR DESCRIPTION
I ran into problems while trying `mill.bat` from various folders..  
This ensures you can use it from e.g. "C:\New folder\mill.bat" (notice the space)