### PR TITLE
Added --repl and --no-server and changed behavior of -i/--interactive for #926

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -597,7 +597,7 @@ def launcherScript(shellJvmArgs: Seq[String],
          |    COURSIER_CACHE=.coursier ${java("mill.MillMain")}
          |else
          |    case "$$1" in
-         |      -i | --interactive )
+         |      -i | --interactive | --repl | --no-server )
          |        ${java("mill.MillMain")}
          |        ;;
          |      *)
@@ -616,6 +616,8 @@ def launcherScript(shellJvmArgs: Seq[String],
          |if not "%JAVA_HOME%"=="" set "JAVACMD=%JAVA_HOME%\\bin\\java.exe"
          |if "%1" == "-i" set _I_=true
          |if "%1" == "--interactive" set _I_=true
+         |if "%1" == "--repl" set _I_=true
+         |if "%1" == "--no-server" set _I_=true
          |if defined _I_ (
          |  ${java("mill.MillMain")}
          |) else (

--- a/docs/pages/1 - Intro to Mill.md
+++ b/docs/pages/1 - Intro to Mill.md
@@ -65,7 +65,9 @@ Mill also works on a sh environment on Windows (e.g.,
 [WSL](https://docs.microsoft.com/en-us/windows/wsl);
 to get started, follow the instructions in the [manual](#manual) section below. Note that:
 
-* In some environments (such as WSL), mill might have to be run using interactive mode (`-i`)
+* In some environments (such as WSL), mill might have to be run
+  without a server (using `-i`, `--interactive`, `--no-server`, or
+  `--repl`.)
 
 * On Cygwin, run the following after downloading mill:
 
@@ -707,10 +709,10 @@ generate an IntelliJ project config for your build.
 This also configures IntelliJ to allow easy navigate & code-completion within
 your build file itself.
 
-## The Build Repl
+## The Build REPL
 
 ```bash
-$ mill -i
+$ mill --repl
 Loading...
 @ foo
 res0: foo.type = ammonite.predef.build#foo:4
@@ -747,10 +749,10 @@ res2: mill.scalalib.api.CompilationResult = CompilationResult(
 )
 ```
 
-You can run `mill -i` to open a build REPL; this is a Scala console with your
-`build.sc` loaded, which lets you run tasks interactively. The task-running
-syntax is slightly different from the command-line, but more in-line with how
-you would depend on tasks from within your build file.
+You can run `mill --repl` to open a build REPL; this is a Scala console with
+your `build.sc` loaded, which lets you run tasks interactively. The
+task-running syntax is slightly different from the command-line, but more
+in-line with how you would depend on tasks from within your build file.
 
 You can use this REPL to interactively explore your build to see what is available.
 

--- a/docs/pages/2 - Configuring Mill.md
+++ b/docs/pages/2 - Configuring Mill.md
@@ -297,10 +297,11 @@ the same testing framework, etc. and all that can be extracted out into the
 
 Mill builds on ammonite which allows you to
 [define global configuration](http://ammonite.io/#ScriptPredef). Depending on
-how you start mill 2 different files will be loaded. For interactive mode it's
-`~/.mill/ammonite/predef.sc` and from the command line it's
-`~/.mill/ammonite/predefScript.sc`. You might want to create a symlink from one
-to the other to avoid duplication.
+how you start mill, one of two files will be loaded. For the build REPL
+(`--repl` or `-i` without specifying a target), `~/.mill/ammonite/predef.sc`
+will be loaded, and for builds from the command line the file
+`~/.mill/ammonite/predefScript.sc` will be included. You might want to create
+a symlink from one to the other to avoid duplication.
 
 Example `~/.mill/ammonite/predef.sc`
 ```scala


### PR DESCRIPTION
This adds `--repl` and `--no-server` as options, and makes `-i` with no targets produce a warning message.

* `--repl` starts a build REPL, but fails if a target is given
* `--no-server` fails unless targets are given
* `-i`/`--interactive` is the same as `--no-server`, but emits a warning and starts a build REPL if no targets are given

Giving any of these arguments as the first option on the command-line causes `mill.MillMain` to run (interactive mode). Giving none of them as the first argument causes `mill.client.MillClientMain` to run. It is an error to give more than one of these options.

The only possible undesirable feature is that It is now possible to give one of these options more than once, with the first occurrence being as the first argument and another occurrence later in the switches. The "these switches have to be first" error is now emitted based on whether interactive mode is active when one of these switches are present. It would be possible to change the code to disallow any repeats if that's unacceptable.