### PR TITLE
Replace scala-library artifact with dotty-library

### DIFF
--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -89,9 +89,16 @@ object Lib{
       // in Scala <= 2.13, the scaladoc tool is included in the compiler
       scalaCompilerIvyDeps(scalaOrganization, scalaVersion)
 
-  def scalaRuntimeIvyDeps(scalaOrganization: String, scalaVersion: String) = Agg[Dep](
-    ivy"$scalaOrganization:scala-library:$scalaVersion".forceVersion()
-  )
+  def scalaRuntimeIvyDeps(scalaOrganization: String, scalaVersion: String) =
+    if (mill.scalalib.api.Util.isDotty(scalaVersion))
+      Agg(
+        // note that dotty-library has a binary version suffix, hence the :: is necessary here
+        ivy"$scalaOrganization::dotty-library:$scalaVersion".forceVersion()
+      )
+    else
+      Agg(
+        ivy"$scalaOrganization:scala-library:$scalaVersion".forceVersion()
+      )
 
   def listClassFiles(base: os.Path): Iterator[String] = {
     if (os.isDir(base)) os.walk(base).toIterator.filter(_.ext == "class").map(_.relativeTo(base).toString)


### PR DESCRIPTION
This change is a "symptomatic treatment" to fix bloop config generation, which is currently broken for dotty projects.

In particular, [this issue](https://github.com/scalameta/metals/issues/1768) describes the error observed, and also hints to the fix.

The gist of it seems to be that Dotty publishes an empty jar named "scala-library" (not sure why?), but the actual standard library is published in the artifact "dotty-library". While the former is empty and isn't strictly a problem when compiling, it does cause bloop to crash if included in the classpath.

~Note that I am not exactly sure what the root cause is, and I'm also not sure what the future plans are regarding the naming of artifacts. It would be great to get feedback from someone more knowledgeable in this area before accepting these changes.~ (thanks for the review, Guillaume!)