### PR TITLE
fix doc Tasks  code

### DIFF
--- a/docs/pages/2 - Configuring Mill.md
+++ b/docs/pages/2 - Configuring Mill.md
@@ -329,7 +329,7 @@ object foo extends ScalaModule {
 
 def lineCount = T {
 
-  foo.sources().flatMap(ref => os.walk(ref.path)).filter(os.isFile(_)).flatMap(os.read.lines(_)).size
+  foo.sources().flatMap(ref => os.walk(ref.path)).filter(os.isFile).flatMap(os.read.lines).size
 }
 
 def printLineCount() = T.command {

--- a/docs/pages/4 - Tasks.md
+++ b/docs/pages/4 - Tasks.md
@@ -5,7 +5,7 @@ for building Scala.
 The following is a simple self-contained example using Mill to compile Java:
 
 ```scala
-, mill._
+import mill._, mill.modules.Jvm
 
 // sourceRoot -> allSources -> classFiles
 //                                |
@@ -18,17 +18,18 @@ def resourceRoot = T.sources { os.pwd / 'resources }
 
 def allSources = T { sourceRoot().flatMap(p => os.walk(p.path)).map(PathRef(_)) }
 
-def classFiles = T { 
+def classFiles = T {
   os.makeDir.all(T.ctx.dest)
-  
-  %("javac", allSources().map(_.path.toString()), "-d", T.ctx.dest)(wd = T.ctx.dest)
-  PathRef(T.ctx.dest) 
+
+  os.proc("javac", allSources().map(_.path.toString()), "-d", T.ctx.dest)
+    .call(cwd = T.ctx.dest)
+  PathRef(T.ctx.dest)
 }
 
-def jar = T { Jvm.createJar(Loose.Agg(classFiles().path) ++ resourceRoot().map(_.path)) }
+def jar = T { Jvm.createJar(Agg(classFiles().path) ++ resourceRoot().map(_.path)) }
 
 def run(mainClsName: String) = T.command {
-  os.proc('java, "-cp", classFiles().path, mainClsName).call()
+  os.proc("java", "-cp", classFiles().path, mainClsName).call() 
 }
 ```
 


### PR DESCRIPTION
Fix  doc Tasks code to make it workable
 - import broken/missing packages
-  use `os.proc` to run subprocess

Improve  Custom Tasks code by removing redundant placeholder `_` in `os.isFile` and `os.read.lines`