### PR TITLE
Adds a way to skip bloop configuration

### DIFF
--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -63,7 +63,7 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
     }
 
     /**
-      * Setting to true enables the bloop configuration generation
+      * Setting to true enables skipping the bloop configuration generation
       */
     def skipBloop: Boolean = false
   }

--- a/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
+++ b/contrib/bloop/test/src/mill/contrib/bloop/BloopTests.scala
@@ -57,6 +57,11 @@ object BloopTests extends TestSuite {
       override def releaseMode = T(ReleaseMode.Release)
     }
 
+    object skippedModule extends scalalib.ScalaModule with testBloop.Module {
+      def scalaVersion = "2.12.8"
+      override def skipBloop: Boolean = true
+    }
+
 
   }
 
@@ -161,6 +166,10 @@ object BloopTests extends TestSuite {
         assert(version == "2.11.12")
         assert(platform.config.mode == BloopConfig.LinkerMode.Release)
         assert(platform.config.clang == clang.toNIO)
+      }
+      'skipped - {
+        val exists = os.exists(workdir / ".bloop" / "skippedModule.json")
+        assert(exists == false)
       }
     }
   }


### PR DESCRIPTION
When a project has a large amount of cross-compilation and bloop is
only used as a gateway to metals, one might want to skip the generation
of the configuration for some specific scala versions or target
platforms