### PR TITLE
Handle dots in segment names for foreign modules

### DIFF
--- a/main/core/src/define/Ctx.scala
+++ b/main/core/src/define/Ctx.scala
@@ -11,7 +11,7 @@ sealed trait Segment{
 }
 object Segment{
   case class Label(value: String) extends Segment{
-    assert(!value.contains('.'))
+    assert(!value.contains('.'), s"$value contained a .")
   }
   case class Cross(value: Seq[Any]) extends Segment
 }

--- a/main/src/main/MainRunner.scala
+++ b/main/src/main/MainRunner.scala
@@ -179,7 +179,12 @@ class MainRunner(val config: ammonite.main.Cli.Config,
         // Encoding the number of `/..`
         val ups = if (relative.ups > 0) Seq(s"up-${relative.ups}") else Seq()
         val segs = Seq("foreign-modules") ++ ups ++ relative.segments
-        val segsList = segs.map(pprint.Util.literalize(_)).mkString(", ")
+        val segsList = segs
+          .map({
+            case ".mill" => "DOT-mill"
+            case seg => seg
+          })
+          .map(pprint.Util.literalize(_)).mkString(", ")
         s"Some(mill.define.Segments.labels($segsList))"
       }
       else "None"


### PR DESCRIPTION
It seems like `.mill/ammonite/predefScript.sc` stopped working in mill 0.5.5. This encodes the segment label for `.mill` (and only `.mill`) as `"DOT-mill"` in order to pass the assertion, and also adds a message to the assertion so that if anything like this happens in the future it will be slightly easier to spot what it's coming from.

This will also encode `.mill` in other locations as `DOT-mill`, not just those in `~/.mill`.

One alternative would be to special-case `.mill` => `DOT-mill` in `Segments.labels` instead.

Another possibility would be to make `.<blah>` => `DOT-blah` globally, or make any dots into `DOT` to work with arbitrary directory names containing dots.

Both of those options would be more general and easier to test, but I opted for the smallest most specific fix that would allow `predefScript.sc` to start working again.