### PR TITLE
Upgrade coursier to 2.0.0-RC6-15

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -41,7 +41,7 @@ object Deps {
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.0"
   val ammonite = ivy"com.lihaoyi:::ammonite:2.1.1"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.4.0-RC1"
-  val coursier = ivy"io.get-coursier::coursier:2.0.0-RC5-3"
+  val coursier = ivy"io.get-coursier::coursier:2.0.0-RC6-15"
   val flywayCore = ivy"org.flywaydb:flyway-core:6.0.1"
   val graphvizJava = ivy"guru.nidi:graphviz-java:0.8.3"
   val ipcsocket = ivy"org.scala-sbt.ipcsocket:ipcsocket:1.0.0"


### PR DESCRIPTION
The newer version of coursier has deterministic ordering (see coursier/coursier#1546, thanks for the pointer @smarter), which in turn fixes #853.