### PR TITLE
Fixed destination path for foreign-module setup

### DIFF
--- a/main/core/src/eval/Evaluator.scala
+++ b/main/core/src/eval/Evaluator.scala
@@ -583,8 +583,9 @@ object Evaluator{
     case Segment.Label(s) => Seq(s)
     case Segment.Cross(values) => values.map(_.toString)
   }
-  def resolveDestPaths(workspacePath: os.Path, segments: Segments): Paths = {
-    val segmentStrings = makeSegmentStrings(segments)
+  def resolveDestPaths(workspacePath: os.Path, segments: Segments, foreignSegments: Option[Segments] = None): Paths = {
+    val refinedSegments = foreignSegments.map(_ ++ segments).getOrElse(segments)
+    val segmentStrings = makeSegmentStrings(refinedSegments)
     val targetPath = workspacePath / segmentStrings
     Paths(targetPath, targetPath / 'dest, targetPath / "meta.json", targetPath / 'log)
   }

--- a/main/src/main/RunScript.scala
+++ b/main/src/main/RunScript.scala
@@ -238,7 +238,7 @@ object RunScript{
           t match {
             case t: mill.define.NamedTask[_] =>
               val jsonFile = Evaluator
-                .resolveDestPaths(evaluator.outPath, t.ctx.segments)
+                .resolveDestPaths(evaluator.outPath, t.ctx.segments, t.ctx.foreign)
                 .meta
               val metadata = upickle.default.read[Evaluator.Cached](ujson.read(jsonFile.toIO))
               Some(metadata.value)


### PR DESCRIPTION
A tiny fix resolving miss of appropriate destination directory for foreign modules that causes following error:

```
Exception in thread "main" java.nio.file.NoSuchFileException: /Users/goodfella/dev/out/baz/compile/meta.json
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
        at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
        at java.base/java.nio.file.Files.newByteChannel(Files.java:375)
        at java.base/java.nio.file.Files.newByteChannel(Files.java:426)
        at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
        at java.base/java.nio.file.Files.newInputStream(Files.java:160)
        at ujson.Readable$$anon$1.transform(Readable.scala:20)
        at ujson.package$.transform(package.scala:4)
        at ujson.package$.read(package.scala:9)
        at mill.main.RunScript$.$anonfun$evaluate$6(RunScript.scala:243)
        at scala.collection.immutable.List.map(List.scala:246)
        at scala.collection.immutable.List.map(List.scala:79)
        at mill.main.RunScript$.evaluate(RunScript.scala:237)
        at mill.main.RunScript$.$anonfun$evaluateTasks$1(RunScript.scala:188)
        at scala.util.Either.map(Either.scala:382)
        at mill.main.RunScript$.evaluateTasks(RunScript.scala:187)
        at mill.main.RunScript$.$anonfun$runScript$4(RunScript.scala:66)
        at ammonite.util.Res$Success.flatMap(Res.scala:62)
        at mill.main.RunScript$.runScript(RunScript.scala:65)
        at mill.main.MainRunner.$anonfun$runScript$1(MainRunner.scala:115)
        at mill.main.MainRunner.watchLoop2(MainRunner.scala:64)
        at mill.main.MainRunner.runScript(MainRunner.scala:90)
        at mill.MillMain$.main0(MillMain.scala:239)
        at mill.MillMain$.main(MillMain.scala:30)
        at mill.MillMain.main(MillMain.scala)
```

Module `baz` is actually a `foo.bar.baz`, that was imported as a `$file` to root `build.sc`.
This PR resolves resolution of `baz` targets destination to the `/Users/goodfella/dev/out/foreign-modules/foo/bar/baz/*`