### PR TITLE
Dottydoc fix

### DIFF
--- a/scalalib/src/JavaModule.scala
+++ b/scalalib/src/JavaModule.scala
@@ -304,6 +304,14 @@ trait JavaModule extends mill.Module
   def javadocOptions: T[Seq[String]] = T { Seq[String]() }
 
   /**
+    * Extra directories to be processed by the API documentation tool.
+    *
+    * Typically includes static files such as html and markdown, but depends
+    * on the doc tool that is actually used.
+    */
+  def docSources = T.sources(millSourcePath / 'docs)
+
+  /**
    * The documentation jar, containing all the Javadoc/Scaladoc HTML files, for
    * publishing to Maven Central
    */

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -72,14 +72,22 @@ object Lib{
   def scalaCompilerIvyDeps(scalaOrganization: String, scalaVersion: String) =
     if (mill.scalalib.api.Util.isDotty(scalaVersion))
       Agg(
-        ivy"$scalaOrganization::dotty-compiler:$scalaVersion".forceVersion(),
-        ivy"$scalaOrganization::dotty-doc:$scalaVersion".forceVersion()
+        ivy"$scalaOrganization::dotty-compiler:$scalaVersion".forceVersion()
       )
     else
       Agg(
         ivy"$scalaOrganization:scala-compiler:$scalaVersion".forceVersion(),
         ivy"$scalaOrganization:scala-reflect:$scalaVersion".forceVersion()
       )
+
+  def scalaDocIvyDeps(scalaOrganization: String, scalaVersion: String) =
+    if (mill.scalalib.api.Util.isDotty(scalaVersion))
+      Agg(
+        ivy"$scalaOrganization::dotty-doc:$scalaVersion".forceVersion()
+      )
+    else
+      // in Scala <= 2.13, the scaladoc tool is included in the compiler
+      scalaCompilerIvyDeps(scalaOrganization, scalaVersion)
 
   def scalaRuntimeIvyDeps(scalaOrganization: String, scalaVersion: String) = Agg[Dep](
     ivy"$scalaOrganization:scala-library:$scalaVersion".forceVersion()

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -71,7 +71,10 @@ object Lib{
   }
   def scalaCompilerIvyDeps(scalaOrganization: String, scalaVersion: String) =
     if (mill.scalalib.api.Util.isDotty(scalaVersion))
-      Agg(ivy"$scalaOrganization::dotty-compiler:$scalaVersion".forceVersion())
+      Agg(
+        ivy"$scalaOrganization::dotty-compiler:$scalaVersion".forceVersion(),
+        ivy"$scalaOrganization::dotty-doc:$scalaVersion".forceVersion()
+      )
     else
       Agg(
         ivy"$scalaOrganization:scala-compiler:$scalaVersion".forceVersion(),

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -160,7 +160,7 @@ trait ScalaModule extends JavaModule { outer =>
     os.makeDir.all(javadocDir)
 
     if (isDotty(scalaVersion())) {
-      os.copy(millSourcePath / dottydocSiteRoot(), javadocDir, replaceExisting = true)
+      os.copy(dottydocSiteRoot(), javadocDir, replaceExisting = true)
     }
 
     val files = allSourceFiles().map(_.path.toString)
@@ -205,7 +205,7 @@ trait ScalaModule extends JavaModule { outer =>
 
   def dottydocProjectName = T { artifactName() }
 
-  def dottydocSiteRoot = T { "docs" }
+  def dottydocSiteRoot = T { millSourcePath / 'docs }
 
   /**
     * Opens up a Scala console with your module and all dependencies present,

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -172,17 +172,16 @@ trait ScalaModule extends JavaModule { outer =>
     os.makeDir.all(javadocDir)
 
     if (isDotty(scalaVersion())) {
-      // merge all docSources into one directory by symlinking their contents
+      // merge all docSources into one directory by copying all children
       for {
         ref <- docSources()
-        path = ref.path
-        if os.exists(path) && os.isDir(path)
-        children = os.list(path)
-        src <- children
+        docSource = ref.path
+        if os.exists(docSource) && os.isDir(docSource)
+        children = os.walk(docSource)
+        child <- children
+        if os.isFile(child)
       } {
-        val dest = javadocDir / src.last
-        if (os.exists(dest)) os.remove(dest)
-        os.symlink(dest, src)
+        os.copy.over(child, javadocDir / (child.subRelativeTo(docSource)), createFolders = true)
       }
     }
 

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -160,7 +160,7 @@ trait ScalaModule extends JavaModule { outer =>
     os.makeDir.all(javadocDir)
 
     if (isDotty(scalaVersion())) {
-      val root = dottydocSiteRoot()
+      val root = dottydocSiteRoot().path
       if (os.exists(root)) {
         os.copy(root, javadocDir, replaceExisting = true)
       } else {
@@ -210,7 +210,7 @@ trait ScalaModule extends JavaModule { outer =>
 
   def dottydocProjectName = T { artifactName() }
 
-  def dottydocSiteRoot = T { millSourcePath / 'docs }
+  def dottydocSiteRoot = T.source { millSourcePath / 'docs }
 
   /**
     * Opens up a Scala console with your module and all dependencies present,

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -160,7 +160,12 @@ trait ScalaModule extends JavaModule { outer =>
     os.makeDir.all(javadocDir)
 
     if (isDotty(scalaVersion())) {
-      os.copy(dottydocSiteRoot(), javadocDir, replaceExisting = true)
+      val root = dottydocSiteRoot()
+      if (os.exists(root)) {
+        os.copy(root, javadocDir, replaceExisting = true)
+      } else {
+        os.makeDir.all(javadocDir)
+      }
     }
 
     val files = allSourceFiles().map(_.path.toString)

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -105,6 +105,15 @@ trait ScalaModule extends JavaModule { outer =>
   }
 
   /**
+    * Classpath of the scaladoc (or dottydoc) tool.
+    */
+  def scalaDocClasspath: T[Agg[PathRef]] = T {
+    resolveDeps(
+      T.task{scalaDocIvyDeps(scalaOrganization(), scalaVersion())}
+    )()
+  }
+
+  /**
     * The ivy coordinates of Scala's own standard library
     */
   def scalaDocPluginClasspath: T[Agg[PathRef]] = T {
@@ -194,7 +203,7 @@ trait ScalaModule extends JavaModule { outer =>
       zincWorker.worker().docJar(
         scalaVersion(),
         scalaOrganization(),
-        scalaCompilerClasspath().map(_.path),
+        scalaDocClasspath().map(_.path),
         scalacPluginClasspath().map(_.path),
         files ++ options
       ) match{

--- a/scalalib/test/resources/dottydoc/empty/src/Main.scala
+++ b/scalalib/test/resources/dottydoc/empty/src/Main.scala
@@ -1,0 +1,8 @@
+package pkg
+
+@main
+def main() =
+  println("hello, world!")
+
+/** A doc comment. */
+case class SomeClass()

--- a/scalalib/test/resources/dottydoc/multidocs/docs1/index.md
+++ b/scalalib/test/resources/dottydoc/multidocs/docs1/index.md
@@ -1,0 +1,6 @@
+---
+layout: doc-page
+---
+
+Hello, DottyDoc!
+

--- a/scalalib/test/resources/dottydoc/multidocs/docs1/nested/original.md
+++ b/scalalib/test/resources/dottydoc/multidocs/docs1/nested/original.md
@@ -1,0 +1,5 @@
+---
+layout: doc-page
+---
+
+Extra docs

--- a/scalalib/test/resources/dottydoc/multidocs/docs1/sidebar.yml
+++ b/scalalib/test/resources/dottydoc/multidocs/docs1/sidebar.yml
@@ -1,0 +1,3 @@
+sidebar:
+  - title: Docs
+    url: nested/extra.html

--- a/scalalib/test/resources/dottydoc/multidocs/docs2/index.md
+++ b/scalalib/test/resources/dottydoc/multidocs/docs2/index.md
@@ -1,0 +1,6 @@
+---
+layout: doc-page
+---
+
+overwritten
+

--- a/scalalib/test/resources/dottydoc/multidocs/docs2/nested/extra.md
+++ b/scalalib/test/resources/dottydoc/multidocs/docs2/nested/extra.md
@@ -1,0 +1,5 @@
+---
+layout: doc-page
+---
+
+Extra docs

--- a/scalalib/test/resources/dottydoc/multidocs/src/Main.scala
+++ b/scalalib/test/resources/dottydoc/multidocs/src/Main.scala
@@ -1,0 +1,8 @@
+package pkg
+
+@main
+def main() =
+  println("hello, world!")
+
+/** A doc comment. */
+case class SomeClass()

--- a/scalalib/test/resources/dottydoc/static/docs/index.md
+++ b/scalalib/test/resources/dottydoc/static/docs/index.md
@@ -1,0 +1,6 @@
+---
+layout: doc-page
+---
+
+Hello, DottyDoc!
+

--- a/scalalib/test/resources/dottydoc/static/docs/nested/extra.md
+++ b/scalalib/test/resources/dottydoc/static/docs/nested/extra.md
@@ -1,0 +1,5 @@
+---
+layout: doc-page
+---
+
+Extra docs

--- a/scalalib/test/resources/dottydoc/static/docs/sidebar.yml
+++ b/scalalib/test/resources/dottydoc/static/docs/sidebar.yml
@@ -1,0 +1,3 @@
+sidebar:
+  - title: Docs
+    url: nested/extra.html

--- a/scalalib/test/resources/dottydoc/static/src/Main.scala
+++ b/scalalib/test/resources/dottydoc/static/src/Main.scala
@@ -1,0 +1,8 @@
+package pkg
+
+@main
+def main() =
+  println("hello, world!")
+
+/** A doc comment. */
+case class SomeClass()

--- a/scalalib/test/src/DottyDocTests.scala
+++ b/scalalib/test/src/DottyDocTests.scala
@@ -1,0 +1,67 @@
+package mill.scalalib
+
+import mill._
+import utest._
+import utest.framework.TestPath
+import mill.util.{TestEvaluator, TestUtil}
+
+import scala.collection.JavaConverters._
+import scala.util.Properties.isJavaAtLeast
+
+object DottyDocTests extends TestSuite {
+  trait TestBase extends TestUtil.BaseModule{
+    def millSourcePath =  TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+  }
+
+  // a project with static docs
+  object StaticDocsModule extends TestBase {
+    object static extends ScalaModule {
+      def scalaVersion = "0.24.0-RC1"
+    }
+  }
+
+  // a project without static docs (i.e. only api docs, no markdown files)
+  object EmptyDocsModule extends TestBase {
+    object empty extends ScalaModule {
+      def scalaVersion = "0.24.0-RC1"
+    }
+  }
+
+  val resourcePath = os.pwd / 'scalalib / 'test / 'resources / 'dottydoc
+
+  def workspaceTest[T](
+      m: TestUtil.BaseModule,
+      resourcePath: os.Path = resourcePath)(t: TestEvaluator => T)(
+      implicit tp: TestPath): T = {
+    val eval = new TestEvaluator(m)
+    os.remove.all(m.millSourcePath)
+    os.remove.all(eval.outPath)
+    os.makeDir.all(m.millSourcePath / os.up)
+    os.copy(resourcePath, m.millSourcePath)
+    t(eval)
+  }
+
+  def tests: Tests = Tests {
+    'static - workspaceTest(StaticDocsModule){ eval =>
+      val Right((_, _)) = eval.apply(StaticDocsModule.static.docJar)
+      val dest = eval.outPath / 'static / 'docJar / 'dest
+      assert(
+        os.exists(dest / "out.jar"), // final jar should exist
+        // check if extra markdown files have been included and translated to html
+        os.exists(dest / 'javadoc / '_site / "index.html"),
+        os.exists(dest / 'javadoc / '_site / 'nested / "extra.html"),
+        // also check that API docs have been generated
+        os.exists(dest / 'javadoc / '_site / 'api / 'pkg / "SomeClass.html")
+      )
+    }
+    'empty - workspaceTest(EmptyDocsModule){ eval =>
+      val Right((_, _)) = eval.apply(EmptyDocsModule.empty.docJar)
+      val dest = eval.outPath / 'empty / 'docJar / 'dest
+      assert(
+        os.exists(dest / "out.jar"),
+        os.exists(dest / 'javadoc / '_site / 'api / 'pkg / "SomeClass.html")
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
This is a rebase of #787 on master with some added tests.

In the last commit I added one additional change however: the scaladoc tool now has distinct classpath and ivydeps from the compiler. In Scala <= 2.13 this is not necessary, as the doc tool is included in the compiler artifact, however in dotty this is no longer the case. Feel free to drop that last commit if you'd rather not have the split.