### PR TITLE
fix `Cannot find scala-library-2.13.0.jar ..` Exception when compile dotty project

### DIFF
--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -55,18 +55,28 @@ object Util {
     scalaVersion.startsWith("0.") ||
     scalaVersion.startsWith("3.")
 
+  // eg, grepJar(classPath, name = "scala-library", versionPrefix = "2.13.")
+  // return first path in `classPath` that match:
+  // **/scala-library-2.13.*.jar or
+  // **/2.13.*/jars/scala-library.jar
+  def grepJar(classPath: Agg[os.Path], name: String, versionPrefix: String, sources: Boolean = false) = {
+    val suffix = if (sources) "-sources.jar" else ".jar"
+    lazy val dir = if (sources) "srcs" else "jars"
 
-  def grepJar(classPath: Agg[os.Path], name: String, version: String, sources: Boolean = false) = {
-    val suffix = if (sources) "-sources" else ""
-    val mavenStylePath = s"$name-$version$suffix.jar"
-    val ivyStylePath = {
-      val dir = if (sources) "srcs" else "jars"
-      s"$version/$dir/$name$suffix.jar"
+    def mavenStyleMatch(fname: String) =
+      fname.startsWith(s"$name-$versionPrefix") && fname.endsWith(suffix)
+
+    def ivyStyleMatch(p: os.Path) = {
+      val fname = s"$name$suffix"
+      p.segments.toSeq match {
+        case _ :+ v :+ `dir` :+ `fname` if v.startsWith(versionPrefix) => true
+        case _ => false
+      }
     }
 
-    classPath
-      .find(p => p.toString.endsWith(mavenStylePath) || p.toString.endsWith(ivyStylePath))
-      .getOrElse(throw new Exception(s"Cannot find $mavenStylePath or $ivyStylePath in ${classPath.mkString("[", ", ", "]")}"))
+    classPath.iterator
+      .find(p => mavenStyleMatch(p.last) || ivyStyleMatch(p))
+      .getOrElse(throw new Exception(s"Cannot find **/$name-$versionPrefix*$suffix or **/$versionPrefix*/$dir/$name$suffix in ${classPath.iterator.mkString("[", ", ", "]")}"))
   }
 
   val PartialVersion = raw"""(\d+)\.(\d+)\.*""".r

--- a/scalalib/worker/src/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/ZincWorkerImpl.scala
@@ -345,7 +345,9 @@ class ZincWorkerImpl(compilerBridge: Either[
         loader = getCachedClassLoader(compilersSig, combinedCompilerJars),
         libraryJar = libraryJarNameGrep(
           compilerClasspath,
-          if (isDotty(scalaVersion)) "2.13.0" else scalaVersion
+          // we don't support too outdated dotty versions
+          // and because there will be no scala 2.14, so hardcode "2.13." here is acceptable
+          if (isDotty(scalaVersion)) "2.13." else scalaVersion
         ).toIO,
         compilerJar = compilerJar.toIO,
         allJars = combinedCompilerJars,


### PR DESCRIPTION
+ build.sc
```scala
import mill._, scalalib._

object foo extends Cross[FooModule]("0.24.0-RC1", "2.13.2")
class FooModule(val crossScalaVersion: String) extends CrossSbtModule
```
+ output
<details>

```scala
% cat .mill-version 
0.6.2-35-7d1144
% mill 'foo[0.24.0-RC1]'.compile
Compiling /Users/thanhbv/ohze/oss/mill-example/build.sc
[26/26] foo[0.24.0-RC1].compile 
java.lang.Exception: Cannot find scala-library-2.13.0.jar or 2.13.0/jars/scala-library.jar in [/Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/ch/epfl/lamp/scala-library/0.24.0-RC1/scala-library-0.24.0-RC1.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/ch/epfl/lamp/dotty-interfaces/0.24.0-RC1/dotty-interfaces-0.24.0-RC1.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/ch/epfl/lamp/dotty-compiler_0.24/0.24.0-RC1/dotty-compiler_0.24-0.24.0-RC1.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/ch/epfl/lamp/dotty-library_0.24/0.24.0-RC1/dotty-library_0.24-0.24.0-RC1.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.2.2/util-interface-1.2.2.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/org/jline/jline-terminal/3.9.0/jline-terminal-3.9.0.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/net/java/dev/jna/jna/4.2.2/jna-4.2.2.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-asm/7.3.1-scala-1/scala-asm-7.3.1-scala-1.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.2.5/compiler-interface-1.2.5.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/org/jline/jline-reader/3.9.0/jline-reader-3.9.0.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/ch/epfl/lamp/tasty-core_0.24/0.24.0-RC1/tasty-core_0.24-0.24.0-RC1.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.2/scala-library-2.13.2.jar, /Users/thanhbv/.coursier/cache/v1/https/repo1.maven.org/maven2/org/jline/jline-terminal-jna/3.9.0/jline-terminal-jna-3.9.0.jar]
        at mill.scalalib.api.Util$.$anonfun$grepJar$2(ZincWorkerApi.scala:69)
        at scala.Option.getOrElse(Option.scala:201)
        at mill.scalalib.api.Util$.grepJar(ZincWorkerApi.scala:69)
        at mill.scalalib.ZincWorkerModule.$anonfun$worker$6(ZincWorkerModule.scala:74)
        at mill.scalalib.worker.ZincWorkerImpl.$anonfun$withCompilers$3(ZincWorkerImpl.scala:348)
        at scala.Option.getOrElse(Option.scala:201)
        at mill.api.FixSizedCache.withCachedValue(FixSizedCache.scala:53)
        at mill.scalalib.worker.ZincWorkerImpl.withCompilers(ZincWorkerImpl.scala:360)
        at mill.scalalib.worker.ZincWorkerImpl.compileMixed0(ZincWorkerImpl.scala:284)
        at mill.scalalib.worker.ZincWorkerImpl.compileMixed(ZincWorkerImpl.scala:254)
        at mill.scalalib.ScalaModule.$anonfun$compile$2(ScalaModule.scala:143)
        at mill.define.ApplyerGenerated.$anonfun$zipMap$9(ApplicativeGenerated.scala:21)
        at mill.define.Task$MappedDest.evaluate(Task.scala:392)
        at mill.eval.Evaluator.$anonfun$evaluateGroup$13(Evaluator.scala:476)
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:59)
        at scala.Console$.withErr(Console.scala:193)
        at mill.eval.Evaluator.$anonfun$evaluateGroup$12(Evaluator.scala:476)
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:59)
        at scala.Console$.withOut(Console.scala:164)
        at mill.eval.Evaluator.$anonfun$evaluateGroup$11(Evaluator.scala:475)
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:59)
        at scala.Console$.withIn(Console.scala:227)
        at mill.eval.Evaluator.$anonfun$evaluateGroup$8(Evaluator.scala:474)
        at mill.eval.Evaluator.$anonfun$evaluateGroup$8$adapted(Evaluator.scala:426)
        at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:553)
        at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:551)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:921)
        at mill.eval.Evaluator.evaluateGroup(Evaluator.scala:426)
        at mill.eval.Evaluator.evaluateGroupCached(Evaluator.scala:329)
        at mill.eval.Evaluator.$anonfun$sequentialEvaluate$2(Evaluator.scala:110)
        at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:553)
        at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:551)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1274)
        at mill.eval.Evaluator.sequentialEvaluate(Evaluator.scala:93)
        at mill.eval.Evaluator.evaluate(Evaluator.scala:79)
        at mill.main.RunScript$.evaluate(RunScript.scala:209)
        at mill.main.RunScript$.$anonfun$evaluateTasks$1(RunScript.scala:195)
        at scala.util.Either.map(Either.scala:382)
        at mill.main.RunScript$.evaluateTasks(RunScript.scala:194)
        at mill.main.RunScript$.$anonfun$runScript$4(RunScript.scala:68)
        at ammonite.util.Res$Success.flatMap(Res.scala:62)
        at mill.main.RunScript$.runScript(RunScript.scala:67)
        at mill.main.MainRunner.$anonfun$runScript$1(MainRunner.scala:106)
        at mill.main.MainRunner.watchLoop2(MainRunner.scala:63)
        at mill.main.MainRunner.runScript(MainRunner.scala:81)
        at mill.MillMain$.main0(MillMain.scala:227)
        at mill.main.MillServerMain$.main0(MillServerMain.scala:67)
        at mill.main.Server.$anonfun$handleRun$1(MillServerMain.scala:154)
        at java.base/java.lang.Thread.run(Thread.java:830)
```
</details>

