### PR TITLE
Adding url to generated developer setting in published pom.

### DIFF
--- a/scalalib/src/publish/Pom.scala
+++ b/scalalib/src/publish/Pom.scala
@@ -78,6 +78,7 @@ object Pom {
     <developer>
       <id>{d.id}</id>
       <name>{d.name}</name>
+      <url>{d.url}</url>
       { <organization>{d.organization}</organization>.optional }
       { <organizationUrl>{d.organizationUrl}</organizationUrl>.optional }
     </developer>


### PR DESCRIPTION
This is just to include the url set in the Developer case class in the pom that is generated when publishing to Sonatype or to the local maven repo. 