### PR TITLE
Avoid duplicate target with __ and fix resolve __

### DIFF
--- a/docs/pages/8 - Mill Internals.md
+++ b/docs/pages/8 - Mill Internals.md
@@ -104,7 +104,7 @@ macros which allow you to use `Task#apply()` within the block to "extract" a
 value.
 
 ```scala
-def testUncached() = T.command {
+def test() = T.command {
   TestRunner.apply(
    "mill.UTestFramework",
    runDepClasspath().map(_.path) :+ compile().path,
@@ -116,7 +116,7 @@ def testUncached() = T.command {
 This is roughly equivalent to the following:
 
 ```scala
-def testUncached() = T.command { T.zipMap(runDepClasspath, compile, compile) { 
+def test() = T.command { T.zipMap(runDepClasspath, compile, compile) { 
   (runDepClasspath1, compile2, compile3) =>
   TestRunner.apply(
     "mill.UTestFramework",

--- a/integration/test/resources/ammonite/build.sc
+++ b/integration/test/resources/ammonite/build.sc
@@ -262,16 +262,16 @@ class SshdModule(val crossScalaVersion: String) extends AmmModule{
 }
 
 def unitTest(scalaVersion: String = sys.env("TRAVIS_SCALA_VERSION")) = T.command{
-  ops(scalaVersion).test.testUncached()()
-  terminal(scalaVersion).test.testUncached()()
-  amm.repl(scalaVersion).test.testUncached()()
-  amm(scalaVersion).test.testUncached()()
-  shell(scalaVersion).test.testUncached()()
-  sshd(scalaVersion).test.testUncached()()
+  ops(scalaVersion).test.test()()
+  terminal(scalaVersion).test.test()()
+  amm.repl(scalaVersion).test.test()()
+  amm(scalaVersion).test.test()()
+  shell(scalaVersion).test.test()()
+  sshd(scalaVersion).test.test()()
 }
 
 def integrationTest(scalaVersion: String = sys.env("TRAVIS_SCALA_VERSION")) = T.command{
-  integration(scalaVersion).test.testUncached()()
+  integration(scalaVersion).test.test()()
 }
 
 def generateConstantsFile(version: String = buildVersion,

--- a/integration/test/src/AmmoniteTests.scala
+++ b/integration/test/src/AmmoniteTests.scala
@@ -11,7 +11,7 @@ class AmmoniteTests(fork: Boolean)
       val replTests = eval(
         s"amm.repl[$scalaVersion].test", "{ammonite.unit,ammonite.session.ProjectTests.guava}"
       )
-      val replTestMeta = meta(s"amm.repl[$scalaVersion].test.testUncached")
+      val replTestMeta = meta(s"amm.repl[$scalaVersion].test.test")
       assert(
         replTests,
         replTestMeta.contains("ammonite.session.ProjectTests.guava"),

--- a/integration/test/src/BetterFilesTests.scala
+++ b/integration/test/src/BetterFilesTests.scala
@@ -12,7 +12,7 @@ class BetterFilesTests(fork: Boolean)
       assert(eval("akka.test"))
       assert(eval("benchmarks.test.compile"))
 
-      val coreTestMeta = meta("core.test.testUncached")
+      val coreTestMeta = meta("core.test.test")
       assert(coreTestMeta.contains("better.files.FileSpec"))
       assert(coreTestMeta.contains("files should handle BOM"))
 

--- a/integration/test/src/PlayJsonTests.scala
+++ b/integration/test/src/PlayJsonTests.scala
@@ -14,7 +14,7 @@ class PlayJsonTests(fork: Boolean) extends IntegrationTestSuite("MILL_PLAY_JSON_
 
     'jvm - {
       assert(eval("playJsonJvm[2.12.4].test"))
-      val jvmMeta = meta("playJsonJvm[2.12.4].test.testUncached")
+      val jvmMeta = meta("playJsonJvm[2.12.4].test.test")
 
       assert(
         jvmMeta.contains("play.api.libs.json.JsonSharedSpec"),
@@ -28,7 +28,7 @@ class PlayJsonTests(fork: Boolean) extends IntegrationTestSuite("MILL_PLAY_JSON_
     }
     'js - {
       assert(eval("playJsonJs[2.12.4].test"))
-      val jsMeta = meta("playJsonJs[2.12.4].test.testUncached")
+      val jsMeta = meta("playJsonJs[2.12.4].test.test")
 
       assert(
         jsMeta.contains("play.api.libs.json.JsonSharedSpec"),
@@ -42,7 +42,7 @@ class PlayJsonTests(fork: Boolean) extends IntegrationTestSuite("MILL_PLAY_JSON_
     }
     'playJoda - {
       assert(eval("playJoda[2.12.4].test"))
-      val metaFile = meta("playJoda[2.12.4].test.testUncached")
+      val metaFile = meta("playJoda[2.12.4].test.test")
 
       assert(
         metaFile.contains("play.api.libs.json.JsonJodaValidSpec"),

--- a/integration/test/src/UpickleTests.scala
+++ b/integration/test/src/UpickleTests.scala
@@ -8,20 +8,20 @@ class UpickleTests(fork: Boolean) extends IntegrationTestSuite("MILL_UPICKLE_REP
     'jvm21111 - {
       mill.util.TestUtil.disableInJava9OrAbove({
         assert(eval("upickleJvm[2.11.11].test"))
-        val jvmMeta = meta("upickleJvm[2.11.11].test.testUncached")
+        val jvmMeta = meta("upickleJvm[2.11.11].test.test")
         assert(jvmMeta.contains("example.ExampleTests.simple"))
         assert(jvmMeta.contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
       })
     }
     'jvm2124 - {
       assert(eval("upickleJvm[2.12.4].test"))
-      val jvmMeta = meta("upickleJvm[2.12.4].test.testUncached")
+      val jvmMeta = meta("upickleJvm[2.12.4].test.test")
       assert(jvmMeta.contains("example.ExampleTests.simple"))
       assert(jvmMeta.contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
     }
     'js - {
       assert(eval("upickleJs[2.12.4].test"))
-      val jsMeta = meta("upickleJs[2.12.4].test.testUncached")
+      val jsMeta = meta("upickleJs[2.12.4].test.test")
       assert(jsMeta .contains("example.ExampleTests.simple"))
       assert(jsMeta .contains("upickle.MacroTests.commonCustomStructures.simpleAdt"))
     }

--- a/main/src/main/MainModule.scala
+++ b/main/src/main/MainModule.scala
@@ -194,7 +194,7 @@ trait MainModule extends mill.Module{
         // When using `show`, redirect all stdout of the evaluated tasks so the
         // printed JSON is the only thing printed to stdout.
         baseLogger = evaluator.baseLogger match{
-          case PrintLogger(c1, d, c2, o, i, e, in, de, uc) => PrintLogger(c1, d, c2, e, i, e, in, de, uc)
+          case PrintLogger(c1, d, c2, _, i, e, in, de, uc) => PrintLogger(c1, d, c2, e, i, e, in, de, uc)
           case l => l
         }
       ),

--- a/main/src/main/Resolve.scala
+++ b/main/src/main/Resolve.scala
@@ -29,11 +29,10 @@ object ResolveMetadata extends Resolve[String]{
   }
 
   def endResolveLabel(obj: Module,
-                      revSelectorsSoFar: List[Segment],
                       last: String,
                       discover: Discover[_],
                       rest: Seq[String]): Either[String, Seq[String]] = {
-    def direct = singleModuleMeta(obj, discover, revSelectorsSoFar.isEmpty)
+    def direct = singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty)
     last match{
       case "__" =>
         Right(
@@ -43,14 +42,13 @@ object ResolveMetadata extends Resolve[String]{
       case "_" => Right(direct)
       case _ =>
         direct.find(_.split('.').last == last) match {
-          case None => Resolve.errorMsgLabel(direct, last, revSelectorsSoFar)
+          case None => Resolve.errorMsgLabel(direct, last, obj.millModuleSegments.value)
           case Some(s) => Right(Seq(s))
         }
     }
   }
 
   def endResolveCross(obj: Module,
-                      revSelectorsSoFar: List[Segment],
                       last: List[String],
                       discover: Discover[_],
                       rest: Seq[String]): Either[String, List[String]] = {
@@ -67,7 +65,7 @@ object ResolveMetadata extends Resolve[String]{
                 Resolve.errorMsgCross(
                   c.items.map(_._1.map(_.toString)),
                   last,
-                  revSelectorsSoFar
+                  obj.millModuleSegments.value
                 )
               case res => Right(res)
             }
@@ -75,8 +73,8 @@ object ResolveMetadata extends Resolve[String]{
         }
       case _ =>
         Left(
-          Resolve.unableToResolve(Segment.Cross(last), revSelectorsSoFar) +
-          Resolve.hintListLabel(revSelectorsSoFar)
+          Resolve.unableToResolve(Segment.Cross(last), obj.millModuleSegments.value) +
+          Resolve.hintListLabel(obj.millModuleSegments.value)
         )
     }
   }
@@ -85,7 +83,6 @@ object ResolveMetadata extends Resolve[String]{
 object ResolveSegments extends Resolve[Segments] {
 
   override def endResolveCross(obj: Module,
-                               revSelectorsSoFar: List[Segment],
                                last: List[String],
                                discover: Discover[_],
                                rest: Seq[String]): Either[String, Seq[Segments]] = {
@@ -102,21 +99,20 @@ object ResolveSegments extends Resolve[Segments] {
                 Resolve.errorMsgCross(
                   c.items.map(_._1.map(_.toString)),
                   last,
-                  revSelectorsSoFar
+                  obj.millModuleSegments.value
                 )
               case res => Right(res)
             }
         }
       case _ =>
         Left(
-          Resolve.unableToResolve(Segment.Cross(last), revSelectorsSoFar) +
-            Resolve.hintListLabel(revSelectorsSoFar)
+          Resolve.unableToResolve(Segment.Cross(last), obj.millModuleSegments.value) +
+            Resolve.hintListLabel(obj.millModuleSegments.value)
         )
     }
   }
 
   def endResolveLabel(obj: Module,
-                      revSelectorsSoFar: List[Segment],
                       last: String,
                       discover: Discover[_],
                       rest: Seq[String]): Either[String, Seq[Segments]] = {
@@ -141,9 +137,9 @@ object ResolveSegments extends Resolve[Segments] {
     command orElse target orElse module match {
       case None =>
         Resolve.errorMsgLabel(
-          singleModuleMeta(obj, discover, revSelectorsSoFar.isEmpty),
+          singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty),
           last,
-          revSelectorsSoFar
+          obj.millModuleSegments.value
         )
 
       case Some(either) => either.right.map(Seq(_))
@@ -155,7 +151,6 @@ object ResolveTasks extends Resolve[NamedTask[Any]]{
 
 
   def endResolveCross(obj: Module,
-                      revSelectorsSoFar: List[Segment],
                       last: List[String],
                       discover: Discover[_],
                       rest: Seq[String]): Either[String, Seq[NamedTask[Any]]] = {
@@ -165,20 +160,19 @@ object ResolveTasks extends Resolve[NamedTask[Any]]{
           case None =>
             Left(
               "Cannot find default task to evaluate for module " +
-              Segments((Segment.Cross(last) :: revSelectorsSoFar).reverse:_*).render
+              Segments((Segment.Cross(last) +: obj.millModuleSegments.value).reverse:_*).render
             )
           case Some(v) => v.map(Seq(_))
         }
       case _ =>
         Left(
-          Resolve.unableToResolve(Segment.Cross(last), revSelectorsSoFar) +
-          Resolve.hintListLabel(revSelectorsSoFar)
+          Resolve.unableToResolve(Segment.Cross(last), obj.millModuleSegments.value) +
+          Resolve.hintListLabel(obj.millModuleSegments.value)
         )
     }
   }
 
   def endResolveLabel(obj: Module,
-                      revSelectorsSoFar: List[Segment],
                       last: String,
                       discover: Discover[_],
                       rest: Seq[String]): Either[String, Seq[NamedTask[Any]]] = last match{
@@ -202,9 +196,9 @@ object ResolveTasks extends Resolve[NamedTask[Any]]{
       command orElse target orElse Resolve.runDefault(obj, Segment.Label(last), discover, rest).flatten.headOption match {
         case None =>
           Resolve.errorMsgLabel(
-            singleModuleMeta(obj, discover, revSelectorsSoFar.isEmpty),
+            singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty),
             last,
-            revSelectorsSoFar
+            obj.millModuleSegments.value
           )
 
         // Contents of `either` *must* be a `Task`, because we only select
@@ -232,28 +226,27 @@ object Resolve{
     dist(s2.length)(s1.length)
   }
 
-  def unableToResolve(last: Segment, revSelectorsSoFar: List[Segment]): String = {
-    unableToResolve(Segments((last :: revSelectorsSoFar).reverse: _*).render)
+  def unableToResolve(last: Segment, revSelectorsSoFar: Seq[Segment]): String = {
+    unableToResolve(Segments((last +: revSelectorsSoFar).reverse: _*).render)
   }
 
   def unableToResolve(segments: String): String = "Cannot resolve " + segments + "."
 
-  def hintList(revSelectorsSoFar: List[Segment]) = {
+  def hintList(revSelectorsSoFar: Seq[Segment]) = {
     val search = Segments(revSelectorsSoFar.reverse: _*).render
     s" Try `mill resolve $search` to see what's available."
   }
 
-  def hintListLabel(revSelectorsSoFar: List[Segment]) = {
-    hintList(Segment.Label("_") :: revSelectorsSoFar)
+  def hintListLabel(revSelectorsSoFar: Seq[Segment]) = {
+    hintList(Segment.Label("_") +: revSelectorsSoFar)
   }
 
-  def hintListCross(revSelectorsSoFar: List[Segment]) = {
-    hintList(Segment.Cross(Seq("__")) :: revSelectorsSoFar)
+  def hintListCross(revSelectorsSoFar: Seq[Segment]) = {
+    hintList(Segment.Cross(Seq("__")) +: revSelectorsSoFar)
   }
 
   def errorMsgBase[T](direct: Seq[T],
                       last0: T,
-                      revSelectorsSoFar: List[Segment],
                       editSplit: String => String,
                       defaultErrorMsg: String)
                      (strings: T => Seq[String],
@@ -282,11 +275,10 @@ object Resolve{
     }
   }
 
-  def errorMsgLabel(direct: Seq[String], last: String, revSelectorsSoFar: List[Segment]) = {
+  def errorMsgLabel(direct: Seq[String], last: String, revSelectorsSoFar: Seq[Segment]) = {
     errorMsgBase(
       direct,
-      Segments((Segment.Label(last) :: revSelectorsSoFar).reverse:_*).render,
-      revSelectorsSoFar,
+      Segments((Segment.Label(last) +: revSelectorsSoFar).reverse:_*).render,
       _.split('.').last,
       hintListLabel(revSelectorsSoFar)
     )(
@@ -297,16 +289,15 @@ object Resolve{
 
   def errorMsgCross(crossKeys: Seq[Seq[String]],
                     last: Seq[String],
-                    revSelectorsSoFar: List[Segment]) = {
+                    revSelectorsSoFar: Seq[Segment]) = {
     errorMsgBase(
       crossKeys,
       last,
-      revSelectorsSoFar,
       x => x,
       hintListCross(revSelectorsSoFar)
     )(
       crossKeys => crossKeys,
-      crossKeys => Segments((Segment.Cross(crossKeys) :: revSelectorsSoFar).reverse:_*).render
+      crossKeys => Segments((Segment.Cross(crossKeys) +: revSelectorsSoFar).reverse:_*).render
     )
   }
 
@@ -346,12 +337,10 @@ object Resolve{
 }
 abstract class Resolve[R: ClassTag] {
   def endResolveCross(obj: Module,
-                      revSelectorsSoFar: List[Segment],
                       last: List[String],
                       discover: Discover[_],
                       rest: Seq[String]): Either[String, Seq[R]]
   def endResolveLabel(obj: Module,
-                      revSelectorsSoFar: List[Segment],
                       last: String,
                       discover: Discover[_],
                       rest: Seq[String]): Either[String, Seq[R]]
@@ -360,21 +349,18 @@ abstract class Resolve[R: ClassTag] {
               obj: mill.Module,
               discover: Discover[_],
               rest: Seq[String],
-              remainingCrossSelectors: List[List[String]],
-              revSelectorsSoFar: List[Segment]): Either[String, Seq[R]] = {
+              remainingCrossSelectors: List[List[String]]): Either[String, Seq[R]] = {
 
     remainingSelector match{
       case Segment.Cross(last) :: Nil =>
-        endResolveCross(obj, revSelectorsSoFar, last.map(_.toString).toList, discover, rest)
+        endResolveCross(obj, last.map(_.toString).toList, discover, rest)
       case Segment.Label(last) :: Nil =>
-        endResolveLabel(obj, revSelectorsSoFar, last, discover, rest)
+        endResolveLabel(obj, last, discover, rest)
 
       case head :: tail =>
-        val newRevSelectorsSoFar = head :: revSelectorsSoFar
-
         def recurse(searchModules: Seq[Module], resolveFailureMsg: => Left[String, Nothing]) = {
           val matching = searchModules
-            .map(resolve(tail, _, discover, rest, remainingCrossSelectors, newRevSelectorsSoFar))
+            .map(resolve(tail, _, discover, rest, remainingCrossSelectors))
 
           matching match{
             case Seq(Left(err)) => Left(err)
@@ -396,13 +382,13 @@ abstract class Resolve[R: ClassTag] {
                   .toSeq
               },
               if (singleLabel != "_") Resolve.errorMsgLabel(
-                singleModuleMeta(obj, discover, revSelectorsSoFar.isEmpty),
+                singleModuleMeta(obj, discover, obj.millModuleSegments.value.isEmpty),
                 singleLabel,
-                revSelectorsSoFar
+                obj.millModuleSegments.value
               )
               else Left(
-                "Cannot resolve " + Segments((remainingSelector.reverse ++ revSelectorsSoFar).reverse:_*).render +
-                ". Try `mill resolve " + Segments((Segment.Label("_") :: revSelectorsSoFar).reverse:_*).render + "` to see what's available"
+                "Cannot resolve " + Segments((remainingSelector.reverse ++ obj.millModuleSegments.value).reverse:_*).render +
+                ". Try `mill resolve " + Segments((Segment.Label("_") +: obj.millModuleSegments.value).reverse:_*).render + "` to see what's available"
               )
             ).map(
               _.distinctBy {
@@ -425,7 +411,7 @@ abstract class Resolve[R: ClassTag] {
                   Resolve.errorMsgCross(
                     c.items.map(_._1.map(_.toString)),
                     cross.map(_.toString),
-                    revSelectorsSoFar
+                    obj.millModuleSegments.value
                   )
                 )
               case _ =>

--- a/main/src/main/RunScript.scala
+++ b/main/src/main/RunScript.scala
@@ -142,10 +142,7 @@ object RunScript{
               // main build. Resolving targets from external builds as CLI arguments
               // is not currently supported
               mill.eval.Evaluator.currentEvaluator.set(evaluator)
-              resolver.resolve(
-                sel.value.toList, rootModule, rootModule.millDiscover,
-                args, crossSelectors.toList, Nil
-              )
+              resolver.resolve(sel.value.toList, rootModule, rootModule.millDiscover, args, crossSelectors.toList)
             } finally {
               mill.eval.Evaluator.currentEvaluator.set(null)
             }

--- a/main/src/main/RunScript.scala
+++ b/main/src/main/RunScript.scala
@@ -151,10 +151,7 @@ object RunScript{
         EitherOps.sequence(selected)
       }
       res <- EitherOps.sequence(taskss)
-    } yield res.flatten//.distinctBy {
-//      case t: NamedTask[_] => t.ctx.segments
-//      case t => t
-//    }
+    } yield res.flatten
   }
 
   def resolveRootModule[T](evaluator: Evaluator, scopedSel: Option[Segments]) = {

--- a/main/src/main/RunScript.scala
+++ b/main/src/main/RunScript.scala
@@ -1,7 +1,6 @@
 package mill.main
 
 import java.nio.file.NoSuchFileException
-
 import ammonite.interp.Interpreter
 import ammonite.runtime.SpecialClassLoader
 import ammonite.util.Util.CodeSource
@@ -12,7 +11,6 @@ import mill.eval.{Evaluator, PathRef, Result}
 import mill.util.{EitherOps, ParseArgs, PrintLogger, Watched}
 import mill.api.Logger
 import mill.api.Strict.Agg
-
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
@@ -121,7 +119,6 @@ object RunScript{
       } catch {
         case e: Throwable => Res.Exception(e, "")
       }
-//      _ <- Res(consistencyCheck(mapping))
     } yield module
   }
 
@@ -137,7 +134,6 @@ object RunScript{
           for(res <- prepareResolve(evaluator, scopedSel, sel))
           yield {
             val (rootModule, crossSelectors) = res
-
 
             try {
               // We inject the `evaluator.rootModule` into the TargetScopt, rather
@@ -158,7 +154,10 @@ object RunScript{
         EitherOps.sequence(selected)
       }
       res <- EitherOps.sequence(taskss)
-    } yield res.flatten
+    } yield res.flatten//.distinctBy {
+//      case t: NamedTask[_] => t.ctx.segments
+//      case t => t
+//    }
   }
 
   def resolveRootModule[T](evaluator: Evaluator, scopedSel: Option[Segments]) = {

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -201,7 +201,7 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
     )
   }
 
-  override def testLocal(args: String*) = T.command { testUncached(args:_*) }
+  override def testLocal(args: String*) = T.command { test(args:_*) }
 
   override protected def testTask(args: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] = T.task {
     val (close, framework) = mill.scalajslib.ScalaJSWorkerApi.scalaJSWorker().getFramework(

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -160,7 +160,7 @@ object HelloJSWorldTests extends TestSuite {
 
     def checkUtest(scalaVersion: String, scalaJSVersion: String, cached: Boolean) = {
       val resultMap = runTests(
-        if(!cached) HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion).test.testUncached()
+        if(!cached) HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion).test.test()
         else HelloJSWorld.buildUTest(scalaVersion, scalaJSVersion).test.testCached
       )
 
@@ -180,7 +180,7 @@ object HelloJSWorldTests extends TestSuite {
 
     def checkScalaTest(scalaVersion: String, scalaJSVersion: String, cached: Boolean) = {
       val resultMap = runTests(
-        if(!cached) HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion).test.testUncached()
+        if(!cached) HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion).test.test()
         else HelloJSWorld.buildScalaTest(scalaVersion, scalaJSVersion).test.testCached
       )
 

--- a/scalajslib/test/src/MultiModuleTests.scala
+++ b/scalajslib/test/src/MultiModuleTests.scala
@@ -57,7 +57,7 @@ object MultiModuleTests extends TestSuite {
     'fullOpt - TestUtil.disableInJava9OrAbove(checkOpt(FullOpt))
 
     'test - {
-      val Right(((_, testResults), evalCount)) = evaluator(MultiModule.client.test.testUncached())
+      val Right(((_, testResults), evalCount)) = evaluator(MultiModule.client.test.test())
 
       assert(
         evalCount > 0,

--- a/scalajslib/test/src/NodeJSConfigTests.scala
+++ b/scalajslib/test/src/NodeJSConfigTests.scala
@@ -77,7 +77,7 @@ object NodeJSConfigTests extends TestSuite {
     'test - {
 
       def checkUtest(nodeArgs: List[String], notNodeArgs: List[String]) = {
-        checkLog(HelloJSWorld.buildUTest(scalaVersion, nodeArgs).test.testUncached(), nodeArgs, notNodeArgs)
+        checkLog(HelloJSWorld.buildUTest(scalaVersion, nodeArgs).test.test(), nodeArgs, notNodeArgs)
       }
 
       'test - checkUtest(nodeArgsEmpty, nodeArgs2G)

--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -574,7 +574,7 @@ trait JavaModule extends mill.Module
 }
 
 trait TestModule extends JavaModule with TaskModule {
-  override def defaultCommandName() = "testUncached"
+  override def defaultCommandName() = "test"
   /**
     * What test frameworks to use.
     */
@@ -584,7 +584,7 @@ trait TestModule extends JavaModule with TaskModule {
     * results to the console.
     * @see [[testCached]]
     */
-  def testUncached(args: String*): Command[(String, Seq[TestRunner.Result])] = T.command {
+  def test(args: String*): Command[(String, Seq[TestRunner.Result])] = T.command {
     testTask(T.task{args})()
   }
 

--- a/scalalib/test/src/HelloJavaTests.scala
+++ b/scalalib/test/src/HelloJavaTests.scala
@@ -67,7 +67,7 @@ object HelloJavaTests extends TestSuite {
     'test - {
       val eval = init()
 
-      val Left(Result.Failure(ref1, Some(v1))) = eval.apply(HelloJava.core.test.testUncached())
+      val Left(Result.Failure(ref1, Some(v1))) = eval.apply(HelloJava.core.test.test())
 
       assert(
         v1._2(0).fullyQualifiedName == "hello.MyCoreTests.lengthTest",
@@ -76,7 +76,7 @@ object HelloJavaTests extends TestSuite {
         v1._2(1).status == "Failure"
       )
 
-      val Right((v2, _)) = eval.apply(HelloJava.app.test.testUncached())
+      val Right((v2, _)) = eval.apply(HelloJava.app.test.test())
 
       assert(
         v2._2(0).fullyQualifiedName == "hello.MyAppTests.appTest",

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -907,7 +907,7 @@ object HelloWorldTests extends TestSuite {
       HelloScalacheck,
       resourcePath = os.pwd / 'scalalib / 'test / 'resources / "hello-scalacheck"
     ){ eval =>
-      val Right((res, evalCount)) = eval.apply(HelloScalacheck.foo.test.testUncached())
+      val Right((res, evalCount)) = eval.apply(HelloScalacheck.foo.test.test())
       assert(
         evalCount > 0,
         res._2.map(_.selector) == Seq(

--- a/scalanativelib/src/ScalaNativeModule.scala
+++ b/scalanativelib/src/ScalaNativeModule.scala
@@ -163,7 +163,7 @@ trait TestScalaNativeModule extends ScalaNativeModule with TestModule { testOute
     def name = clazz.getName.reverse.dropWhile(_ == '$').reverse
   }
 
-  override def testLocal(args: String*) = T.command { testUncached(args:_*) }
+  override def testLocal(args: String*) = T.command { test(args:_*) }
 
   override protected def testTask(args: Task[Seq[String]]): Task[(String, Seq[TestRunner.Result])] = T.task {
     val outputPath = T.dest / "out.json"

--- a/scalanativelib/test/src/HelloNativeWorldTests.scala
+++ b/scalanativelib/test/src/HelloNativeWorldTests.scala
@@ -153,7 +153,7 @@ object HelloNativeWorldTests extends TestSuite {
 
     def checkNoTests(scalaVersion: String, scalaNativeVersion: String, mode: ReleaseMode, cached: Boolean) = {
       val Right(((message, results), _)) = helloWorldEvaluator(
-        if (!cached) HelloNativeWorld.buildNoTests(scalaVersion, scalaNativeVersion, mode).test.testUncached()
+        if (!cached) HelloNativeWorld.buildNoTests(scalaVersion, scalaNativeVersion, mode).test.test()
         else HelloNativeWorld.buildNoTests(scalaVersion, scalaNativeVersion, mode).test.testCached
       )
 
@@ -165,7 +165,7 @@ object HelloNativeWorldTests extends TestSuite {
 
     def checkUtest(scalaVersion: String, scalaNativeVersion: String, mode: ReleaseMode, cached: Boolean) = {
       val resultMap = runTests(
-        if (!cached) HelloNativeWorld.buildUTest(scalaVersion, scalaNativeVersion, mode).test.testUncached()
+        if (!cached) HelloNativeWorld.buildUTest(scalaVersion, scalaNativeVersion, mode).test.test()
         else HelloNativeWorld.buildUTest(scalaVersion, scalaNativeVersion, mode).test.testCached
       )
 
@@ -185,7 +185,7 @@ object HelloNativeWorldTests extends TestSuite {
 
     def checkScalaTest(scalaVersion: String, scalaNativeVersion: String, mode: ReleaseMode, cached: Boolean) = {
       val resultMap = runTests(
-        if (!cached) HelloNativeWorld.buildScalaTest(scalaVersion, scalaNativeVersion, mode).test.testUncached()
+        if (!cached) HelloNativeWorld.buildScalaTest(scalaVersion, scalaNativeVersion, mode).test.test()
         else HelloNativeWorld.buildScalaTest(scalaVersion, scalaNativeVersion, mode).test.testCached
       )
 


### PR DESCRIPTION
This is also rolling back the `testUncached` to `test`.

The buggy result before this PR:
```shell
> ci/publish-local.sh && ./mill -i dev.run ../kubernetes-client resolve __
checkFormat
checkFormat
com.goyeau.mill.git.GitVersionModule.version
com.goyeau.mill.git.GitVersionModule.version
console
console
console
console
doIt
doIt
fix
fix
ideaConfigFiles
ideaConfigFiles
ideaConfigFiles
ideaConfigFiles
ideaJavaModuleFacets
ideaJavaModuleFacets
ideaJavaModuleFacets
ideaJavaModuleFacets
ivyDepsTree
ivyDepsTree
ivyDepsTree
ivyDepsTree
kubernetes-client[2.12.11]
kubernetes-client[2.12.11].allSourceFiles
kubernetes-client[2.12.11].allSources
kubernetes-client[2.12.11].allSwaggerSourceFiles
kubernetes-client[2.12.11].ammoniteReplClasspath
kubernetes-client[2.12.11].ammoniteVersion
kubernetes-client[2.12.11].artifactId
kubernetes-client[2.12.11].artifactMetadata
kubernetes-client[2.12.11].artifactName
kubernetes-client[2.12.11].artifactScalaVersion
kubernetes-client[2.12.11].artifactSuffix
kubernetes-client[2.12.11].assembly
kubernetes-client[2.12.11].compile
kubernetes-client[2.12.11].compileClasspath
kubernetes-client[2.12.11].compileIvyDeps
kubernetes-client[2.12.11].crossFullScalaVersion
kubernetes-client[2.12.11].docJar
kubernetes-client[2.12.11].extraPublish
kubernetes-client[2.12.11].finalMainClass
kubernetes-client[2.12.11].finalMainClassOpt
kubernetes-client[2.12.11].forkArgs
kubernetes-client[2.12.11].forkEnv
kubernetes-client[2.12.11].forkWorkingDir
kubernetes-client[2.12.11].generatedSources
kubernetes-client[2.12.11].ideaCompileOutput
kubernetes-client[2.12.11].ivy
kubernetes-client[2.12.11].ivyDeps
kubernetes-client[2.12.11].jar
kubernetes-client[2.12.11].javacOptions
kubernetes-client[2.12.11].javacOptions
kubernetes-client[2.12.11].javadocOptions
kubernetes-client[2.12.11].launcher
kubernetes-client[2.12.11].localClasspath
kubernetes-client[2.12.11].mainClass
kubernetes-client[2.12.11].manifest
kubernetes-client[2.12.11].platformSuffix
kubernetes-client[2.12.11].pom
kubernetes-client[2.12.11].pomSettings
kubernetes-client[2.12.11].prependShellScript
kubernetes-client[2.12.11].publishArtifacts
kubernetes-client[2.12.11].publishSelfDependency
kubernetes-client[2.12.11].resources
kubernetes-client[2.12.11].runClasspath
kubernetes-client[2.12.11].runIvyDeps
kubernetes-client[2.12.11].scalaCompilerClasspath
kubernetes-client[2.12.11].scalaDocOptions
kubernetes-client[2.12.11].scalaDocPluginClasspath
kubernetes-client[2.12.11].scalaDocPluginIvyDeps
kubernetes-client[2.12.11].scalaLibraryIvyDeps
kubernetes-client[2.12.11].scalaOrganization
kubernetes-client[2.12.11].scalaVersion
kubernetes-client[2.12.11].scalacOptions
kubernetes-client[2.12.11].scalacOptions
kubernetes-client[2.12.11].scalacPluginClasspath
kubernetes-client[2.12.11].scalacPluginIvyDeps
kubernetes-client[2.12.11].scalacPluginIvyDeps
kubernetes-client[2.12.11].scalafixConfig
kubernetes-client[2.12.11].scalafixIvyDeps
kubernetes-client[2.12.11].scalafmtConfig
kubernetes-client[2.12.11].sourceJar
kubernetes-client[2.12.11].sources
kubernetes-client[2.12.11].swaggerSources
kubernetes-client[2.12.11].test
kubernetes-client[2.12.11].test.allSourceFiles
kubernetes-client[2.12.11].test.allSources
kubernetes-client[2.12.11].test.ammoniteReplClasspath
kubernetes-client[2.12.11].test.ammoniteVersion
kubernetes-client[2.12.11].test.artifactId
kubernetes-client[2.12.11].test.artifactName
kubernetes-client[2.12.11].test.artifactScalaVersion
kubernetes-client[2.12.11].test.artifactSuffix
kubernetes-client[2.12.11].test.assembly
kubernetes-client[2.12.11].test.compile
kubernetes-client[2.12.11].test.compileClasspath
kubernetes-client[2.12.11].test.compileIvyDeps
kubernetes-client[2.12.11].test.crossFullScalaVersion
kubernetes-client[2.12.11].test.docJar
kubernetes-client[2.12.11].test.finalMainClass
kubernetes-client[2.12.11].test.finalMainClassOpt
kubernetes-client[2.12.11].test.forkArgs
kubernetes-client[2.12.11].test.forkEnv
kubernetes-client[2.12.11].test.forkWorkingDir
kubernetes-client[2.12.11].test.generatedSources
kubernetes-client[2.12.11].test.ideaCompileOutput
kubernetes-client[2.12.11].test.ivyDeps
kubernetes-client[2.12.11].test.jar
kubernetes-client[2.12.11].test.javadocOptions
kubernetes-client[2.12.11].test.launcher
kubernetes-client[2.12.11].test.localClasspath
kubernetes-client[2.12.11].test.mainClass
kubernetes-client[2.12.11].test.manifest
kubernetes-client[2.12.11].test.platformSuffix
kubernetes-client[2.12.11].test.prependShellScript
kubernetes-client[2.12.11].test.resources
kubernetes-client[2.12.11].test.runClasspath
kubernetes-client[2.12.11].test.runIvyDeps
kubernetes-client[2.12.11].test.scalaCompilerClasspath
kubernetes-client[2.12.11].test.scalaDocOptions
kubernetes-client[2.12.11].test.scalaDocPluginClasspath
kubernetes-client[2.12.11].test.scalaDocPluginIvyDeps
kubernetes-client[2.12.11].test.scalaLibraryIvyDeps
kubernetes-client[2.12.11].test.scalaOrganization
kubernetes-client[2.12.11].test.scalaVersion
kubernetes-client[2.12.11].test.scalacPluginClasspath
kubernetes-client[2.12.11].test.sourceJar
kubernetes-client[2.12.11].test.sources
kubernetes-client[2.12.11].test.testCached
kubernetes-client[2.12.11].test.testCachedArgs
kubernetes-client[2.12.11].test.testFrameworks
kubernetes-client[2.12.11].test.transitiveIvyDeps
kubernetes-client[2.12.11].test.transitiveLocalClasspath
kubernetes-client[2.12.11].test.unmanagedClasspath
kubernetes-client[2.12.11].test.upstreamAssembly
kubernetes-client[2.12.11].test.upstreamAssemblyClasspath
kubernetes-client[2.12.11].test.upstreamCompileOutput
kubernetes-client[2.12.11].test.yoyo
kubernetes-client[2.12.11].transitiveIvyDeps
kubernetes-client[2.12.11].transitiveLocalClasspath
kubernetes-client[2.12.11].unmanagedClasspath
kubernetes-client[2.12.11].upstreamAssembly
kubernetes-client[2.12.11].upstreamAssemblyClasspath
kubernetes-client[2.12.11].upstreamCompileOutput
kubernetes-client[2.13.2]
kubernetes-client[2.13.2].allSourceFiles
kubernetes-client[2.13.2].allSources
kubernetes-client[2.13.2].allSwaggerSourceFiles
kubernetes-client[2.13.2].ammoniteReplClasspath
kubernetes-client[2.13.2].ammoniteVersion
kubernetes-client[2.13.2].artifactId
kubernetes-client[2.13.2].artifactMetadata
kubernetes-client[2.13.2].artifactName
kubernetes-client[2.13.2].artifactScalaVersion
kubernetes-client[2.13.2].artifactSuffix
kubernetes-client[2.13.2].assembly
kubernetes-client[2.13.2].compile
kubernetes-client[2.13.2].compileClasspath
kubernetes-client[2.13.2].compileIvyDeps
kubernetes-client[2.13.2].crossFullScalaVersion
kubernetes-client[2.13.2].docJar
kubernetes-client[2.13.2].extraPublish
kubernetes-client[2.13.2].finalMainClass
kubernetes-client[2.13.2].finalMainClassOpt
kubernetes-client[2.13.2].forkArgs
kubernetes-client[2.13.2].forkEnv
kubernetes-client[2.13.2].forkWorkingDir
kubernetes-client[2.13.2].generatedSources
kubernetes-client[2.13.2].ideaCompileOutput
kubernetes-client[2.13.2].ivy
kubernetes-client[2.13.2].ivyDeps
kubernetes-client[2.13.2].jar
kubernetes-client[2.13.2].javacOptions
kubernetes-client[2.13.2].javacOptions
kubernetes-client[2.13.2].javadocOptions
kubernetes-client[2.13.2].launcher
kubernetes-client[2.13.2].localClasspath
kubernetes-client[2.13.2].mainClass
kubernetes-client[2.13.2].manifest
kubernetes-client[2.13.2].platformSuffix
kubernetes-client[2.13.2].pom
kubernetes-client[2.13.2].pomSettings
kubernetes-client[2.13.2].prependShellScript
kubernetes-client[2.13.2].publishArtifacts
kubernetes-client[2.13.2].publishSelfDependency
kubernetes-client[2.13.2].resources
kubernetes-client[2.13.2].runClasspath
kubernetes-client[2.13.2].runIvyDeps
kubernetes-client[2.13.2].scalaCompilerClasspath
kubernetes-client[2.13.2].scalaDocOptions
kubernetes-client[2.13.2].scalaDocPluginClasspath
kubernetes-client[2.13.2].scalaDocPluginIvyDeps
kubernetes-client[2.13.2].scalaLibraryIvyDeps
kubernetes-client[2.13.2].scalaOrganization
kubernetes-client[2.13.2].scalaVersion
kubernetes-client[2.13.2].scalacOptions
kubernetes-client[2.13.2].scalacOptions
kubernetes-client[2.13.2].scalacPluginClasspath
kubernetes-client[2.13.2].scalacPluginIvyDeps
kubernetes-client[2.13.2].scalacPluginIvyDeps
kubernetes-client[2.13.2].scalafixConfig
kubernetes-client[2.13.2].scalafixIvyDeps
kubernetes-client[2.13.2].scalafmtConfig
kubernetes-client[2.13.2].sourceJar
kubernetes-client[2.13.2].sources
kubernetes-client[2.13.2].swaggerSources
kubernetes-client[2.13.2].test
kubernetes-client[2.13.2].test.allSourceFiles
kubernetes-client[2.13.2].test.allSources
kubernetes-client[2.13.2].test.ammoniteReplClasspath
kubernetes-client[2.13.2].test.ammoniteVersion
kubernetes-client[2.13.2].test.artifactId
kubernetes-client[2.13.2].test.artifactName
kubernetes-client[2.13.2].test.artifactScalaVersion
kubernetes-client[2.13.2].test.artifactSuffix
kubernetes-client[2.13.2].test.assembly
kubernetes-client[2.13.2].test.compile
kubernetes-client[2.13.2].test.compileClasspath
kubernetes-client[2.13.2].test.compileIvyDeps
kubernetes-client[2.13.2].test.crossFullScalaVersion
kubernetes-client[2.13.2].test.docJar
kubernetes-client[2.13.2].test.finalMainClass
kubernetes-client[2.13.2].test.finalMainClassOpt
kubernetes-client[2.13.2].test.forkArgs
kubernetes-client[2.13.2].test.forkEnv
kubernetes-client[2.13.2].test.forkWorkingDir
kubernetes-client[2.13.2].test.generatedSources
kubernetes-client[2.13.2].test.ideaCompileOutput
kubernetes-client[2.13.2].test.ivyDeps
kubernetes-client[2.13.2].test.jar
kubernetes-client[2.13.2].test.javadocOptions
kubernetes-client[2.13.2].test.launcher
kubernetes-client[2.13.2].test.localClasspath
kubernetes-client[2.13.2].test.mainClass
kubernetes-client[2.13.2].test.manifest
kubernetes-client[2.13.2].test.platformSuffix
kubernetes-client[2.13.2].test.prependShellScript
kubernetes-client[2.13.2].test.resources
kubernetes-client[2.13.2].test.runClasspath
kubernetes-client[2.13.2].test.runIvyDeps
kubernetes-client[2.13.2].test.scalaCompilerClasspath
kubernetes-client[2.13.2].test.scalaDocOptions
kubernetes-client[2.13.2].test.scalaDocPluginClasspath
kubernetes-client[2.13.2].test.scalaDocPluginIvyDeps
kubernetes-client[2.13.2].test.scalaLibraryIvyDeps
kubernetes-client[2.13.2].test.scalaOrganization
kubernetes-client[2.13.2].test.scalaVersion
kubernetes-client[2.13.2].test.scalacPluginClasspath
kubernetes-client[2.13.2].test.sourceJar
kubernetes-client[2.13.2].test.sources
kubernetes-client[2.13.2].test.testCached
kubernetes-client[2.13.2].test.testCachedArgs
kubernetes-client[2.13.2].test.testFrameworks
kubernetes-client[2.13.2].test.transitiveIvyDeps
kubernetes-client[2.13.2].test.transitiveLocalClasspath
kubernetes-client[2.13.2].test.unmanagedClasspath
kubernetes-client[2.13.2].test.upstreamAssembly
kubernetes-client[2.13.2].test.upstreamAssemblyClasspath
kubernetes-client[2.13.2].test.upstreamCompileOutput
kubernetes-client[2.13.2].test.yoyo
kubernetes-client[2.13.2].transitiveIvyDeps
kubernetes-client[2.13.2].transitiveLocalClasspath
kubernetes-client[2.13.2].unmanagedClasspath
kubernetes-client[2.13.2].upstreamAssembly
kubernetes-client[2.13.2].upstreamAssemblyClasspath
kubernetes-client[2.13.2].upstreamCompileOutput
publish
publish
publishLocal
publishLocal
publishM2Local
publishM2Local
reformat
reformat
repl
repl
repl
repl
run
run
run
run
runBackground
runBackground
runBackground
runBackground
runLocal
runLocal
runLocal
runLocal
runMain
runMain
runMain
runMain
runMainBackground
runMainBackground
runMainBackground
runMainBackground
runMainLocal
runMainLocal
runMainLocal
runMainLocal
testLocal
testLocal
testUncached
testUncached
```

Corrected result with this PR:
```shell
> ci/publish-local.sh && ./mill -i dev.run ../kubernetes-client resolve __
all
clean
com.goyeau.mill.git.GitVersionModule.version
com.goyeau.mill.git.GitVersionModule.version
inspect
kubernetes-client
kubernetes-client[2.12.11]
kubernetes-client[2.12.11].allSourceFiles
kubernetes-client[2.12.11].allSources
kubernetes-client[2.12.11].allSwaggerSourceFiles
kubernetes-client[2.12.11].ammoniteReplClasspath
kubernetes-client[2.12.11].ammoniteVersion
kubernetes-client[2.12.11].artifactId
kubernetes-client[2.12.11].artifactMetadata
kubernetes-client[2.12.11].artifactName
kubernetes-client[2.12.11].artifactScalaVersion
kubernetes-client[2.12.11].artifactSuffix
kubernetes-client[2.12.11].assembly
kubernetes-client[2.12.11].checkFormat
kubernetes-client[2.12.11].compile
kubernetes-client[2.12.11].compileClasspath
kubernetes-client[2.12.11].compileIvyDeps
kubernetes-client[2.12.11].console
kubernetes-client[2.12.11].crossFullScalaVersion
kubernetes-client[2.12.11].docJar
kubernetes-client[2.12.11].extraPublish
kubernetes-client[2.12.11].finalMainClass
kubernetes-client[2.12.11].finalMainClassOpt
kubernetes-client[2.12.11].fix
kubernetes-client[2.12.11].forkArgs
kubernetes-client[2.12.11].forkEnv
kubernetes-client[2.12.11].forkWorkingDir
kubernetes-client[2.12.11].generatedSources
kubernetes-client[2.12.11].ideaCompileOutput
kubernetes-client[2.12.11].ideaConfigFiles
kubernetes-client[2.12.11].ideaJavaModuleFacets
kubernetes-client[2.12.11].ivy
kubernetes-client[2.12.11].ivyDeps
kubernetes-client[2.12.11].ivyDepsTree
kubernetes-client[2.12.11].jar
kubernetes-client[2.12.11].javacOptions
kubernetes-client[2.12.11].javacOptions
kubernetes-client[2.12.11].javadocOptions
kubernetes-client[2.12.11].launcher
kubernetes-client[2.12.11].localClasspath
kubernetes-client[2.12.11].mainClass
kubernetes-client[2.12.11].manifest
kubernetes-client[2.12.11].platformSuffix
kubernetes-client[2.12.11].pom
kubernetes-client[2.12.11].pomSettings
kubernetes-client[2.12.11].prependShellScript
kubernetes-client[2.12.11].publish
kubernetes-client[2.12.11].publishArtifacts
kubernetes-client[2.12.11].publishLocal
kubernetes-client[2.12.11].publishM2Local
kubernetes-client[2.12.11].publishSelfDependency
kubernetes-client[2.12.11].reformat
kubernetes-client[2.12.11].repl
kubernetes-client[2.12.11].resources
kubernetes-client[2.12.11].run
kubernetes-client[2.12.11].runBackground
kubernetes-client[2.12.11].runClasspath
kubernetes-client[2.12.11].runIvyDeps
kubernetes-client[2.12.11].runLocal
kubernetes-client[2.12.11].runMain
kubernetes-client[2.12.11].runMainBackground
kubernetes-client[2.12.11].runMainLocal
kubernetes-client[2.12.11].scalaCompilerClasspath
kubernetes-client[2.12.11].scalaDocOptions
kubernetes-client[2.12.11].scalaDocPluginClasspath
kubernetes-client[2.12.11].scalaDocPluginIvyDeps
kubernetes-client[2.12.11].scalaLibraryIvyDeps
kubernetes-client[2.12.11].scalaOrganization
kubernetes-client[2.12.11].scalaVersion
kubernetes-client[2.12.11].scalacOptions
kubernetes-client[2.12.11].scalacOptions
kubernetes-client[2.12.11].scalacPluginClasspath
kubernetes-client[2.12.11].scalacPluginIvyDeps
kubernetes-client[2.12.11].scalacPluginIvyDeps
kubernetes-client[2.12.11].scalafixConfig
kubernetes-client[2.12.11].scalafixIvyDeps
kubernetes-client[2.12.11].scalafmtConfig
kubernetes-client[2.12.11].sourceJar
kubernetes-client[2.12.11].sources
kubernetes-client[2.12.11].swaggerSources
kubernetes-client[2.12.11].test
kubernetes-client[2.12.11].test.allSourceFiles
kubernetes-client[2.12.11].test.allSources
kubernetes-client[2.12.11].test.ammoniteReplClasspath
kubernetes-client[2.12.11].test.ammoniteVersion
kubernetes-client[2.12.11].test.artifactId
kubernetes-client[2.12.11].test.artifactName
kubernetes-client[2.12.11].test.artifactScalaVersion
kubernetes-client[2.12.11].test.artifactSuffix
kubernetes-client[2.12.11].test.assembly
kubernetes-client[2.12.11].test.compile
kubernetes-client[2.12.11].test.compileClasspath
kubernetes-client[2.12.11].test.compileIvyDeps
kubernetes-client[2.12.11].test.console
kubernetes-client[2.12.11].test.crossFullScalaVersion
kubernetes-client[2.12.11].test.docJar
kubernetes-client[2.12.11].test.finalMainClass
kubernetes-client[2.12.11].test.finalMainClassOpt
kubernetes-client[2.12.11].test.forkArgs
kubernetes-client[2.12.11].test.forkEnv
kubernetes-client[2.12.11].test.forkWorkingDir
kubernetes-client[2.12.11].test.generatedSources
kubernetes-client[2.12.11].test.ideaCompileOutput
kubernetes-client[2.12.11].test.ideaConfigFiles
kubernetes-client[2.12.11].test.ideaJavaModuleFacets
kubernetes-client[2.12.11].test.ivyDeps
kubernetes-client[2.12.11].test.ivyDepsTree
kubernetes-client[2.12.11].test.jar
kubernetes-client[2.12.11].test.javadocOptions
kubernetes-client[2.12.11].test.launcher
kubernetes-client[2.12.11].test.localClasspath
kubernetes-client[2.12.11].test.mainClass
kubernetes-client[2.12.11].test.manifest
kubernetes-client[2.12.11].test.platformSuffix
kubernetes-client[2.12.11].test.prependShellScript
kubernetes-client[2.12.11].test.repl
kubernetes-client[2.12.11].test.resources
kubernetes-client[2.12.11].test.run
kubernetes-client[2.12.11].test.runBackground
kubernetes-client[2.12.11].test.runClasspath
kubernetes-client[2.12.11].test.runIvyDeps
kubernetes-client[2.12.11].test.runLocal
kubernetes-client[2.12.11].test.runMain
kubernetes-client[2.12.11].test.runMainBackground
kubernetes-client[2.12.11].test.runMainLocal
kubernetes-client[2.12.11].test.scalaCompilerClasspath
kubernetes-client[2.12.11].test.scalaDocOptions
kubernetes-client[2.12.11].test.scalaDocPluginClasspath
kubernetes-client[2.12.11].test.scalaDocPluginIvyDeps
kubernetes-client[2.12.11].test.scalaLibraryIvyDeps
kubernetes-client[2.12.11].test.scalaOrganization
kubernetes-client[2.12.11].test.scalaVersion
kubernetes-client[2.12.11].test.scalacPluginClasspath
kubernetes-client[2.12.11].test.sourceJar
kubernetes-client[2.12.11].test.sources
kubernetes-client[2.12.11].test.test
kubernetes-client[2.12.11].test.testCached
kubernetes-client[2.12.11].test.testCachedArgs
kubernetes-client[2.12.11].test.testFrameworks
kubernetes-client[2.12.11].test.testLocal
kubernetes-client[2.12.11].test.transitiveIvyDeps
kubernetes-client[2.12.11].test.transitiveLocalClasspath
kubernetes-client[2.12.11].test.unmanagedClasspath
kubernetes-client[2.12.11].test.upstreamAssembly
kubernetes-client[2.12.11].test.upstreamAssemblyClasspath
kubernetes-client[2.12.11].test.upstreamCompileOutput
kubernetes-client[2.12.11].test.yoyo
kubernetes-client[2.12.11].test.yoyo.doIt
kubernetes-client[2.12.11].transitiveIvyDeps
kubernetes-client[2.12.11].transitiveLocalClasspath
kubernetes-client[2.12.11].unmanagedClasspath
kubernetes-client[2.12.11].upstreamAssembly
kubernetes-client[2.12.11].upstreamAssemblyClasspath
kubernetes-client[2.12.11].upstreamCompileOutput
kubernetes-client[2.13.2]
kubernetes-client[2.13.2].allSourceFiles
kubernetes-client[2.13.2].allSources
kubernetes-client[2.13.2].allSwaggerSourceFiles
kubernetes-client[2.13.2].ammoniteReplClasspath
kubernetes-client[2.13.2].ammoniteVersion
kubernetes-client[2.13.2].artifactId
kubernetes-client[2.13.2].artifactMetadata
kubernetes-client[2.13.2].artifactName
kubernetes-client[2.13.2].artifactScalaVersion
kubernetes-client[2.13.2].artifactSuffix
kubernetes-client[2.13.2].assembly
kubernetes-client[2.13.2].checkFormat
kubernetes-client[2.13.2].compile
kubernetes-client[2.13.2].compileClasspath
kubernetes-client[2.13.2].compileIvyDeps
kubernetes-client[2.13.2].console
kubernetes-client[2.13.2].crossFullScalaVersion
kubernetes-client[2.13.2].docJar
kubernetes-client[2.13.2].extraPublish
kubernetes-client[2.13.2].finalMainClass
kubernetes-client[2.13.2].finalMainClassOpt
kubernetes-client[2.13.2].fix
kubernetes-client[2.13.2].forkArgs
kubernetes-client[2.13.2].forkEnv
kubernetes-client[2.13.2].forkWorkingDir
kubernetes-client[2.13.2].generatedSources
kubernetes-client[2.13.2].ideaCompileOutput
kubernetes-client[2.13.2].ideaConfigFiles
kubernetes-client[2.13.2].ideaJavaModuleFacets
kubernetes-client[2.13.2].ivy
kubernetes-client[2.13.2].ivyDeps
kubernetes-client[2.13.2].ivyDepsTree
kubernetes-client[2.13.2].jar
kubernetes-client[2.13.2].javacOptions
kubernetes-client[2.13.2].javacOptions
kubernetes-client[2.13.2].javadocOptions
kubernetes-client[2.13.2].launcher
kubernetes-client[2.13.2].localClasspath
kubernetes-client[2.13.2].mainClass
kubernetes-client[2.13.2].manifest
kubernetes-client[2.13.2].platformSuffix
kubernetes-client[2.13.2].pom
kubernetes-client[2.13.2].pomSettings
kubernetes-client[2.13.2].prependShellScript
kubernetes-client[2.13.2].publish
kubernetes-client[2.13.2].publishArtifacts
kubernetes-client[2.13.2].publishLocal
kubernetes-client[2.13.2].publishM2Local
kubernetes-client[2.13.2].publishSelfDependency
kubernetes-client[2.13.2].reformat
kubernetes-client[2.13.2].repl
kubernetes-client[2.13.2].resources
kubernetes-client[2.13.2].run
kubernetes-client[2.13.2].runBackground
kubernetes-client[2.13.2].runClasspath
kubernetes-client[2.13.2].runIvyDeps
kubernetes-client[2.13.2].runLocal
kubernetes-client[2.13.2].runMain
kubernetes-client[2.13.2].runMainBackground
kubernetes-client[2.13.2].runMainLocal
kubernetes-client[2.13.2].scalaCompilerClasspath
kubernetes-client[2.13.2].scalaDocOptions
kubernetes-client[2.13.2].scalaDocPluginClasspath
kubernetes-client[2.13.2].scalaDocPluginIvyDeps
kubernetes-client[2.13.2].scalaLibraryIvyDeps
kubernetes-client[2.13.2].scalaOrganization
kubernetes-client[2.13.2].scalaVersion
kubernetes-client[2.13.2].scalacOptions
kubernetes-client[2.13.2].scalacOptions
kubernetes-client[2.13.2].scalacPluginClasspath
kubernetes-client[2.13.2].scalacPluginIvyDeps
kubernetes-client[2.13.2].scalacPluginIvyDeps
kubernetes-client[2.13.2].scalafixConfig
kubernetes-client[2.13.2].scalafixIvyDeps
kubernetes-client[2.13.2].scalafmtConfig
kubernetes-client[2.13.2].sourceJar
kubernetes-client[2.13.2].sources
kubernetes-client[2.13.2].swaggerSources
kubernetes-client[2.13.2].test
kubernetes-client[2.13.2].test.allSourceFiles
kubernetes-client[2.13.2].test.allSources
kubernetes-client[2.13.2].test.ammoniteReplClasspath
kubernetes-client[2.13.2].test.ammoniteVersion
kubernetes-client[2.13.2].test.artifactId
kubernetes-client[2.13.2].test.artifactName
kubernetes-client[2.13.2].test.artifactScalaVersion
kubernetes-client[2.13.2].test.artifactSuffix
kubernetes-client[2.13.2].test.assembly
kubernetes-client[2.13.2].test.compile
kubernetes-client[2.13.2].test.compileClasspath
kubernetes-client[2.13.2].test.compileIvyDeps
kubernetes-client[2.13.2].test.console
kubernetes-client[2.13.2].test.crossFullScalaVersion
kubernetes-client[2.13.2].test.docJar
kubernetes-client[2.13.2].test.finalMainClass
kubernetes-client[2.13.2].test.finalMainClassOpt
kubernetes-client[2.13.2].test.forkArgs
kubernetes-client[2.13.2].test.forkEnv
kubernetes-client[2.13.2].test.forkWorkingDir
kubernetes-client[2.13.2].test.generatedSources
kubernetes-client[2.13.2].test.ideaCompileOutput
kubernetes-client[2.13.2].test.ideaConfigFiles
kubernetes-client[2.13.2].test.ideaJavaModuleFacets
kubernetes-client[2.13.2].test.ivyDeps
kubernetes-client[2.13.2].test.ivyDepsTree
kubernetes-client[2.13.2].test.jar
kubernetes-client[2.13.2].test.javadocOptions
kubernetes-client[2.13.2].test.launcher
kubernetes-client[2.13.2].test.localClasspath
kubernetes-client[2.13.2].test.mainClass
kubernetes-client[2.13.2].test.manifest
kubernetes-client[2.13.2].test.platformSuffix
kubernetes-client[2.13.2].test.prependShellScript
kubernetes-client[2.13.2].test.repl
kubernetes-client[2.13.2].test.resources
kubernetes-client[2.13.2].test.run
kubernetes-client[2.13.2].test.runBackground
kubernetes-client[2.13.2].test.runClasspath
kubernetes-client[2.13.2].test.runIvyDeps
kubernetes-client[2.13.2].test.runLocal
kubernetes-client[2.13.2].test.runMain
kubernetes-client[2.13.2].test.runMainBackground
kubernetes-client[2.13.2].test.runMainLocal
kubernetes-client[2.13.2].test.scalaCompilerClasspath
kubernetes-client[2.13.2].test.scalaDocOptions
kubernetes-client[2.13.2].test.scalaDocPluginClasspath
kubernetes-client[2.13.2].test.scalaDocPluginIvyDeps
kubernetes-client[2.13.2].test.scalaLibraryIvyDeps
kubernetes-client[2.13.2].test.scalaOrganization
kubernetes-client[2.13.2].test.scalaVersion
kubernetes-client[2.13.2].test.scalacPluginClasspath
kubernetes-client[2.13.2].test.sourceJar
kubernetes-client[2.13.2].test.sources
kubernetes-client[2.13.2].test.test
kubernetes-client[2.13.2].test.testCached
kubernetes-client[2.13.2].test.testCachedArgs
kubernetes-client[2.13.2].test.testFrameworks
kubernetes-client[2.13.2].test.testLocal
kubernetes-client[2.13.2].test.transitiveIvyDeps
kubernetes-client[2.13.2].test.transitiveLocalClasspath
kubernetes-client[2.13.2].test.unmanagedClasspath
kubernetes-client[2.13.2].test.upstreamAssembly
kubernetes-client[2.13.2].test.upstreamAssemblyClasspath
kubernetes-client[2.13.2].test.upstreamCompileOutput
kubernetes-client[2.13.2].test.yoyo
kubernetes-client[2.13.2].test.yoyo.doIt
kubernetes-client[2.13.2].transitiveIvyDeps
kubernetes-client[2.13.2].transitiveLocalClasspath
kubernetes-client[2.13.2].unmanagedClasspath
kubernetes-client[2.13.2].upstreamAssembly
kubernetes-client[2.13.2].upstreamAssemblyClasspath
kubernetes-client[2.13.2].upstreamCompileOutput
par
path
plan
resolve
show
shutdown
version
visualize
visualizePlan
```