### PR TITLE
Align JNA API/platform version

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -53,8 +53,10 @@ object Deps {
   val jettyServer = ivy"org.eclipse.jetty:jetty-server:8.1.16.v20140903"
   val jettyWebsocket =  ivy"org.eclipse.jetty:jetty-websocket:8.1.16.v20140903"
   val jgraphtCore = ivy"org.jgrapht:jgrapht-core:1.3.0"
+  
   val jna = ivy"net.java.dev.jna:jna:5.0.0"
   val jnaPlatform = ivy"net.java.dev.jna:jna-platform:5.0.0"
+  
   val junitInterface = ivy"com.novocode:junit-interface:0.11"
   val lambdaTest = ivy"de.tototec:de.tobiasroeser.lambdatest:0.7.0"
   val osLib = ivy"com.lihaoyi::os-lib:0.6.3"

--- a/build.sc
+++ b/build.sc
@@ -54,7 +54,7 @@ object Deps {
   val jettyWebsocket =  ivy"org.eclipse.jetty:jetty-websocket:8.1.16.v20140903"
   val jgraphtCore = ivy"org.jgrapht:jgrapht-core:1.3.0"
   val jna = ivy"net.java.dev.jna:jna:5.0.0"
-  val jnaPlatform = ivy"net.java.dev.jna:jna-platform:4.5.0"
+  val jnaPlatform = ivy"net.java.dev.jna:jna-platform:5.0.0"
   val junitInterface = ivy"com.novocode:junit-interface:0.11"
   val lambdaTest = ivy"de.tototec:de.tobiasroeser.lambdatest:0.7.0"
   val osLib = ivy"com.lihaoyi::os-lib:0.6.3"


### PR DESCRIPTION
JNA folks made some break changes in JNA 5.0. Without this, running under windows without `-i` will throws:
```
F:\repos\test>mill clean
Exception in thread "main" java.lang.NoSuchFieldError: SIZE
        at com.sun.jna.platform.win32.WinBase.<clinit>(WinBase.java:52)
        at com.sun.jna.platform.win32.WinNT$HANDLE.fromNative(WinNT.java:1366)
        at com.sun.jna.NativeMappedConverter.fromNative(NativeMappedConverter.java:78)
        at com.sun.jna.Function.invoke(Function.java:369)
        at com.sun.jna.Library$Handler.invoke(Library.java:244)
        at com.sun.proxy.$Proxy0.CreateNamedPipe(Unknown Source)
        at org.scalasbt.ipcsocket.Win32NamedPipeServerSocket.<init>(Win32NamedPipeServerSocket.java:92)
        at org.scalasbt.ipcsocket.Win32NamedPipeServerSocket.<init>(Win32NamedPipeServerSocket.java:61)
        at org.scalasbt.ipcsocket.Win32NamedPipeServerSocket.<init>(Win32NamedPipeServerSocket.java:47)
        at mill.main.Server.$anonfun$run$2(MillServerMain.scala:87)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
        at mill.main.Server$.lockBlock(MillServerMain.scala:198)
        at mill.main.Server.$anonfun$run$1(MillServerMain.scala:84)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
        at mill.main.Server$.tryLockBlock(MillServerMain.scala:205)
        at mill.main.Server.run(MillServerMain.scala:81)
        at mill.main.MillServerMain$.main(MillServerMain.scala:45)
        at mill.main.MillServerMain.main(MillServerMain.scala)
```