### PR TITLE
Allows the ScalafmtModule to format build sources

### DIFF
--- a/scalalib/src/scalafmt/ScalafmtModule.scala
+++ b/scalalib/src/scalafmt/ScalafmtModule.scala
@@ -29,7 +29,13 @@ trait ScalafmtModule extends JavaModule {
   protected def filesToFormat(sources: Seq[PathRef]) = {
     for {
       pathRef <- sources if os.exists(pathRef.path)
-      file <- os.walk(pathRef.path) if os.isFile(file) && file.ext == "scala"
+      file <- {
+        if (os.isDir(pathRef.path)) {
+          os.walk(pathRef.path).filter(file => os.isFile(file) && (file.ext == "scala" || file.ext == "sc"))
+        } else {
+          Seq(pathRef.path)
+        }
+      }
     } yield PathRef(file)
   }
 

--- a/scalalib/test/resources/scalafmt/core/util.sc
+++ b/scalalib/test/resources/scalafmt/core/util.sc
@@ -1,0 +1,2 @@
+ def sayHelloWorld() =
+println("Hello World")


### PR DESCRIPTION
This allows that the MillScalafmtModule can be utilised to format the mill build sources (such as build.sc) as well.

Here is an example how a command can be created to trigger the formatting:
```
def buildSources: Sources = T.sources(os.pwd / "build.sc")

def fmtBuild(): Command[Unit] =
  T.command {
    MillScalafmtModule.reformatAll(Tasks(Seq(buildSources)))
  }
```