### PR TITLE
BSP: Deduplicate targets to compile

### DIFF
--- a/contrib/bsp/src/mill/contrib/bsp/MillBuildServer.scala
+++ b/contrib/bsp/src/mill/contrib/bsp/MillBuildServer.scala
@@ -180,7 +180,7 @@ class MillBuildServer(evaluator: Evaluator, bspVersion: String, serverVersion: S
       val params = TaskParameters.fromCompileParams(compileParams)
       val taskId = params.hashCode()
       val compileTasks = Strict.Agg(
-        params.getTargets.filter(_ != millBuildTargetId).map(getModule(_, modules).compile): _*
+        params.getTargets.distinct.filter(_ != millBuildTargetId).map(getModule(_, modules).compile): _*
       )
       val result = evaluator.evaluate(
         compileTasks,


### PR DESCRIPTION
Due to an Intellij workaround (shared modules) to support cross compiled code we are receiving multiple times the same target.