### PR TITLE
GenIdea: Use new content element for each source path

### DIFF
--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -543,29 +543,34 @@ case class GenIdeaImpl(evaluator: Evaluator,
         }
         <exclude-output />
         {
+          for {
+            generatedSourcePath <- generatedSourcePaths.toSeq.distinct.sorted
+            path <- Seq(relify(generatedSourcePath))
+          } yield
+              <content url={"file://$MODULE_DIR$/" + path}>
+                <sourceFolder url={"file://$MODULE_DIR$/" + path} isTestSource={isTest.toString} generated="true" />
+              </content>
+          }
+        {
+          // keep the "real" base path as last content, to ensure, Idea picks it up as "main" module dir
+          for {
+            normalSourcePath <- normalSourcePaths.toSeq.sorted
+            path <- Seq(relify(normalSourcePath))
+          } yield
+              <content url={"file://$MODULE_DIR$/" + path}>
+                <sourceFolder url={"file://$MODULE_DIR$/" + path} isTestSource={isTest.toString} />
+              </content>
+          }
+        {
+        val resourceType = if (isTest) "java-test-resource" else "java-resource"
         for {
-          generatedSourcePath <- generatedSourcePaths.toSeq.distinct.sorted
-          path <- Seq(relify(generatedSourcePath))
+          resourcePath <- resourcePaths.toSeq.sorted
+          path <- Seq(relify(resourcePath))
         } yield
             <content url={"file://$MODULE_DIR$/" + path}>
-              <sourceFolder url={"file://$MODULE_DIR$/" + path} isTestSource={isTest.toString} generated="true" />
+              <sourceFolder url={"file://$MODULE_DIR$/" + path} type={resourceType} />
             </content>
         }
-        <content url={"file://$MODULE_DIR$/" + relify(basePath)}>
-          {
-          // keep the "real" base path as last content, to ensure, Idea picks it up as "main" module dir
-          for (normalSourcePath <- normalSourcePaths.toSeq.sorted)
-            yield
-              <sourceFolder url={"file://$MODULE_DIR$/" + relify(normalSourcePath)} isTestSource={isTest.toString} />
-          }
-          {
-          val resourceType = if (isTest) "java-test-resource" else "java-resource"
-          for (resourcePath <- resourcePaths.toSeq.sorted)
-            yield
-              <sourceFolder url={"file://$MODULE_DIR$/" + relify(resourcePath)} type={resourceType} />
-          }
-          <excludeFolder url={"file://$MODULE_DIR$/" +  relify(basePath) + "/target"} />
-        </content>
         <orderEntry type="inheritedJdk" />
         <orderEntry type="sourceFolder" forTests="false" />
         {

--- a/scalalib/test/resources/gen-idea-extended-hello-world/idea_modules/helloworld.iml
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/idea_modules/helloworld.iml
@@ -5,10 +5,11 @@
         <content url="file://$MODULE_DIR$/../out/HelloWorld/generatedSources/dest/classes">
             <sourceFolder url="file://$MODULE_DIR$/../out/HelloWorld/generatedSources/dest/classes" isTestSource="false" generated="true"/>
         </content>
-        <content url="file://$MODULE_DIR$/../HelloWorld">
+        <content url="file://$MODULE_DIR$/../HelloWorld/src">
             <sourceFolder url="file://$MODULE_DIR$/../HelloWorld/src" isTestSource="false"/>
+        </content>
+        <content url="file://$MODULE_DIR$/../HelloWorld/resources">
             <sourceFolder url="file://$MODULE_DIR$/../HelloWorld/resources" type="java-resource"/>
-            <excludeFolder url="file://$MODULE_DIR$/../HelloWorld/target"/>
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>

--- a/scalalib/test/resources/gen-idea-extended-hello-world/idea_modules/helloworld.test.iml
+++ b/scalalib/test/resources/gen-idea-extended-hello-world/idea_modules/helloworld.test.iml
@@ -2,10 +2,11 @@
     <component name="NewModuleRootManager">
         <output-test url="file://$MODULE_DIR$/../out/HelloWorld/test/ideaCompileOutput/dest/classes"/>
         <exclude-output/>
-        <content url="file://$MODULE_DIR$/../HelloWorld/test">
+        <content url="file://$MODULE_DIR$/../HelloWorld/test/src">
             <sourceFolder url="file://$MODULE_DIR$/../HelloWorld/test/src" isTestSource="true"/>
+        </content>
+        <content url="file://$MODULE_DIR$/../HelloWorld/test/resources">
             <sourceFolder url="file://$MODULE_DIR$/../HelloWorld/test/resources" type="java-test-resource"/>
-            <excludeFolder url="file://$MODULE_DIR$/../HelloWorld/test/target"/>
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>

--- a/scalalib/test/resources/gen-idea-hello-world/idea_modules/helloworld.iml
+++ b/scalalib/test/resources/gen-idea-hello-world/idea_modules/helloworld.iml
@@ -2,10 +2,11 @@
     <component name="NewModuleRootManager">
         <output url="file://$MODULE_DIR$/../out/HelloWorld/ideaCompileOutput/dest/classes"/>
         <exclude-output/>
-        <content url="file://$MODULE_DIR$/../HelloWorld">
+        <content url="file://$MODULE_DIR$/../HelloWorld/src">
             <sourceFolder url="file://$MODULE_DIR$/../HelloWorld/src" isTestSource="false"/>
+        </content>
+        <content url="file://$MODULE_DIR$/../HelloWorld/resources">
             <sourceFolder url="file://$MODULE_DIR$/../HelloWorld/resources" type="java-resource"/>
-            <excludeFolder url="file://$MODULE_DIR$/../HelloWorld/target"/>
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>

--- a/scalalib/test/resources/gen-idea-hello-world/idea_modules/helloworld.test.iml
+++ b/scalalib/test/resources/gen-idea-hello-world/idea_modules/helloworld.test.iml
@@ -2,10 +2,11 @@
     <component name="NewModuleRootManager">
         <output-test url="file://$MODULE_DIR$/../out/HelloWorld/test/ideaCompileOutput/dest/classes"/>
         <exclude-output/>
-        <content url="file://$MODULE_DIR$/../HelloWorld/test">
+        <content url="file://$MODULE_DIR$/../HelloWorld/test/src">
             <sourceFolder url="file://$MODULE_DIR$/../HelloWorld/test/src" isTestSource="true"/>
+        </content>
+        <content url="file://$MODULE_DIR$/../HelloWorld/test/resources">
             <sourceFolder url="file://$MODULE_DIR$/../HelloWorld/test/resources" type="java-test-resource"/>
-            <excludeFolder url="file://$MODULE_DIR$/../HelloWorld/test/target"/>
         </content>
         <orderEntry type="inheritedJdk"/>
         <orderEntry type="sourceFolder" forTests="false"/>


### PR DESCRIPTION
This makes sure we also use the right content dir for source folders outside our module dir, which is most probably the case when you have "shared" sources in e.g. cross JVM/JS projects.