### PR TITLE
improve task doc and use OS-Lib code

### DIFF
--- a/docs/pages/1 - Intro to Mill.md
+++ b/docs/pages/1 - Intro to Mill.md
@@ -862,7 +862,7 @@ Each folder currently contains the following files:
 
 - `dest/`: a path for the `Task` to use either as a scratch space, or to place
   generated files that are returned using `PathRef`s. `Task`s should only output
-  files within their given `dest/` folder (available as `T.ctx.dest`) to avoid
+  files within their given `dest/` folder (available as `T.dest`) to avoid
   conflicting with other `Task`s, but files within `dest/` can be named
   arbitrarily.
 

--- a/docs/pages/2 - Configuring Mill.md
+++ b/docs/pages/2 - Configuring Mill.md
@@ -360,7 +360,7 @@ to return nothing.
 Your custom targets can depend on each other using the `def bar = T {... foo()
 ...}` syntax, and you can create arbitrarily long chains of dependent targets.
 Mill will handle the re-evaluation and caching of the targets' output for you,
-and will provide you a `T.ctx.dest` folder for you to use as scratch space or
+and will provide you a `T.dest` folder for you to use as scratch space or
 to store files you want to return.
 
 Custom targets and commands can contain arbitrary code. Whether you want to
@@ -486,7 +486,7 @@ object foo extends ScalaModule {
   def scalaVersion = "2.12.4"
   def unmanagedClasspath = T {
     if (!os.exists(millSourcePath / "lib")) Agg()
-    else Agg.from(os.ls(millSourcePath / "lib").map(PathRef(_)))
+    else Agg.from(os.list(millSourcePath / "lib").map(PathRef(_)))
   }
 }
 ```

--- a/docs/pages/2 - Configuring Mill.md
+++ b/docs/pages/2 - Configuring Mill.md
@@ -485,8 +485,8 @@ import mill._, scalalib._
 object foo extends ScalaModule {
   def scalaVersion = "2.12.4"
   def unmanagedClasspath = T {
-    if (!ammonite.ops.exists(millSourcePath / "lib")) Agg()
-    else Agg.from(ammonite.ops.ls(millSourcePath / "lib").map(PathRef(_)))
+    if (!os.exists(millSourcePath / "lib")) Agg()
+    else Agg.from(os.ls(millSourcePath / "lib").map(PathRef(_)))
   }
 }
 ```

