### PR TITLE
BSP fixes and workaround for cross projects

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -169,18 +169,18 @@ object main extends MillModule {
 
     def generatedSources = T {
       val dest = T.ctx.dest
-      val version = publishVersion()
-      writeBuildInfo(dest, version)
+      writeBuildInfo(dest, scalaVersion(), publishVersion())
       shared.generateCoreSources(dest)
       Seq(PathRef(dest))
     }
 
-    def writeBuildInfo(dir : os.Path, version : String) = {
+    def writeBuildInfo(dir : os.Path, scalaVersion: String, millVersion: String) = {
       val code = s"""
         |package mill
         |
         |object BuildInfo {
-        |  val millVersion = "$version"
+        |  val scalaVersion = "$scalaVersion"
+        |  val millVersion = "$millVersion"
         |}
       """.stripMargin.trim
 

--- a/contrib/bsp/src/mill/contrib/BSP.scala
+++ b/contrib/bsp/src/mill/contrib/BSP.scala
@@ -3,24 +3,24 @@ package mill.contrib
 import java.io.PrintWriter
 import java.nio.file.FileAlreadyExistsException
 import java.util.concurrent.Executors
-
 import ch.epfl.scala.bsp4j._
 import mill._
+import mill.contrib.bsp.MillBuildServer
 import mill.define.{Command, Discover, ExternalModule}
 import mill.eval.Evaluator
+import mill.modules.Util
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import upickle.default._
-
 import scala.collection.JavaConverters._
 import scala.concurrent.CancellationException
 
-case class BspConfigJson(name: String,
-                         argv: Seq[String],
-                         version: String,
-                         bspVersion: String,
-                         languages: Seq[String])
-  extends BspConnectionDetails(name, argv.asJava, version, bspVersion, languages.asJava) {
-}
+case class BspConfigJson(
+    name: String,
+    argv: Seq[String],
+    millVersion: String,
+    bspVersion: String,
+    languages: Seq[String]
+) extends BspConnectionDetails(name, argv.asJava, millVersion, bspVersion, languages.asJava) {}
 
 object BspConfigJson {
   implicit val rw: ReadWriter[BspConfigJson] = macroRW
@@ -31,107 +31,126 @@ object BSP extends ExternalModule {
   implicit def millScoptEvaluatorReads[T] = new mill.main.EvaluatorScopt[T]()
 
   lazy val millDiscover: Discover[BSP.this.type] = Discover[this.type]
-  val version = "1.0.0"
   val bspProtocolVersion = "2.0.0"
-  val languages = List("scala", "java")
+  val languages = Seq("scala", "java")
 
   /**
-    * Installs the mill-bsp server. It creates a json file
-    * with connection details in the ./.bsp directory for
-    * a potential client to find.
-    *
+   * Installs the mill-bsp server. It creates a json file
+   * with connection details in the ./.bsp directory for
+   * a potential client to find.
+   *
     * If a .bsp folder with a connection file already
-    * exists in the working directory, it will be
-    * overwritten and a corresponding message will be displayed
-    * in stdout.
-    *
+   * exists in the working directory, it will be
+   * overwritten and a corresponding message will be displayed
+   * in stdout.
+   *
     * If the creation of the .bsp folder fails due to any other
-    * reason, the message and stacktrace of the exception will be
-    * printed to stdout.
-    *
+   * reason, the message and stacktrace of the exception will be
+   * printed to stdout.
+   *
     */
-  def install(ev: Evaluator): Command[Unit] = T.command {
-    val bspDirectory = os.pwd / ".bsp"
-    if (!os.exists(bspDirectory)) os.makeDir.all(bspDirectory)
-    try {
-      os.write(bspDirectory / "mill.json", createBspConnectionJson())
-    } catch {
-      case e: FileAlreadyExistsException =>
-        println("The bsp connection json file probably exists already - will be overwritten")
-        os.remove(bspDirectory / "mill.json")
+  def install(ev: Evaluator): Command[Unit] =
+    T.command {
+      val bspDirectory = os.pwd / ".bsp"
+      if (!os.exists(bspDirectory)) os.makeDir.all(bspDirectory)
+      try {
         os.write(bspDirectory / "mill.json", createBspConnectionJson())
-      case e: Exception =>
-        println("An exception occurred while installing mill-bsp")
-        e.printStackTrace()
-    }
+      } catch {
+        case _: FileAlreadyExistsException =>
+          T.log.info("The bsp connection json file probably exists already - will be overwritten")
+          os.remove(bspDirectory / "mill.json")
+          os.write(bspDirectory / "mill.json", createBspConnectionJson())
+        case e: Exception =>
+          T.log.error("An exception occurred while installing mill-bsp")
+          e.printStackTrace()
+      }
 
-  }
+    }
 
   // creates a Json with the BSP connection details
   def createBspConnectionJson(): String = {
-    val millPath = Option(mill.modules.Util.millProperty("MILL_CLASSPATH")).getOrElse(System.getProperty("MILL_CLASSPATH"))
-    val millVersion = scala.sys.props.get("MILL_VERSION").getOrElse(System.getProperty("MILL_VERSION"))
-    write(BspConfigJson("mill-bsp",
-                        List(whichJava,
-                             s"-DMILL_CLASSPATH=$millPath",
-                             s"-DMILL_VERSION=$millVersion",
-                             "-Djna.nosys=true",
-                             "-cp",
-                             millPath,
-                             "mill.MillMain",
-                             "mill.contrib.BSP/start"),
-                        version,
-                        bspProtocolVersion,
-                        languages))
+    val millPath = Util
+      .millProperty("MILL_CLASSPATH")
+      .getOrElse(throw new IllegalStateException("MILL_CLASSPATH not set"))
+    val millVersion = Util.millProperty("MILL_VERSION").getOrElse(BuildInfo.millVersion)
+    write(
+      BspConfigJson(
+        "mill-bsp",
+        Seq(
+          whichJava,
+          s"-DMILL_CLASSPATH=$millPath",
+          s"-DMILL_VERSION=$millVersion",
+          "-Djna.nosys=true",
+          "-cp",
+          millPath,
+          "mill.MillMain",
+          "mill.contrib.BSP/start"
+        ),
+        millVersion,
+        bspProtocolVersion,
+        languages
+      )
+    )
   }
 
   // computes the path to the java executable
-  def whichJava: String = {
-    if (scala.sys.props.contains("JAVA_HOME")) scala.sys.props("JAVA_HOME") else "java"
-  }
+  def whichJava: String = sys.props.getOrElse("JAVA_HOME", "java")
 
   /**
-    * Computes a mill command which starts the mill-bsp
-    * server and establishes connection to client. Waits
-    * until a client connects and ends the connection
-    * after the client sent an "exit" notification
-    *
+   * Computes a mill command which starts the mill-bsp
+   * server and establishes connection to client. Waits
+   * until a client connects and ends the connection
+   * after the client sent an "exit" notification
+   *
     * @param ev Environment, used by mill to evaluate commands
-    * @return: mill.Command which executes the starting of the
-    *          server
-    */
-  def start(ev: Evaluator): Command[Unit] = T.command {
-    val eval = new Evaluator(ev.home, ev.outPath, ev.externalOutPath, ev.rootModule, ev.baseLogger, ev.classLoaderSig,
-                             ev.workerCache, ev.env, false)
-    val millServer = new mill.contrib.bsp.MillBuildServer(eval, bspProtocolVersion, version, languages)
-    val executor = Executors.newCachedThreadPool()
+   * @return: mill.Command which executes the starting of the
+   *          server
+   */
+  def start(ev: Evaluator): Command[Unit] =
+    T.command {
+      val eval = new Evaluator(
+        ev.home,
+        ev.outPath,
+        ev.externalOutPath,
+        ev.rootModule,
+        ev.baseLogger,
+        ev.classLoaderSig,
+        ev.workerCache,
+        ev.env,
+        false
+      )
+      val millServer = new MillBuildServer(eval, bspProtocolVersion, BuildInfo.millVersion)
+      val executor = Executors.newCachedThreadPool()
 
-    val stdin = System.in
-    val stdout = System.out
-    try {
-      val launcher = new Launcher.Builder[BuildClient]()
-        .setOutput(stdout)
-        .setInput(stdin)
-        .setLocalService(millServer)
-        .setRemoteInterface(classOf[BuildClient]).
-        traceMessages(new PrintWriter((os.pwd / "bsp.log").toIO))
-        .setExecutorService(executor)
-        .create()
-      millServer.onConnectWithClient(launcher.getRemoteProxy)
-      val listening = launcher.startListening()
-      millServer.cancelator = () => listening.cancel(true)
-      val voidFuture = listening.get()
-    } catch {
-      case _: CancellationException => System.err.println("The mill server was shut down.")
-      case e: Exception =>
-        System.err.println("An exception occured while connecting to the client.")
-        System.err.println("Cause: " + e.getCause)
-        System.err.println("Message: " + e.getMessage)
-        System.err.println("Exception class: " + e.getClass)
-        System.err.println("Stack Trace: " + e.getStackTrace)
-    } finally {
-      System.err.println("Shutting down executor")
-      executor.shutdown()
+      val stdin = System.in
+      val stdout = System.out
+      try {
+        val launcher = new Launcher.Builder[BuildClient]()
+          .setOutput(stdout)
+          .setInput(stdin)
+          .setLocalService(millServer)
+          .setRemoteInterface(classOf[BuildClient])
+          .traceMessages(new PrintWriter((os.pwd / ".bsp" / "mill.log").toIO))
+          .setExecutorService(executor)
+          .create()
+        millServer.onConnectWithClient(launcher.getRemoteProxy)
+        val listening = launcher.startListening()
+        millServer.cancelator = () => listening.cancel(true)
+        listening.get()
+        ()
+      } catch {
+        case _: CancellationException => T.log.error("The mill server was shut down.")
+        case e: Exception =>
+          T.log.error(
+            s"""An exception occured while connecting to the client.
+              |Cause: ${e.getCause}
+              |Message: ${e.getMessage}
+              |Exception class: ${e.getClass}
+              |Stack Trace: ${e.getStackTrace}""".stripMargin
+          )
+      } finally {
+        T.log.error("Shutting down executor")
+        executor.shutdown()
+      }
     }
-  }
 }

--- a/contrib/bsp/src/mill/contrib/bsp/MillBuildServer.scala
+++ b/contrib/bsp/src/mill/contrib/bsp/MillBuildServer.scala
@@ -1,64 +1,40 @@
 package mill.contrib.bsp
 
-import java.util.concurrent.CompletableFuture
-
 import ch.epfl.scala.bsp4j._
 import com.google.gson.JsonObject
-import mill.api.Result.{Skipped, Success}
-import mill.api.{BuildProblemReporter, DummyTestReporter, Result, Strict}
+import java.util.concurrent.CompletableFuture
+import mill._
+import mill.api.{DummyTestReporter, Result, Strict}
 import mill.contrib.bsp.ModuleUtils._
+import mill.contrib.bsp.Utils._
 import mill.define.Segment.Label
 import mill.define.{Discover, ExternalModule}
 import mill.eval.Evaluator
 import mill.main.{EvaluatorScopt, MainModule}
-import mill.modules.Jvm
-import mill.scalalib.Lib.discoverTests
 import mill.scalalib._
-import mill.scalalib.api.CompilationResult
 import mill.util.{Ctx, DummyLogger}
-import mill.{scalalib, _}
 import os.Path
-
 import scala.collection.JavaConverters._
 
-
-class MillBuildServer(evaluator: Evaluator,
-                      _bspVersion: String,
-                      serverVersion: String,
-                      languages: List[String]) extends ExternalModule with BuildServer with ScalaBuildServer {
-
+class MillBuildServer(evaluator: Evaluator, bspVersion: String, serverVersion: String)
+    extends ExternalModule
+    with BuildServer
+    with ScalaBuildServer {
   implicit def millScoptEvaluatorReads[T]: EvaluatorScopt[T] = new mill.main.EvaluatorScopt[T]()
 
   lazy val millDiscover: Discover[MillBuildServer.this.type] = Discover[this.type]
-  val bspVersion: String = _bspVersion
-  val supportedLanguages: List[String] = languages
-  val millServerVersion: String = serverVersion
-  val millEvaluator: Evaluator = evaluator
-  val ctx: Ctx.Log with Ctx.Home = new Ctx.Log with Ctx.Home {
+  implicit val ctx: Ctx.Log with Ctx.Home = new Ctx.Log with Ctx.Home {
     val log: DummyLogger.type = mill.util.DummyLogger
     val home: Path = os.pwd
   }
   var cancelator: () => Unit = () => ()
-  var rootModule: JavaModule = ModuleUtils.getRootJavaModule(evaluator.rootModule)
-  var millModules: Seq[JavaModule] = getMillModules(millEvaluator)
   var client: BuildClient = _
-  var moduleToTargetId: Predef.Map[JavaModule, BuildTargetIdentifier] = ModuleUtils.getModuleTargetIdMap(
-    millModules,
-    evaluator
-    )
-  var targetIdToModule: Predef.Map[BuildTargetIdentifier, JavaModule] = targetToModule(moduleToTargetId)
-  var moduleToTarget: Predef.Map[JavaModule, BuildTarget] =
-    ModuleUtils.millModulesToBspTargets(millModules, rootModule, evaluator, List("scala", "java"))
-  var moduleCodeToTargetId: Predef.Map[Int, BuildTargetIdentifier] =
-    for ((targetId, module) <- targetIdToModule) yield (module.hashCode(), targetId)
   var initialized = false
   var clientInitialized = false
 
-  override def onConnectWithClient(server: BuildClient): Unit =
-    client = server
+  override def onConnectWithClient(server: BuildClient): Unit = client = server
 
   override def buildInitialize(params: InitializeBuildParams): CompletableFuture[InitializeBuildResult] = {
-
     val capabilities = new BuildServerCapabilities
     capabilities.setCompileProvider(new CompileProvider(List("java", "scala").asJava))
     capabilities.setRunProvider(new RunProvider(List("java", "scala").asJava))
@@ -68,7 +44,7 @@ class MillBuildServer(evaluator: Evaluator,
     capabilities.setResourcesProvider(true)
     capabilities.setBuildTargetChangedProvider(false) //TODO: for now it's false, but will try to support this later
     val future = new CompletableFuture[InitializeBuildResult]()
-    future.complete(new InitializeBuildResult("mill-bsp", millServerVersion, bspVersion, capabilities))
+    future.complete(new InitializeBuildResult("mill-bsp", serverVersion, bspVersion, capabilities))
     initialized = true
     future
   }
@@ -77,215 +53,171 @@ class MillBuildServer(evaluator: Evaluator,
     clientInitialized = true
   }
 
-  override def buildShutdown(): CompletableFuture[Object] = {
-    handleExceptions[String, Object](_ => "shut down this server".asInstanceOf[Object], "")
-  }
+  override def buildShutdown(): CompletableFuture[Object] =
+    handleExceptions {
+      "shut down this server".asInstanceOf[Object]
+    }
 
-  override def onBuildExit(): Unit = {
-    cancelator()
-  }
+  override def onBuildExit(): Unit = cancelator()
 
-  override def workspaceBuildTargets(): CompletableFuture[WorkspaceBuildTargetsResult] = {
-    recomputeTargets()
-    handleExceptions[String, WorkspaceBuildTargetsResult](
-      _ => new WorkspaceBuildTargetsResult(moduleToTarget.values.toList.asJava),
-      "")
-  }
+  override def workspaceBuildTargets(): CompletableFuture[WorkspaceBuildTargetsResult] =
+    handleExceptions {
+      val targets = getTargets(getModules(evaluator), evaluator)
 
-  override def buildTargetSources(sourcesParams: SourcesParams): CompletableFuture[SourcesResult] = {
-    recomputeTargets()
+      // Remove the sortBy, reverse and distinctBy when https://youtrack.jetbrains.com/issue/SCL-17551 is resolved
+      new WorkspaceBuildTargetsResult(targets.sortBy(_.getId.getUri).reverse.distinctBy(_.getBaseDirectory).asJava)
+    }
 
-    def computeSourcesResult: SourcesResult = {
-      var items = List[SourcesItem]()
+  override def buildTargetSources(sourcesParams: SourcesParams): CompletableFuture[SourcesResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
 
-      for (targetId <- sourcesParams.getTargets.asScala) {
-        var itemSources = List[SourceItem]()
+      def sourceItem(source: Path, generated: Boolean) = {
+        val file = source.toIO
+        new SourceItem(
+          file.toURI.toString,
+          if (file.isFile) SourceItemKind.FILE else SourceItemKind.DIRECTORY,
+          generated
+        )
+      }
 
-        val sources = evaluateInformativeTask(evaluator, targetIdToModule(targetId).sources, Agg.empty[PathRef]).
-          map(pathRef => pathRef.path).toSeq
-        val generatedSources = evaluateInformativeTask(evaluator,
-                                                       targetIdToModule(targetId).generatedSources,
-                                                       Agg.empty[PathRef]).
-          map(pathRef => pathRef.path).toSeq
+      val items = sourcesParams.getTargets.asScala.foldLeft(Seq.empty[SourcesItem]) { (items, targetId) =>
+        val newItem =
+          if (targetId == getMillBuildTargetId(evaluator))
+            new SourcesItem(
+              targetId,
+              Seq(sourceItem(evaluator.rootModule.millSourcePath / "src", generated = false)).asJava // Intellij needs one
+            )
+          else {
+            val module = getModule(targetId, modules)
+            val sources = evaluateInformativeTask(evaluator, module.sources, Seq.empty[PathRef])
+              .map(p => sourceItem(p.path, generated = false))
+            val generatedSources = evaluateInformativeTask(evaluator, module.generatedSources, Seq.empty[PathRef])
+              .map(p => sourceItem(p.path, generated = true))
 
-        for (source <- sources) {
-          itemSources ++= List(
-            new SourceItem(source.toIO.toURI.toString, SourceItemKind.DIRECTORY, false))
-        }
+            new SourcesItem(targetId, (sources ++ generatedSources).asJava)
+          }
 
-        for (genSource <- generatedSources) {
-          itemSources ++= List(
-            new SourceItem(genSource.toIO.toURI.toString, SourceItemKind.DIRECTORY, true))
-        }
-
-        items ++= List(new SourcesItem(targetId, itemSources.asJava))
+        items :+ newItem
       }
 
       new SourcesResult(items.asJava)
     }
 
-    handleExceptions[String, SourcesResult](_ => computeSourcesResult, "")
-  }
+  override def buildTargetInverseSources(
+      inverseSourcesParams: InverseSourcesParams
+  ): CompletableFuture[InverseSourcesResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
 
-  override def buildTargetInverseSources(inverseSourcesParams: InverseSourcesParams):
-  CompletableFuture[InverseSourcesResult] = {
-    recomputeTargets()
+      val targets = modules
+        .filter(m =>
+          ModuleUtils
+            .evaluateInformativeTask(evaluator, m.allSourceFiles, Seq.empty[PathRef])
+            .map(_.path.toIO.toURI.toString)
+            .contains(inverseSourcesParams.getTextDocument.getUri)
+        )
+        .map(getTargetId)
 
-    def getInverseSourcesResult: InverseSourcesResult = {
-      val textDocument = inverseSourcesParams.getTextDocument
-      val targets = millModules.filter(m => ModuleUtils.evaluateInformativeTask(
-        millEvaluator, m.allSourceFiles, Seq.empty[PathRef]).
-        map(pathRef => pathRef.path.toIO.toURI.toString).
-        contains(textDocument.getUri)).
-        map(m => moduleToTargetId(m))
       new InverseSourcesResult(targets.asJava)
     }
 
-    handleExceptions[String, InverseSourcesResult](_ => getInverseSourcesResult, "")
-  }
+  override def buildTargetDependencySources(
+      dependencySourcesParams: DependencySourcesParams
+  ): CompletableFuture[DependencySourcesResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
 
-  override def buildTargetDependencySources(dependencySourcesParams: DependencySourcesParams):
-  CompletableFuture[DependencySourcesResult] = {
-    recomputeTargets()
+      val items =
+        dependencySourcesParams.getTargets.asScala.foldLeft(Seq.empty[DependencySourcesItem]) { (items, targetId) =>
+          val newItem =
+            if (targetId == getMillBuildTargetId(evaluator)) new DependencySourcesItem(targetId, Seq.empty.asJava)
+            else {
+              val sources = evaluateInformativeTask(
+                evaluator,
+                getModule(targetId, modules).compileClasspath,
+                Agg.empty[PathRef]
+              )
 
-    def getDependencySources: DependencySourcesResult = {
-      var items = List[DependencySourcesItem]()
+              new DependencySourcesItem(targetId, sources.map(_.path.toIO.toURI.toString).iterator.to(Seq).asJava)
+            }
 
-      for (targetId <- dependencySourcesParams.getTargets.asScala) {
-        val millModule = targetIdToModule(targetId)
-        var sources = evaluateInformativeTask(evaluator,
-                                              millModule.resolveDeps(millModule.transitiveIvyDeps, true),
-                                              Agg.empty[PathRef]) ++
-          evaluateInformativeTask(evaluator,
-                                  millModule.resolveDeps(millModule.compileIvyDeps, true),
-                                  Agg.empty[PathRef]) ++
-          evaluateInformativeTask(evaluator,
-                                  millModule.unmanagedClasspath,
-                                  Agg.empty[PathRef])
-        millModule match {
-          case _: ScalaModule => sources ++= evaluateInformativeTask(evaluator,
-                                                                     millModule.resolveDeps(millModule.asInstanceOf[ScalaModule].scalaLibraryIvyDeps, true),
-                                                                     Agg.empty[PathRef])
-          case _: JavaModule => sources ++= List()
+          items :+ newItem
         }
-        items ++= List(new DependencySourcesItem(targetId, sources.
-          map(pathRef => pathRef.path.toIO.toURI.toString).
-          toList.asJava))
-      }
 
       new DependencySourcesResult(items.asJava)
     }
 
-    handleExceptions[String, DependencySourcesResult](_ => getDependencySources, "")
-  }
+  override def buildTargetResources(resourcesParams: ResourcesParams): CompletableFuture[ResourcesResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
 
-  // Recompute the modules in the project in case any changes to the build took place
-  // and update all the mappings that depend on this info
-  private[this] def recomputeTargets(): Unit = {
-    rootModule = ModuleUtils.getRootJavaModule(millEvaluator.rootModule)
-    millModules = getMillModules(millEvaluator)
-    moduleToTargetId = ModuleUtils.getModuleTargetIdMap(millModules, millEvaluator)
-    targetIdToModule = targetToModule(moduleToTargetId)
-    moduleToTarget = ModuleUtils.millModulesToBspTargets(millModules, rootModule, evaluator, List("scala", "java"))
-  }
+      val items = resourcesParams.getTargets.asScala.foldLeft(Seq.empty[ResourcesItem]) { (items, targetId) =>
+        val newItem =
+          if (targetId == getMillBuildTargetId(evaluator)) new ResourcesItem(targetId, Seq.empty.asJava)
+          else {
+            val resources =
+              evaluateInformativeTask(evaluator, getModule(targetId, modules).resources, Seq.empty[PathRef])
+                .filter(pathRef => os.exists(pathRef.path))
 
-  // Given the mapping from modules to targetIds, construct the mapping from targetIds to modules
-  private[this] def targetToModule(moduleToTargetId: Predef.Map[JavaModule, BuildTargetIdentifier]):
-  Predef.Map[BuildTargetIdentifier, JavaModule] = {
-    moduleToTargetId.keys.map(mod => (moduleToTargetId(mod), mod)).toMap
+            new ResourcesItem(targetId, resources.map(_.path.toNIO.toUri.toString).asJava)
+          }
 
-  }
-
-  // Resolve all the mill modules contained in the project
-  private[this] def getMillModules(ev: Evaluator): Seq[JavaModule] = {
-    ev.rootModule.millInternal.segmentsToModules.values.
-      collect {
-        case m: scalalib.JavaModule => m
-      }.toSeq ++ Seq(rootModule)
-  }
-
-  // Given a function that take input of type T and return output of type V,
-  // apply the function on the given inputs and return a completable future of
-  // the result. If the execution of the function raises an Exception, complete
-  // the future exceptionally. Also complete exceptionally if the server was not
-  // yet initialized.
-  private[this] def handleExceptions[T, V](serverMethod: T => V, input: T): CompletableFuture[V] = {
-    val future = new CompletableFuture[V]()
-    if (initialized) {
-      try {
-        future.complete(serverMethod(input))
-      } catch {
-        case e: Exception => future.completeExceptionally(e)
+        items :+ newItem
       }
-    } else {
-      future.completeExceptionally(
-        new Exception("Can not respond to any request before receiving the `initialize` request.")
-        )
-    }
-    future
-  }
 
-  override def buildTargetResources(resourcesParams: ResourcesParams): CompletableFuture[ResourcesResult] = {
-    recomputeTargets()
-
-    def getResources: ResourcesResult = {
-      var items = List[ResourcesItem]()
-
-      for (targetId <- resourcesParams.getTargets.asScala) {
-        val millModule = targetIdToModule(targetId)
-        val resources = evaluateInformativeTask(evaluator, millModule.resources, Agg.empty[PathRef]).
-          filter(pathRef => os.exists(pathRef.path)).
-          flatMap(pathRef => os.walk(pathRef.path)).
-          map(path => path.toIO.toURI.toString).
-          toList.asJava
-        items ++= List(new ResourcesItem(targetId, resources))
-      }
       new ResourcesResult(items.asJava)
     }
 
-    handleExceptions[String, ResourcesResult](_ => getResources, "")
-  }
-
-  //TODO: if the client wants to give compilation arguments and the module
+  // TODO: if the client wants to give compilation arguments and the module
   // already has some from the build file, what to do?
-  override def buildTargetCompile(compileParams: CompileParams): CompletableFuture[CompileResult] = {
-    recomputeTargets()
+  override def buildTargetCompile(compileParams: CompileParams): CompletableFuture[CompileResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
 
-    def getCompileResult: CompileResult = {
       val params = TaskParameters.fromCompileParams(compileParams)
       val taskId = params.hashCode()
-      val compileTasks = Strict.Agg(params.getTargets.
-        filter(targetId => targetId != moduleToTarget(rootModule).getId).
-        map(targetId => targetIdToModule(targetId).compile): _*)
-      val result = millEvaluator.evaluate(compileTasks,
-                                          getBspLoggedReporterPool(params, t => s"Started compiling target: $t",
-                                                                   TaskDataKind.COMPILE_TASK, (targetId: BuildTargetIdentifier) => new CompileTask(targetId)),
-                                          DummyTestReporter,
-                                          new MillBspLogger(client, taskId, millEvaluator.baseLogger)
-                                          )
+      val compileTasks = Strict.Agg(params.getTargets.map(targetId => getModule(targetId, modules).compile): _*)
+      val result = evaluator.evaluate(
+        compileTasks,
+        getBspLoggedReporterPool(
+          params,
+          t => s"Started compiling target: $t",
+          TaskDataKind.COMPILE_TASK,
+          targetId => new CompileTask(targetId),
+          modules,
+          evaluator,
+          client
+        ),
+        DummyTestReporter,
+        new MillBspLogger(client, taskId, evaluator.baseLogger)
+      )
       val compileResult = new CompileResult(getStatusCode(result))
       compileResult.setOriginId(compileParams.getOriginId)
-      compileResult //TODO: See in what form IntelliJ expects data about products of compilation in order to set data field
+      compileResult // TODO: See in what form IntelliJ expects data about products of compilation in order to set data field
     }
 
-    handleExceptions[String, CompileResult](_ => getCompileResult, "")
-  }
+  override def buildTargetRun(runParams: RunParams): CompletableFuture[RunResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
 
-  override def buildTargetRun(runParams: RunParams): CompletableFuture[RunResult] = {
-    recomputeTargets()
-
-    def getRunResult: RunResult = {
       val params = TaskParameters.fromRunParams(runParams)
-      val module = targetIdToModule(params.getTargets.head)
+      val module = getModule(params.getTargets.head, modules)
       val args = params.getArguments.getOrElse(Seq.empty[String])
       val runTask = module.run(args: _*)
-      val runResult = millEvaluator.evaluate(Strict.Agg(runTask),
-                                             getBspLoggedReporterPool(
-                                               params,
-                                               t => s"Started compiling target: $t",
-                                               TaskDataKind.COMPILE_TASK,
-                                               (targetId: BuildTargetIdentifier) => new CompileTask(targetId)),
-        logger = new MillBspLogger(client, runTask.hashCode(), millEvaluator.baseLogger))
+      val runResult = evaluator.evaluate(
+        Strict.Agg(runTask),
+        getBspLoggedReporterPool(
+          params,
+          t => s"Started compiling target: $t",
+          TaskDataKind.COMPILE_TASK,
+          targetId => new CompileTask(targetId),
+          modules,
+          evaluator,
+          client
+        ),
+        logger = new MillBspLogger(client, runTask.hashCode(), evaluator.baseLogger)
+      )
       val response = runResult.results(runTask) match {
         case _: Result.Success[Any] => new RunResult(StatusCode.OK)
         case _ => new RunResult(StatusCode.ERROR)
@@ -294,35 +226,34 @@ class MillBuildServer(evaluator: Evaluator,
         case Some(id) => response.setOriginId(id)
         case None =>
       }
+
       response
     }
 
-    handleExceptions[String, RunResult](_ => getRunResult, "")
-  }
+  override def buildTargetTest(testParams: TestParams): CompletableFuture[TestResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
+      val targets = getTargets(modules, evaluator)
 
-  override def buildTargetTest(testParams: TestParams): CompletableFuture[TestResult] = {
-    recomputeTargets()
-
-    def getTestResult: TestResult = {
       val params = TaskParameters.fromTestParams(testParams)
-      val argsMap = try {
-        val scalaTestParams = testParams.getData.asInstanceOf[JsonObject]
-        (for (testItem <- scalaTestParams.get("testClasses").getAsJsonArray.asScala)
-          yield (
-            testItem.getAsJsonObject.get("target").getAsJsonObject.get("uri").getAsString,
-            testItem.getAsJsonObject.get("classes").getAsJsonArray
-              .asScala.map(elem => elem.getAsString).toSeq)).toMap
-      } catch {
-        case _: Exception => (for (targetId <- testParams.getTargets.asScala) yield
-          (targetId.getUri, Seq.empty[String])).toMap
-
-      }
+      val argsMap =
+        try {
+          val scalaTestParams = testParams.getData.asInstanceOf[JsonObject]
+          (for (testItem <- scalaTestParams.get("testClasses").getAsJsonArray.asScala)
+            yield (
+              testItem.getAsJsonObject.get("target").getAsJsonObject.get("uri").getAsString,
+              testItem.getAsJsonObject.get("classes").getAsJsonArray.asScala.map(elem => elem.getAsString).toSeq
+            )).toMap
+        } catch {
+          case _: Exception =>
+            (for (targetId <- testParams.getTargets.asScala) yield (targetId.getUri, Seq.empty[String])).toMap
+        }
 
       var overallStatusCode = StatusCode.OK
       for (targetId <- testParams.getTargets.asScala) {
-        val module = targetIdToModule(targetId)
-        module match {
-          case m: TestModule => val testModule = m.asInstanceOf[TestModule]
+        getModule(targetId, modules) match {
+          case m: TestModule =>
+            val testModule = m.asInstanceOf[TestModule]
             val testTask = testModule.testLocal(argsMap(targetId.getUri): _*)
 
             // notifying the client that the testing of this build target started
@@ -333,33 +264,42 @@ class MillBuildServer(evaluator: Evaluator,
             taskStartParams.setData(new TestTask(targetId))
             client.onBuildTaskStart(taskStartParams)
 
-            val testReporter = new BspTestReporter(
-              client, targetId,
-              new TaskId(testTask.hashCode().toString),
-              Seq.empty[String])
+            val testReporter =
+              new BspTestReporter(client, targetId, new TaskId(testTask.hashCode().toString), Seq.empty[String])
 
-            val results = millEvaluator.evaluate(
+            val results = evaluator.evaluate(
               Strict.Agg(testTask),
-              getBspLoggedReporterPool(params, t => s"Started compiling target: $t",
-                                       TaskDataKind.COMPILE_TASK, (targetId: BuildTargetIdentifier) => new CompileTask(targetId)),
+              getBspLoggedReporterPool(
+                params,
+                t => s"Started compiling target: $t",
+                TaskDataKind.COMPILE_TASK,
+                (targetId: BuildTargetIdentifier) => new CompileTask(targetId),
+                modules,
+                evaluator,
+                client
+              ),
               testReporter,
-              new MillBspLogger(client, testTask.hashCode, millEvaluator.baseLogger))
+              new MillBspLogger(client, testTask.hashCode, evaluator.baseLogger)
+            )
             val endTime = System.currentTimeMillis()
             val statusCode = getStatusCode(results)
             statusCode match {
               case StatusCode.ERROR => overallStatusCode = StatusCode.ERROR
-              case StatusCode.CANCELLED => overallStatusCode =
-                if (overallStatusCode == StatusCode.ERROR) StatusCode.ERROR else StatusCode.CANCELLED
+              case StatusCode.CANCELLED =>
+                overallStatusCode =
+                  if (overallStatusCode == StatusCode.ERROR) StatusCode.ERROR else StatusCode.CANCELLED
               case StatusCode.OK =>
             }
             // notifying the client that the testing of this build target ended
             val taskFinishParams = new TaskFinishParams(
               new TaskId(testTask.hashCode().toString),
               statusCode
-              )
+            )
             taskFinishParams.setEventTime(endTime)
-            taskFinishParams.setMessage("Finished testing target: " +
-                                          moduleToTarget(targetIdToModule(targetId)).getDisplayName)
+            taskFinishParams.setMessage(
+              "Finished testing target" +
+                targets.find(_.getId == targetId).fold("")(t => s": ${t.getDisplayName}")
+            )
             taskFinishParams.setDataKind(TaskDataKind.TEST_REPORT)
             taskFinishParams.setData(testReporter.getTestReport)
             client.onBuildTaskFinish(taskFinishParams)
@@ -371,78 +311,30 @@ class MillBuildServer(evaluator: Evaluator,
       params.getOriginId match {
         case None => testResult
         case Some(id) =>
-          //TODO: Add the messages from mill to the data field?
+          // TODO: Add the messages from mill to the data field?
           testResult.setOriginId(id)
           testResult
       }
     }
 
-    handleExceptions[String, TestResult](_ => getTestResult, "")
-  }
+  override def buildTargetCleanCache(cleanCacheParams: CleanCacheParams): CompletableFuture[CleanCacheResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
 
-  // define the function that spawns compilation reporter for each module based on the
-  // module's hash code TODO: find something more reliable than the hash code
-  private[this] def getBspLoggedReporterPool(params: Parameters,
-                                             taskStartMessage: String => String,
-                                             taskStartDataKind: String,
-                                             taskStartData: BuildTargetIdentifier => Object):
-  Int => Option[BuildProblemReporter] = {
-    int: Int =>
-      if (moduleCodeToTargetId.contains(int)) {
-        val targetId = moduleCodeToTargetId(int)
-        val taskId = new TaskId(targetIdToModule(targetId).compile.hashCode.toString)
-        val taskStartParams = new TaskStartParams(taskId)
-        taskStartParams.setEventTime(System.currentTimeMillis())
-        taskStartParams.setData(taskStartData(targetId))
-        taskStartParams.setDataKind(taskStartDataKind)
-        taskStartParams.setMessage(taskStartMessage(moduleToTarget(targetIdToModule(targetId)).getDisplayName))
-        client.onBuildTaskStart(taskStartParams)
-        Option(new BspLoggedReporter(client,
-                                     targetId,
-                                     taskId,
-                                     params.getOriginId))
-      }
-      else None
-  }
-
-  // Get the execution status code given the results from Evaluator.evaluate
-  private[this] def getStatusCode(results: Evaluator.Results): StatusCode = {
-
-    val statusCodes = results.results.keys.map(task => getStatusCodePerTask(results, task)).toSeq
-    if (statusCodes.contains(StatusCode.ERROR))
-      StatusCode.ERROR
-    else if (statusCodes.contains(StatusCode.CANCELLED))
-      StatusCode.CANCELLED
-    else
-      StatusCode.OK
-  }
-
-  private[this] def getStatusCodePerTask(results: Evaluator.Results, task: mill.define.Task[_]): StatusCode = {
-    results.results(task) match {
-      case _: Success[_] => StatusCode.OK
-      case Skipped => StatusCode.CANCELLED
-      case _ => StatusCode.ERROR
-    }
-  }
-
-  override def buildTargetCleanCache(cleanCacheParams: CleanCacheParams): CompletableFuture[CleanCacheResult] = {
-    recomputeTargets()
-
-    def getCleanCacheResult: CleanCacheResult = {
       var msg = ""
       var cleaned = true
       for (targetId <- cleanCacheParams.getTargets.asScala) {
-        val module = targetIdToModule(targetId)
+        val module = getModule(targetId, modules)
         val mainModule = new MainModule {
           override implicit def millDiscover: Discover[_] = {
             Discover[this.type]
           }
         }
-        val cleanTask = mainModule.clean(millEvaluator, List(s"${module.millModuleSegments.render}.compile"): _*)
-        val cleanResult = millEvaluator.evaluate(
+        val cleanTask = mainModule.clean(evaluator, Seq(s"${module.millModuleSegments.render}.compile"): _*)
+        val cleanResult = evaluator.evaluate(
           Strict.Agg(cleanTask),
-          logger = new MillBspLogger(client, cleanTask.hashCode, millEvaluator.baseLogger)
-          )
+          logger = new MillBspLogger(client, cleanTask.hashCode, evaluator.baseLogger)
+        )
         if (cleanResult.failing.keyCount > 0) {
           cleaned = false
           msg += s" Target ${module.millModuleSegments.render} could not be cleaned. See message from mill: \n"
@@ -453,8 +345,13 @@ class MillBuildServer(evaluator: Evaluator,
         } else {
           msg += s"${module.millModuleSegments.render} cleaned \n"
 
-          val outDir = Evaluator.resolveDestPaths(os.pwd / "out", module.millModuleSegments ++
-            Seq(Label("compile"))).out
+          val outDir = Evaluator
+            .resolveDestPaths(
+              os.pwd / "out",
+              module.millModuleSegments ++
+                Seq(Label("compile"))
+            )
+            .out
           while (os.exists(outDir)) {
             Thread.sleep(10)
           }
@@ -463,112 +360,118 @@ class MillBuildServer(evaluator: Evaluator,
       new CleanCacheResult(msg, cleaned)
     }
 
-    handleExceptions[String, CleanCacheResult](_ => getCleanCacheResult, "")
-  }
+  override def buildTargetScalacOptions(
+      scalacOptionsParams: ScalacOptionsParams
+  ): CompletableFuture[ScalacOptionsResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
 
-  override def buildTargetScalacOptions(scalacOptionsParams: ScalacOptionsParams):
-  CompletableFuture[ScalacOptionsResult] = {
-    recomputeTargets()
+      val items = scalacOptionsParams.getTargets.asScala.foldLeft(Seq.empty[ScalacOptionsItem]) { (items, targetId) =>
+        val newItem =
+          if (targetId == getMillBuildTargetId(evaluator)) None
+          else {
+            getModule(targetId, modules) match {
+              case m: ScalaModule =>
+                val options = evaluateInformativeTask(evaluator, m.scalacOptions, Seq.empty[String]).toList
+                val classpath = evaluateInformativeTask(evaluator, m.runClasspath, Seq.empty[PathRef])
+                  .map(_.path.toNIO.toUri.toString)
+                  .toList
+                val classDirectory = (Evaluator
+                  .resolveDestPaths(
+                    os.pwd / "out",
+                    m.millModuleSegments ++ Seq(Label("compile"))
+                  )
+                  .dest / "classes").toNIO.toUri.toString
 
-    def getScalacOptionsResult: ScalacOptionsResult = {
-      var targetScalacOptions = List.empty[ScalacOptionsItem]
-      for (targetId <- scalacOptionsParams.getTargets.asScala) {
-        val module = targetIdToModule(targetId)
-        module match {
-          case m: ScalaModule =>
-            val options = evaluateInformativeTask(evaluator, m.scalacOptions, Seq.empty[String]).toList
-            val classpath = evaluateInformativeTask(evaluator, m.runClasspath, Agg.empty[PathRef]).
-              map(pathRef => pathRef.path.toIO.toURI.toString).toList
-            val classDirectory = (Evaluator.resolveDestPaths(
-              os.pwd / "out",
-              m.millModuleSegments ++ Seq(Label("compile"))).dest / "classes"
-              ).toIO.toURI.toString
+                Some(new ScalacOptionsItem(targetId, options.asJava, classpath.asJava, classDirectory))
+              case _: JavaModule => None
+            }
+          }
 
-            targetScalacOptions ++= List(new ScalacOptionsItem(targetId, options.asJava, classpath.asJava, classDirectory))
-          case _: JavaModule => targetScalacOptions ++= List()
-        }
+        items ++ newItem
       }
-      new ScalacOptionsResult(targetScalacOptions.asJava)
+
+      new ScalacOptionsResult(items.asJava)
     }
 
-    handleExceptions[String, ScalacOptionsResult](_ => getScalacOptionsResult, "")
-  }
-
-  //TODO: In the case when mill fails to provide a main classes because multiple were
+  // TODO: In the case when mill fails to provide a main classes because multiple were
   // defined for the same module, do something so that those can still be detected
   // such that IntelliJ can run any of them
-  override def buildTargetScalaMainClasses(scalaMainClassesParams: ScalaMainClassesParams):
-  CompletableFuture[ScalaMainClassesResult] = {
-    recomputeTargets()
+  override def buildTargetScalaMainClasses(
+      scalaMainClassesParams: ScalaMainClassesParams
+  ): CompletableFuture[ScalaMainClassesResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
 
-    def getScalaMainClasses: ScalaMainClassesResult = {
-      var items = List.empty[ScalaMainClassesItem]
-      for (targetId <- scalaMainClassesParams.getTargets.asScala) {
-        val module = targetIdToModule(targetId)
-        val scalaMainClasses = getTaskResult(millEvaluator, module.finalMainClassOpt) match {
-          case result: Result.Success[Any] => result.asSuccess.get.value match {
-            case mainClass: Right[String, String] =>
-              List(new ScalaMainClass(
-                mainClass.value,
-                List.empty[String].asJava,
-                evaluateInformativeTask(evaluator, module.forkArgs, Seq.empty[String]).
-                  toList.asJava))
-            case msg: Left[String, String] =>
-              val messageParams = new ShowMessageParams(MessageType.WARNING, msg.value)
-              messageParams.setOriginId(scalaMainClassesParams.getOriginId)
-              client.onBuildShowMessage(messageParams) // tell the client that no main class was found or specified
-              List.empty[ScalaMainClass]
+      val items =
+        scalaMainClassesParams.getTargets.asScala.foldLeft(Seq.empty[ScalaMainClassesItem]) { (items, targetId) =>
+          val module = getModule(targetId, modules)
+          val scalaMainClasses = getTaskResult(evaluator, module.finalMainClassOpt) match {
+            case result: Result.Success[_] =>
+              result.asSuccess.get.value match {
+                case mainClass: Right[String, String] =>
+                  Seq(
+                    new ScalaMainClass(
+                      mainClass.value,
+                      Seq.empty[String].asJava,
+                      evaluateInformativeTask(evaluator, module.forkArgs, Seq.empty[String]).toList.asJava
+                    )
+                  )
+                case msg: Left[String, String] =>
+                  val messageParams = new ShowMessageParams(MessageType.WARNING, msg.value)
+                  messageParams.setOriginId(scalaMainClassesParams.getOriginId)
+                  client.onBuildShowMessage(messageParams) // tell the client that no main class was found or specified
+                  Seq.empty[ScalaMainClass]
+              }
+            case _ => Seq.empty[ScalaMainClass]
           }
-          case _ => List.empty[ScalaMainClass]
+
+          items :+ new ScalaMainClassesItem(targetId, scalaMainClasses.asJava)
         }
-        val item = new ScalaMainClassesItem(targetId, scalaMainClasses.asJava)
-        items ++= List(item)
-      }
+
       new ScalaMainClassesResult(items.asJava)
     }
 
-    handleExceptions[String, ScalaMainClassesResult](_ => getScalaMainClasses, "")
-  }
+  override def buildTargetScalaTestClasses(
+      scalaTestClassesParams: ScalaTestClassesParams
+  ): CompletableFuture[ScalaTestClassesResult] =
+    handleExceptions {
+      val modules = getModules(evaluator)
 
-  override def buildTargetScalaTestClasses(scalaTestClassesParams: ScalaTestClassesParams):
-  CompletableFuture[ScalaTestClassesResult] = {
-    recomputeTargets()
+      val items =
+        scalaTestClassesParams.getTargets.asScala.foldLeft(Seq.empty[ScalaTestClassesItem]) { (items, targetId) =>
+          val newItem = getModule(targetId, modules) match {
+            case module: TestModule =>
+              Some(new ScalaTestClassesItem(targetId, getTestClasses(module, evaluator).toList.asJava))
+            case _: JavaModule => None // TODO: maybe send a notification that this target has no test classes
+          }
 
-    def getScalaTestClasses(implicit ctx: Ctx.Home): ScalaTestClassesResult = {
-      var items = List.empty[ScalaTestClassesItem]
-      for (targetId <- scalaTestClassesParams.getTargets.asScala) {
-        targetIdToModule(targetId) match {
-          case module: TestModule =>
-            items ++= List(new ScalaTestClassesItem(targetId, getTestClasses(module).toList.asJava))
-          case _: JavaModule => //TODO: maybe send a notification that this target has no test classes
+          items ++ newItem
         }
-      }
+
       new ScalaTestClassesResult(items.asJava)
     }
 
-    handleExceptions[Ctx.Home, ScalaTestClassesResult](c => getScalaTestClasses(c), ctx)
-  }
-
-  // Detect and return the test classes contained in the given TestModule
-  private[this] def getTestClasses(module: TestModule)(implicit ctx: Ctx.Home): Seq[String] = {
-    val runClasspath = getTaskResult(millEvaluator, module.runClasspath)
-    val frameworks = getTaskResult(millEvaluator, module.testFrameworks)
-    val compilationResult = getTaskResult(millEvaluator, module.compile)
-
-    (runClasspath, frameworks, compilationResult) match {
-      case (Result.Success(classpath), Result.Success(testFrameworks), Result.Success(compResult)) =>
-        val classFingerprint = Jvm.inprocess(classpath.asInstanceOf[Seq[PathRef]].map(_.path),
-                                             classLoaderOverrideSbtTesting = true,
-                                             isolated = true,
-                                             closeContextClassLoaderWhenDone = false, cl => {
-            val fs = TestRunner.frameworks(testFrameworks.asInstanceOf[Seq[String]])(cl)
-            fs.flatMap(framework =>
-                         discoverTests(cl, framework, Agg(compResult.asInstanceOf[CompilationResult].
-                           classes.path)))
-          })
-        classFingerprint.map(classF => classF._1.getName.stripSuffix("$"))
-      case _ => Seq.empty[String] //TODO: or send notification that something went wrong
+  /**
+   * Given a function that take input of type T and return output of type V,
+   * apply the function on the given inputs and return a completable future of
+   * the result. If the execution of the function raises an Exception, complete
+   * the future exceptionally. Also complete exceptionally if the server was not
+   * yet initialized.
+   */
+  private[this] def handleExceptions[V](f: => V): CompletableFuture[V] = {
+    val future = new CompletableFuture[V]()
+    if (initialized) {
+      try {
+        future.complete(f)
+      } catch {
+        case e: Exception => future.completeExceptionally(e)
+      }
+    } else {
+      future.completeExceptionally(
+        new Exception("Can not respond to any request before receiving the `initialize` request.")
+      )
     }
+    future
   }
-
 }

--- a/contrib/bsp/src/mill/contrib/bsp/Utils.scala
+++ b/contrib/bsp/src/mill/contrib/bsp/Utils.scala
@@ -1,0 +1,83 @@
+package mill.contrib.bsp
+
+import ch.epfl.scala.bsp4j._
+import mill._
+import mill.api.Result.{Skipped, Success}
+import mill.api.{BuildProblemReporter, Result}
+import mill.contrib.bsp.ModuleUtils._
+import mill.eval.Evaluator
+import mill.modules.Jvm
+import mill.scalalib.Lib.discoverTests
+import mill.scalalib._
+import mill.scalalib.api.CompilationResult
+import mill.util.Ctx
+
+object Utils {
+
+  // define the function that spawns compilation reporter for each module based on the
+  // module's hash code TODO: find something more reliable than the hash code
+  def getBspLoggedReporterPool(
+      params: Parameters,
+      taskStartMessage: String => String,
+      taskStartDataKind: String,
+      taskStartData: BuildTargetIdentifier => Object,
+      modules: Seq[JavaModule],
+      evaluator: Evaluator,
+      client: BuildClient
+  ): Int => Option[BuildProblemReporter] = { hashCode: Int =>
+    getTarget(hashCode, modules, evaluator).map { target =>
+      val taskId = new TaskId(getModule(target.getId, modules).compile.hashCode.toString)
+      val taskStartParams = new TaskStartParams(taskId)
+      taskStartParams.setEventTime(System.currentTimeMillis())
+      taskStartParams.setData(taskStartData(target.getId))
+      taskStartParams.setDataKind(taskStartDataKind)
+      taskStartParams.setMessage(taskStartMessage(target.getDisplayName))
+      client.onBuildTaskStart(taskStartParams)
+      new BspLoggedReporter(client, target.getId, taskId, params.getOriginId)
+    }
+  }
+
+  // Get the execution status code given the results from Evaluator.evaluate
+  def getStatusCode(results: Evaluator.Results): StatusCode = {
+    val statusCodes = results.results.keys.map(task => getStatusCodePerTask(results, task)).toSeq
+    if (statusCodes.contains(StatusCode.ERROR))
+      StatusCode.ERROR
+    else if (statusCodes.contains(StatusCode.CANCELLED))
+      StatusCode.CANCELLED
+    else
+      StatusCode.OK
+  }
+
+  private[this] def getStatusCodePerTask(results: Evaluator.Results, task: mill.define.Task[_]): StatusCode = {
+    results.results(task) match {
+      case _: Success[_] => StatusCode.OK
+      case Skipped => StatusCode.CANCELLED
+      case _ => StatusCode.ERROR
+    }
+  }
+
+  // Detect and return the test classes contained in the given TestModule
+  def getTestClasses(module: TestModule, evaluator: Evaluator)(implicit ctx: Ctx.Home): Seq[String] = {
+    val runClasspath = getTaskResult(evaluator, module.runClasspath)
+    val frameworks = getTaskResult(evaluator, module.testFrameworks)
+    val compilationResult = getTaskResult(evaluator, module.compile)
+
+    (runClasspath, frameworks, compilationResult) match {
+      case (Result.Success(classpath), Result.Success(testFrameworks), Result.Success(compResult)) =>
+        val classFingerprint = Jvm.inprocess(
+          classpath.asInstanceOf[Seq[PathRef]].map(_.path),
+          classLoaderOverrideSbtTesting = true,
+          isolated = true,
+          closeContextClassLoaderWhenDone = false,
+          cl => {
+            val fs = TestRunner.frameworks(testFrameworks.asInstanceOf[Seq[String]])(cl)
+            fs.flatMap(framework =>
+              discoverTests(cl, framework, Agg(compResult.asInstanceOf[CompilationResult].classes.path))
+            )
+          }
+        )
+        classFingerprint.map(classF => classF._1.getName.stripSuffix("$"))
+      case _ => Seq.empty[String] //TODO: or send notification that something went wrong
+    }
+  }
+}

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -1,7 +1,6 @@
 package mill.scalalib
 
 import scala.collection.immutable
-
 import ammonite.runtime.SpecialClassLoader
 import coursier.core.compatibility.xmlParseDom
 import coursier.maven.Pom
@@ -11,11 +10,11 @@ import mill.api.Strict.Agg
 import mill.api.{Loose, Result, Strict}
 import mill.define._
 import mill.eval.{Evaluator, PathRef}
+import mill.modules.Util
 import mill.{T, scalalib}
 import os.{Path, RelPath}
 import scala.util.Try
 import scala.xml.{Elem, MetaData, NodeSeq, Null, UnprefixedAttribute}
-
 import mill.scalalib.GenIdeaModule.{IdeaConfigFile, JavaFacet}
 
 case class GenIdeaImpl(evaluator: Evaluator,
@@ -74,7 +73,7 @@ case class GenIdeaImpl(evaluator: Evaluator,
 
     val buildLibraryPaths: immutable.Seq[Path] =
       if (!fetchMillModules) Nil
-      else Option(mill.modules.Util.millProperty("MILL_BUILD_LIBRARIES")) match {
+      else Util.millProperty("MILL_BUILD_LIBRARIES") match {
         case Some(found) => found.split(',').map(os.Path(_)).distinct.toList
         case None =>
           val repos = modules.foldLeft(Set.empty[Repository]) { _ ++ _._2.repositories } ++ Set(LocalRepositories.ivy2Local, Repositories.central)
@@ -632,7 +631,7 @@ object GenIdeaImpl {
     * Create the module name (to be used by Idea) for the module based on it segments.
     * @see [[Module.millModuleSegments]]
     */
-  def moduleName(p: Segments): String = p.value.foldLeft(StringBuilder.newBuilder) {
+  def moduleName(p: Segments): String = p.value.foldLeft(new StringBuilder()) {
     case (sb, Segment.Label(s)) if sb.isEmpty => sb.append(s)
     case (sb, Segment.Cross(s)) if sb.isEmpty => sb.append(s.mkString("-"))
     case (sb, Segment.Label(s)) => sb.append(".").append(s)

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -42,7 +42,7 @@ trait ScalaModule extends JavaModule { outer =>
     for {
       root <- allSources()
       if os.exists(root.path)
-      path <- (if (os.isDir(root.path)) os.walk(root.path) else Seq(root.path))
+      path <- if (os.isDir(root.path)) os.walk(root.path) else Seq(root.path)
       if os.isFile(path) && ((path.ext == "scala" || path.ext == "java") && !isHiddenFile(path))
     } yield PathRef(path)
   }


### PR DESCRIPTION
This is fixing:
- Some source file considered as directories.
- A workaround [SCL-17551](https://youtrack.jetbrains.com/issue/SCL-17551) that doesn't manage well 2 modules with the same base directory. This is mitigating https://github.com/lihaoyi/mill/issues/864 just like how SBT does 1 version only.
I'm also trying to fix it on the client side https://github.com/JetBrains/intellij-scala/pull/534
- Partially fixing https://github.com/lihaoyi/mill/issues/863. It's resolving `$ivy` imports but missing the `$file` resolutions.
- Removes the weird `/build` root project so that in the future we will be able to support actual root project.

Thanks