### PR TITLE
Relative library paths in GenIdea, and a relative COURSIER_CACHE on WSL2

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -594,7 +594,7 @@ def launcherScript(shellJvmArgs: Seq[String],
          |# Client-server mode doesn't seem to work on WSL, just disable it for now
          |# https://stackoverflow.com/a/43618657/871202
          |if grep -qEi "(Microsoft|WSL)" /proc/version > /dev/null 2> /dev/null ; then
-         |    COURSIER_CACHE=out/.coursier ${java("mill.MillMain")}
+         |    COURSIER_CACHE=.coursier ${java("mill.MillMain")}
          |else
          |    case "$$1" in
          |      -i | --interactive )

--- a/build.sc
+++ b/build.sc
@@ -594,7 +594,7 @@ def launcherScript(shellJvmArgs: Seq[String],
          |# Client-server mode doesn't seem to work on WSL, just disable it for now
          |# https://stackoverflow.com/a/43618657/871202
          |if grep -qEi "(Microsoft|WSL)" foo.txt &> /dev/null ; then
-         |    ${java("mill.MillMain")}
+         |    COURSIER_CACHE=out/.coursier ${java("mill.MillMain")}
          |else
          |    case "$$1" in
          |      -i | --interactive )

--- a/integration/test/src/IntegrationTestSuite.scala
+++ b/integration/test/src/IntegrationTestSuite.scala
@@ -19,10 +19,11 @@ abstract class IntegrationTestSuite(repoKey: String, val workspaceSlug: String, 
   def buildFiles: Seq[os.Path] = os.walk(buildFilePath)
 
   override def initWorkspace() = {
-    super.initWorkspace()
+    val path = super.initWorkspace()
     buildFiles.foreach { file =>
       os.copy.over(file, workspacePath / file.last)
     }
     assert(!os.walk(workspacePath).exists(_.ext == "class"))
+    path
   }
 }

--- a/main/test/src/util/ScriptTestSuite.scala
+++ b/main/test/src/util/ScriptTestSuite.scala
@@ -64,5 +64,6 @@ abstract class ScriptTestSuite(fork: Boolean) extends TestSuite{
     // destination instead of the folder containing the wrapper.
 
     os.copy(scriptSourcePath, workspacePath)
+    workspacePath
   }
 }

--- a/scalalib/test/src/GenIdeaExtendedTests.scala
+++ b/scalalib/test/src/GenIdeaExtendedTests.scala
@@ -12,7 +12,7 @@ object GenIdeaExtendedTests extends ScriptTestSuite(false) {
 
   def tests: Tests = Tests {
     'genIdeaTests - {
-      initWorkspace()
+      val workspacePath = initWorkspace()
       eval("mill.scalalib.GenIdea/idea")
 
       Seq(
@@ -27,15 +27,19 @@ object GenIdeaExtendedTests extends ScriptTestSuite(false) {
 
       ).foreach { case (resource, generated) =>
           val resourceString = scala.io.Source.fromResource(resource).getLines().mkString("\n")
-          val generatedString = normaliseLibraryPaths(os.read(generated))
+          val generatedString = normaliseLibraryPaths(os.read(generated), workspacePath)
 
           assert(resourceString == generatedString)
         }
     }
   }
 
-  private def normaliseLibraryPaths(in: String): String = {
-    in.replaceAll(coursier.paths.CoursierPaths.cacheDirectory().toString, "COURSIER_HOME")
+  private def normaliseLibraryPaths(in: String, workspacePath: os.Path): String = {
+    in.replace(
+      "$PROJECT_DIR$/" +
+      os.Path(coursier.paths.CoursierPaths.cacheDirectory()).relativeTo(workspacePath),
+      "COURSIER_HOME"
+    )
   }
 
 }

--- a/scalalib/test/src/GenIdeaTests.scala
+++ b/scalalib/test/src/GenIdeaTests.scala
@@ -8,7 +8,7 @@ object GenIdeaTests extends ScriptTestSuite(false) {
 
   def tests: Tests = Tests {
     'genIdeaTests - {
-      initWorkspace()
+      val workspacePath = initWorkspace()
       eval("mill.scalalib.GenIdea/idea")
 
       Seq(
@@ -24,15 +24,20 @@ object GenIdeaTests extends ScriptTestSuite(false) {
           workspacePath / ".idea" / "misc.xml"
       ).foreach { case (resource, generated) =>
           val resourceString = scala.io.Source.fromResource(resource).getLines().mkString("\n")
-          val generatedString = normaliseLibraryPaths(os.read(generated))
+          val generatedString = normaliseLibraryPaths(os.read(generated), workspacePath)
 
           assert(resourceString == generatedString)
         }
     }
   }
 
-  private def normaliseLibraryPaths(in: String): String = {
-    in.replaceAll(coursier.paths.CoursierPaths.cacheDirectory().toString, "COURSIER_HOME")
+  private def normaliseLibraryPaths(in: String, workspacePath: os.Path): String = {
+
+    in.replace(
+      "$PROJECT_DIR$/" +
+      os.Path(coursier.paths.CoursierPaths.cacheDirectory()).relativeTo(workspacePath),
+      "COURSIER_HOME"
+    )
   }
 
   override def workspaceSlug: String = "gen-idea-hello-world"


### PR DESCRIPTION
This should allow the GenIdea output XML files to be usable cross-platform, e.g. we could resolve them on a WSL-Ubuntu environment and load them into Intellij on the host Windows machine

Tested locally on OS-X, seems to work, and tested on WSL2 as well. IntelliJ seems to be able to load the config successfully, even across the Ubuntu/Windows boundary