--- a/docs/pages/4 - Tasks.md
+++ b/docs/pages/4 - Tasks.md
@@ -19,11 +19,11 @@ def resourceRoot = T.sources { os.pwd / 'resources }
 def allSources = T { sourceRoot().flatMap(p => os.walk(p.path)).map(PathRef(_)) }
 
 def classFiles = T {
-  os.makeDir.all(T.ctx.dest)
+  os.makeDir.all(T.dest)
 
-  os.proc("javac", allSources().map(_.path.toString()), "-d", T.ctx.dest)
-    .call(cwd = T.ctx.dest)
-  PathRef(T.ctx.dest)
+  os.proc("javac", allSources().map(_.path.toString()), "-d", T.dest)
+    .call(cwd = T.dest)
+  PathRef(T.dest)
 }
 
 def jar = T { Jvm.createJar(Agg(classFiles().path) ++ resourceRoot().map(_.path)) }
@@ -100,8 +100,8 @@ object MyCaseClass {
 ```
 
 If you want to return a file or a set of files as the result of a `Target`,
-write them to disk within your `T.ctx.dest` available through the
-[Task Context API](#task-context-api) and return a `PathRef(T.ctx.dest)`that hashes the files you
+write them to disk within your `T.dest` available through the
+[Task Context API](#task-context-api) and return a `PathRef(T.dest)`that hashes the files you
 wrote.
 
 If a target's inputs change but its output does not, e.g. someone changes a
@@ -177,7 +177,7 @@ Command:
 
 ### mill.api.Ctx.Dest
 
-- `T.ctx.dest`
+- `T.dest`
 - `implicitly[mill.api.Ctx.Dest]`
 
 This is the unique `out/classFiles/dest/` path or `out/run/dest/` path that is

--- a/docs/pages/4 - Tasks.md
+++ b/docs/pages/4 - Tasks.md
@@ -101,8 +101,8 @@ object MyCaseClass {
 
 If you want to return a file or a set of files as the result of a `Target`,
 write them to disk within your `T.dest` available through the
-[Task Context API](#task-context-api) and return a `PathRef(T.dest)`that hashes the files you
-wrote.
+[Task Context API](#task-context-api) and return a `PathRef(T.dest)`
+that hashes the files you wrote.
 
 If a target's inputs change but its output does not, e.g. someone changes a
 comment within the source files that doesn't affect the classfiles, then
@@ -231,7 +231,7 @@ def envVar = T.input { T.ctx.env.get("ENV_VAR") }
 ### Anonymous Tasks
 
 ```scala
-def foo() = T.task { ... bar() ... }
+def foo(x: Int) = T.task { ... x ... bar() ... }
 ```
 
 You can define anonymous tasks using the `T.task { ... }` syntax. These are not
@@ -239,16 +239,9 @@ runnable from the command-line, but can be used to share common code you find
 yourself repeating in `Target`s and `Command`s.
 
 ```scala
-def downstreamTarget = T { ... foo() ... } 
-def downstreamCommand = T.command { ... foo() ... } 
+def downstreamTarget = T { ... foo(42)() ... } 
+def downstreamCommand(x: Int) = T.command { ... foo(x)() ... }
 ```
-
-Anonymous tasks can be parametrized. However, it is not very useful because
-a parameter means two-way dependency: a caller depends on the anonymous
-task's result and the anonymous task depends on the caller to give the input
-value. The compiler raises an error if the caller passes its variable as
-the argument of the anonymous task. Use a regular Scala parameterized method
-to define shared code based on input values.
 
 Anonymous task's output does not need to be JSON-serializable, their output is
 not cached, and they can be defined with or without arguments. Unlike
@@ -257,8 +250,8 @@ anywhere and passed around any way you want, until you finally make use of them
 within a downstream target or command.
 
 While an anonymous task `foo`'s own output is not cached, if it is used in a
-downstream target `bar` and the upstream targets `baz` `qux` haven't changed,
-`bar`'s cached output will be used and `foo`'s evaluation will be skipped
+downstream target `baz` and the upstream target `bar` hasn't changed,
+`baz`'s cached output will be used and `foo`'s evaluation will be skipped
 altogether.
 
 ### Persistent Targets

--- a/docs/pages/7 - Extending Mill.md
+++ b/docs/pages/7 - Extending Mill.md
@@ -48,7 +48,7 @@ object foo extends ScalaModule {
 
 def deploy(assembly: PathRef, credentials: String) = ???
 
-def deployFoo(credentials: String) = T.command { deployFoo(foo.assembly()) }
+def deployFoo(credentials: String) = T.command { deploy(foo.assembly(), credentials) }
 ```
 
 
@@ -181,4 +181,3 @@ Many built-in tools are implemented as custom evaluator commands:
 [all](http://www.lihaoyi.com/mill/#all), [inspect](http://www.lihaoyi.com/mill/#inspect),
 [resolve](http://www.lihaoyi.com/mill/#resolve), [show](http://www.lihaoyi.com/mill/#show).
 If you want a way to run Mill commands and programmatically manipulate the tasks and outputs, you do so with your own evaluator command.
-

--- a/docs/pages/7 - Extending Mill.md
+++ b/docs/pages/7 - Extending Mill.md
@@ -19,9 +19,9 @@ custom Target (for cached computations) or Command (for un-cached actions) and
 you're done.
 
 For subprocess/filesystem operations, you can use the
-[Ammonite-Ops](http://ammonite.io/#Ammonite-Ops) library that comes bundled with
+[OS-Lib](https://github.com/lihaoyi/os-lib) library that comes bundled with
 Mill, or even plain `java.nio`/`java.lang.Process`. Each target gets its own
-[T.ctx.dest](http://www.lihaoyi.com/mill/page/tasks#millutilctxdestctx) folder
+[T.dest](https://www.lihaoyi.com/mill/page/tasks#task-context-api) folder
 that you can use to place files without worrying about colliding with other
 targets.
 


### PR DESCRIPTION
Improve task description and use OS-Lib in code example

- Use `os` instead of `ammonite.ops` for two reasons: 
  - no need to `import ammonite.ops._`
  - the `%` or `%%` requires implicit values to be imported and the results may not be JSON serializable.
- Improve the description of tasks, especially the anonymous tasks
- fix several code errors
- user `override` in overriding methods to help the compiler find errors