### PR TITLE
Wrap class names in single quotes in launcher script

### DIFF
--- a/main/src/modules/Jvm.scala
+++ b/main/src/modules/Jvm.scala
@@ -376,7 +376,7 @@ object Jvm {
                               shebang: Boolean = false) = {
     universalScript(
       shellCommands =
-        s"""exec java ${jvmArgs.mkString(" ")} $$JAVA_OPTS -cp "${shellClassPath.mkString(":")}" $mainClass "$$@"""",
+        s"""exec java ${jvmArgs.mkString(" ")} $$JAVA_OPTS -cp "${shellClassPath.mkString(":")}" '$mainClass' "$$@"""",
       cmdCommands =
         s"""java ${jvmArgs.mkString(" ")} %JAVA_OPTS% -cp "${cmdClassPath.mkString(";")}" $mainClass %*""",
       shebang = shebang


### PR DESCRIPTION
Quotes classnames to that bash doesn't interpret any `$` contained within them (as can happen with dotty's top-level main functions).