### PR TITLE
launcher: fix output redirect to work correctly on non-bash shells

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -593,7 +593,7 @@ def launcherScript(shellJvmArgs: Seq[String],
          |
          |# Client-server mode doesn't seem to work on WSL, just disable it for now
          |# https://stackoverflow.com/a/43618657/871202
-         |if grep -qEi "(Microsoft|WSL)" foo.txt &> /dev/null ; then
+         |if grep -qEi "(Microsoft|WSL)" foo.txt > /dev/null 2> /dev/null ; then
          |    ${java("mill.MillMain")}
          |else
          |    case "$$1" in


### PR DESCRIPTION
A small fix, suppressing unnecessary outputs on systems that do not use bash as their default shell.

See also gitter discussion https://gitter.im/lihaoyi/mill?at=5ebe5e726675d830b1a91081