### PR TITLE
Ability to pass GPG arguments to publish

### DIFF
--- a/scalalib/src/PublishModule.scala
+++ b/scalalib/src/PublishModule.scala
@@ -114,13 +114,17 @@ trait PublishModule extends JavaModule { outer =>
     )
   }
 
+  /**
+    * Publish all given artifacts to Sonatype.
+    * @param gpgArgs GPG arguments. Defaults to `--batch --yes -a -b`.
+    *                 Specifying this will override/remove the defaults. Add the default args to your args to keep them.
+    */
   def publish(sonatypeCreds: String,
-              gpgPassphrase: String = null,
-              gpgKeyName: String = null,
               signed: Boolean = true,
+              gpgArgs: Seq[String] = PublishModule.defaultGpgArgs,
+              release: Boolean,
               readTimeout: Int = 60000,
               connectTimeout: Int = 5000,
-              release: Boolean,
               awaitTimeout: Int = 120 * 1000,
               stagingRelease: Boolean = true): define.Command[Unit] = T.command {
     val PublishModule.PublishData(artifactInfo, artifacts) = publishArtifacts()
@@ -128,9 +132,8 @@ trait PublishModule extends JavaModule { outer =>
       sonatypeUri,
       sonatypeSnapshotUri,
       sonatypeCreds,
-      Option(gpgPassphrase),
-      Option(gpgKeyName),
       signed,
+      gpgArgs,
       readTimeout,
       connectTimeout,
       T.log,
@@ -141,37 +144,41 @@ trait PublishModule extends JavaModule { outer =>
 }
 
 object PublishModule extends ExternalModule {
+  val defaultGpgArgs = Seq("--batch", "--yes", "-a", "-b")
 
   case class PublishData(meta: Artifact, payload: Seq[(PathRef, String)])
   object PublishData{
     implicit def jsonify: upickle.default.ReadWriter[PublishData] = upickle.default.macroRW
   }
 
-  /** An extra resource artifact to publish.
+  /**
+    * An extra resource artifact to publish.
     * @param file The artifact file
     * @param ivyCategory The ivy catogory (e.g. "jars", "zips")
-    * @param The file suffix including the file extension (e.g. "-with-deps.jar", "-dist.zip").
-    *        It will be appended to the artifact id to construct the full file name.
+    * @param suffix The file suffix including the file extension (e.g. "-with-deps.jar", "-dist.zip").
+    *               It will be appended to the artifact id to construct the full file name.
     */
   case class ExtraPublish(file: PathRef, ivyCategory: String, suffix: String)
   object ExtraPublish {
     implicit def jsonify: upickle.default.ReadWriter[ExtraPublish] = upickle.default.macroRW
   }
 
-
-  def publishAll(sonatypeCreds: String,
-                 gpgPassphrase: String = null,
-                 publishArtifacts: mill.main.Tasks[PublishModule.PublishData],
-                 readTimeout: Int = 60000,
-                 connectTimeout: Int = 5000,
+  /**
+    * Publish all given artifacts to Sonatype.
+    * @param gpgArgs GPG arguments. Defaults to `--batch --yes -a -b`.
+    *                Specifying this will override/remove the defaults. Add the default args to your args to keep them.
+    */
+  def publishAll(publishArtifacts: mill.main.Tasks[PublishModule.PublishData],
+                 sonatypeCreds: String,
+                 signed: Boolean = true,
+                 gpgArgs: Seq[String] = defaultGpgArgs,
                  release: Boolean = false,
-                 gpgKeyName: String = null,
                  sonatypeUri: String = "https://oss.sonatype.org/service/local",
                  sonatypeSnapshotUri: String = "https://oss.sonatype.org/content/repositories/snapshots",
-                 signed: Boolean = true,
+                 readTimeout: Int = 60000,
+                 connectTimeout: Int = 5000,
                  awaitTimeout: Int = 120 * 1000,
-                 stagingRelease: Boolean = true) = T.command {
-
+                 stagingRelease: Boolean = true): Command[Unit] = T.command {
     val x: Seq[(Seq[(os.Path, String)], Artifact)] = T.sequence(publishArtifacts.value)().map{
       case PublishModule.PublishData(a, s) => (s.map{case (p, f) => (p.path, f)}, a)
     }
@@ -179,9 +186,8 @@ object PublishModule extends ExternalModule {
       sonatypeUri,
       sonatypeSnapshotUri,
       sonatypeCreds,
-      Option(gpgPassphrase),
-      Option(gpgKeyName),
       signed,
+      gpgArgs,
       readTimeout,
       connectTimeout,
       T.log,


### PR DESCRIPTION
Not sure if we are ok to break the interface here. If not I can probably add back `gpgPassphrase` and `gpgKeyName` with a `@deprecated` and wire that to `gpgArgs`.