### PR TITLE
Rename .test with .testUncached to avoid duplicate resolution

### DIFF
--- a/docs/pages/8 - Mill Internals.md
+++ b/docs/pages/8 - Mill Internals.md
@@ -104,7 +104,7 @@ macros which allow you to use `Task#apply()` within the block to "extract" a
 value.
 
 ```scala
-def test() = T.command {
+def testUncached() = T.command {
   TestRunner.apply(
    "mill.UTestFramework",
    runDepClasspath().map(_.path) :+ compile().path,
@@ -116,7 +116,7 @@ def test() = T.command {
 This is roughly equivalent to the following:
 
 ```scala
-def test() = T.command { T.zipMap(runDepClasspath, compile, compile) { 
+def testUncached() = T.command { T.zipMap(runDepClasspath, compile, compile) { 
   (runDepClasspath1, compile2, compile3) =>
   TestRunner.apply(
     "mill.UTestFramework",

--- a/integration/test/resources/ammonite/build.sc
+++ b/integration/test/resources/ammonite/build.sc
@@ -262,16 +262,16 @@ class SshdModule(val crossScalaVersion: String) extends AmmModule{
 }
 
 def unitTest(scalaVersion: String = sys.env("TRAVIS_SCALA_VERSION")) = T.command{
-  ops(scalaVersion).test.test()()
-  terminal(scalaVersion).test.test()()
-  amm.repl(scalaVersion).test.test()()
-  amm(scalaVersion).test.test()()
-  shell(scalaVersion).test.test()()
-  sshd(scalaVersion).test.test()()
+  ops(scalaVersion).test.testUncached()()
+  terminal(scalaVersion).test.testUncached()()
+  amm.repl(scalaVersion).test.testUncached()()
+  amm(scalaVersion).test.testUncached()()
+  shell(scalaVersion).test.testUncached()()
+  sshd(scalaVersion).test.testUncached()()
 }
 
 def integrationTest(scalaVersion: String = sys.env("TRAVIS_SCALA_VERSION")) = T.command{
-  integration(scalaVersion).test.test()()
+  integration(scalaVersion).test.testUncached()()
 }
 
 def generateConstantsFile(version: String = buildVersion,

--- a/integration/test/src/AmmoniteTests.scala
+++ b/integration/test/src/AmmoniteTests.scala
@@ -11,7 +11,7 @@ class AmmoniteTests(fork: Boolean)
       val replTests = eval(
         s"amm.repl[$scalaVersion].test", "{ammonite.unit,ammonite.session.ProjectTests.guava}"
       )
-      val replTestMeta = meta(s"amm.repl[$scalaVersion].test.test")
+      val replTestMeta = meta(s"amm.repl[$scalaVersion].test.testUncached")
       assert(
         replTests,
         replTestMeta.contains("ammonite.session.ProjectTests.guava"),

--- a/integration/test/src/BetterFilesTests.scala
+++ b/integration/test/src/BetterFilesTests.scala
@@ -12,7 +12,7 @@ class BetterFilesTests(fork: Boolean)
       assert(eval("akka.test"))
       assert(eval("benchmarks.test.compile"))
 
-      val coreTestMeta = meta("core.test.test")
+      val coreTestMeta = meta("core.test.testUncached")
       assert(coreTestMeta.contains("better.files.FileSpec"))
       assert(coreTestMeta.contains("files should handle BOM"))
 

--- a/integration/test/src/PlayJsonTests.scala
+++ b/integration/test/src/PlayJsonTests.scala
@@ -14,7 +14,7 @@ class PlayJsonTests(fork: Boolean) extends IntegrationTestSuite("MILL_PLAY_JSON_
 
     'jvm - {
       assert(eval("playJsonJvm[2.12.4].test"))
-      val jvmMeta = meta("playJsonJvm[2.12.4].test.test")
+      val jvmMeta = meta("playJsonJvm[2.12.4].test.testUncached")
 
       assert(
         jvmMeta.contains("play.api.libs.json.JsonSharedSpec"),
@@ -28,7 +28,7 @@ class PlayJsonTests(fork: Boolean) extends IntegrationTestSuite("MILL_PLAY_JSON_
     }
     'js - {
       assert(eval("playJsonJs[2.12.4].test"))
-      val jsMeta = meta("playJsonJs[2.12.4].test.test")
+      val jsMeta = meta("playJsonJs[2.12.4].test.testUncached")
 
       assert(
         jsMeta.contains("play.api.libs.json.JsonSharedSpec"),
@@ -42,7 +42,7 @@ class PlayJsonTests(fork: Boolean) extends IntegrationTestSuite("MILL_PLAY_JSON_
     }
     'playJoda - {
       assert(eval("playJoda[2.12.4].test"))
-      val metaFile = meta("playJoda[2.12.4].test.test")
+      val metaFile = meta("playJoda[2.12.4].test.testUncached")
 
       assert(
         metaFile.contains("play.api.libs.json.JsonJodaValidSpec"),

--- a/integration/test/src/UpickleTests.scala
+++ b/integration/test/src/UpickleTests.scala
@@ -8,20 +8,20 @@ class UpickleTests(fork: Boolean) extends IntegrationTestSuite("MILL_UPICKLE_REP
     'jvm21111 - {
       mill.util.TestUtil.disableInJava9OrAbove({
         assert(eval("upickleJvm[2.11.11].test"))
-        val jvmMeta = meta("upickleJvm[2.11.11].test.test")
+        val jvmMeta = meta("upickleJvm[2.11.11].test.testUncached")
         assert(jvmMeta.contains("example.ExampleTests.simple"))
         assert(jvmMeta.contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
       })
     }
     'jvm2124 - {
       assert(eval("upickleJvm[2.12.4].test"))
-      val jvmMeta = meta("upickleJvm[2.12.4].test.test")
+      val jvmMeta = meta("upickleJvm[2.12.4].test.testUncached")
       assert(jvmMeta.contains("example.ExampleTests.simple"))
       assert(jvmMeta.contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
     }
     'js - {
       assert(eval("upickleJs[2.12.4].test"))
-      val jsMeta = meta("upickleJs[2.12.4].test.test")
+      val jsMeta = meta("upickleJs[2.12.4].test.testUncached")
       assert(jsMeta .contains("example.ExampleTests.simple"))
       assert(jsMeta .contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
     }

--- a/main/src/main/MainRunner.scala
+++ b/main/src/main/MainRunner.scala
@@ -38,7 +38,12 @@ class MainRunner(val config: ammonite.main.Cli.Config,
   var stateCache  = stateCache0
 
   override def watchAndWait(watched: Seq[(ammonite.interp.Watchable, Long)]) = {
-    printInfo(s"Watching for changes to ${watched.size} values... (Ctrl-C to exit)")
+    val (watchedPaths, watchedValues) = watched.partitionMap {
+      case (ammonite.interp.Watchable.Path(p), _) => Left(())
+      case (_, _) => Right(())
+    }
+    val watchedValueStr = if (watchedValues.isEmpty) "" else s" and ${watchedValues.size} other values"
+    printInfo(s"Watching for changes to ${watchedPaths} values$watchedValueStr... (Ctrl-C to exit)")
     def statAll() = watched.forall{ case (file, lastMTime) =>
       file.poll() == lastMTime
     }

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -201,7 +201,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
     )
   }
 
-  override def testLocal(args: String*) = T.command { test(args:_*) }
+  override def testLocal(args: String*) = T.command { testUncached(args:_*) }
 
   override protected def testTask(args: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] = T.task {
     val (close, framework) = mill.scalajslib.ScalaJSWorkerApi.scalaJSWorker().getFramework(

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -160,7 +160,7 @@ object HelloJSWorldTests extends TestSuite {
 
     def checkUtest(scalaVersion: String, scalaJSVersion: String, cached: Boolean) = {
       val resultMap = runTests(
-        if(!cached) HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion).test.test()
+        if(!cached) HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion).test.testUncached()
         else HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion).test.testCached
       )
 
@@ -180,7 +180,7 @@ object HelloJSWorldTests extends TestSuite {
 
     def checkScalaTest(scalaVersion: String, scalaJSVersion: String, cached: Boolean) = {
       val resultMap = runTests(
-        if(!cached) HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion).test.test()
+        if(!cached) HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion).test.testUncached()
         else HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion).test.testCached
       )
 

--- a/scalajslib/test/src/MultiModuleTests.scala
+++ b/scalajslib/test/src/MultiModuleTests.scala
@@ -57,7 +57,7 @@ object MultiModuleTests extends TestSuite {
     'fullOpt - TestUtil.disableInJava9OrAbove(checkOpt(FullOpt))
 
     'test - {
-      val Right(((_, testResults), evalCount)) = evaluator(MultiModule.client.test.test())
+      val Right(((_, testResults), evalCount)) = evaluator(MultiModule.client.test.testUncached())
 
       assert(
         evalCount > 0,

--- a/scalajslib/test/src/NodeJSConfigTests.scala
+++ b/scalajslib/test/src/NodeJSConfigTests.scala
@@ -77,7 +77,7 @@ object NodeJSConfigTests extends TestSuite {
     'test - {
 
       def checkUtest(nodeArgs: List[String], notNodeArgs: List[String]) = {
-        checkLog(HelloJSWorld.buildUTest(scalaVersion, nodeArgs).test.test(), nodeArgs, notNodeArgs)
+        checkLog(HelloJSWorld.buildUTest(scalaVersion, nodeArgs).test.testUncached(), nodeArgs, notNodeArgs)
       }
 
       'test - checkUtest(nodeArgsEmpty, nodeArgs2G)

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -574,7 +574,7 @@ trait JavaModule extends mill.Module
 }
 
 trait TestModule extends JavaModule with TaskModule {
-  override def defaultCommandName() = "test"
+  override def defaultCommandName() = "testUncached"
   /**
     * What test frameworks to use.
     */
@@ -584,7 +584,7 @@ trait TestModule extends JavaModule with TaskModule {
     * results to the console.
     * @see [[testCached]]
     */
-  def test(args: String*): Command[(String, Seq[TestRunner.Result])] = T.command {
+  def testUncached(args: String*): Command[(String, Seq[TestRunner.Result])] = T.command {
     testTask(T.task{args})()
   }
 

--- a/scalalib/test/src/HelloJavaTests.scala
+++ b/scalalib/test/src/HelloJavaTests.scala
@@ -67,7 +67,7 @@ object HelloJavaTests extends TestSuite {
     'test - {
       val eval = init()
 
-      val Left(Result.Failure(ref1, Some(v1))) = eval.apply(HelloJava.core.test.test())
+      val Left(Result.Failure(ref1, Some(v1))) = eval.apply(HelloJava.core.test.testUncached())
 
       assert(
         v1._2(0).fullyQualifiedName == "hello.MyCoreTests.lengthTest",
@@ -76,7 +76,7 @@ object HelloJavaTests extends TestSuite {
         v1._2(1).status == "Failure"
       )
 
-      val Right((v2, _)) = eval.apply(HelloJava.app.test.test())
+      val Right((v2, _)) = eval.apply(HelloJava.app.test.testUncached())
 
       assert(
         v2._2(0).fullyQualifiedName == "hello.MyAppTests.appTest",

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -907,7 +907,7 @@ object HelloWorldTests extends TestSuite {
       HelloScalacheck,
       resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-scalacheck"
     ){ eval =>
-      val Right((res, evalCount)) = eval.apply(HelloScalacheck.foo.test.test())
+      val Right((res, evalCount)) = eval.apply(HelloScalacheck.foo.test.testUncached())
       assert(
         evalCount > 0,
         res._2.map(_.selector) == Seq(

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -163,7 +163,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule { testOute
     def name = clazz.getName.reverse.dropWhile(_ == '$').reverse
   }
 
-  override def testLocal(args: String*) = T.command { test(args:_*) }
+  override def testLocal(args: String*) = T.command { testUncached(args:_*) }
 
   override protected def testTask(args: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] = T.task {
     val outputPath = T.dest / "out.json"

--- a/scalanativelib/test/src/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/HelloNativeWorldTests.scala
@@ -153,7 +153,7 @@ object HelloNativeWorldTests extends TestSuite {
 
     def checkNoTests(scalaVersion: String, scalaNativeVersion: String, mode: ReleaseMode, cached: Boolean) = {
       val Right(((message, results), _)) = helloWorldEvaluator(
-        if (!cached) HelloNativeWorld.buildNoTests(scalaVersion, scalaNativeVersion, mode).test.test()
+        if (!cached) HelloNativeWorld.buildNoTests(scalaVersion, scalaNativeVersion, mode).test.testUncached()
         else HelloNativeWorld.buildNoTests(scalaVersion, scalaNativeVersion, mode).test.testCached
       )
 
@@ -165,7 +165,7 @@ object HelloNativeWorldTests extends TestSuite {
 
     def checkUtest(scalaVersion: String, scalaNativeVersion: String, mode: ReleaseMode, cached: Boolean) = {
       val resultMap = runTests(
-        if (!cached) HelloNativeWorld.buildUTest(scalaVersion, scalaNativeVersion, mode).test.test()
+        if (!cached) HelloNativeWorld.buildUTest(scalaVersion, scalaNativeVersion, mode).test.testUncached()
         else HelloNativeWorld.buildUTest(scalaVersion, scalaNativeVersion, mode).test.testCached
       )
 
@@ -185,7 +185,7 @@ object HelloNativeWorldTests extends TestSuite {
 
     def checkScalaTest(scalaVersion: String, scalaNativeVersion: String, mode: ReleaseMode, cached: Boolean) = {
       val resultMap = runTests(
-        if (!cached) HelloNativeWorld.buildScalaTest(scalaVersion, scalaNativeVersion, mode).test.test()
+        if (!cached) HelloNativeWorld.buildScalaTest(scalaVersion, scalaNativeVersion, mode).test.testUncached()
         else HelloNativeWorld.buildScalaTest(scalaVersion, scalaNativeVersion, mode).test.testCached
       )
 


### PR DESCRIPTION
This should avoid the problem with `__.test` running the `.test.test()` command twice