### PR TITLE
fix the Configuring Mill doc lineCount task to use correct os methods

### DIFF
--- a/docs/pages/2 - Configuring Mill.md
+++ b/docs/pages/2 - Configuring Mill.md
@@ -329,7 +329,7 @@ object foo extends ScalaModule {
 
 def lineCount = T {
 
-  foo.sources().flatMap(ref => os.walk(ref.path)).filter(_.isFile).flatMap(read.lines).size
+  foo.sources().flatMap(ref => os.walk(ref.path)).filter(os.isFile(_)).flatMap(os.read.lines(_)).size
 }
 
 def printLineCount() = T.command {


### PR DESCRIPTION
The custom task code `foo.sources().flatMap(ref => os.walk(ref.path)).filter(_.isFile).flatMap(read.lines).size` generates the following errros:

```text
build.sc:13: value isFile is not a member of os.Path
    .filter(_.isFile)
              ^
build.sc:14: not found: value read
    .flatMap(read.lines)
             ^
build.sc:9: `T.command` definitions must have 1 parameter list
def lineCount = T {
    ^
Compilation Failed
```

Change the code to use the correct os methods.