### PR TITLE
BSP: Mill build Scala lib dep and forward env vars to server start

### DIFF
--- a/contrib/bsp/src/mill/contrib/BSP.scala
+++ b/contrib/bsp/src/mill/contrib/BSP.scala
@@ -41,16 +41,16 @@ object BSP extends ExternalModule {
    * with connection details in the ./.bsp directory for
    * a potential client to find.
    *
-    * If a .bsp folder with a connection file already
+   * If a .bsp folder with a connection file already
    * exists in the working directory, it will be
    * overwritten and a corresponding message will be displayed
    * in stdout.
    *
-    * If the creation of the .bsp folder fails due to any other
+   * If the creation of the .bsp folder fails due to any other
    * reason, the message and stacktrace of the exception will be
    * printed to stdout.
    *
-    */
+   */
   def install(evaluator: Evaluator): Command[Unit] =
     T.command {
       val bspDirectory = evaluator.rootModule.millSourcePath / ".bsp"
@@ -59,7 +59,8 @@ object BSP extends ExternalModule {
         os.write(bspDirectory / "mill.json", createBspConnectionJson())
       } catch {
         case _: FileAlreadyExistsException =>
-          T.log.info("The bsp connection json file probably exists already - will be overwritten")
+          T.log.info(
+            "The bsp connection json file probably exists already - will be overwritten")
           os.remove(bspDirectory / "mill.json")
           os.write(bspDirectory / "mill.json", createBspConnectionJson())
         case e: Exception =>
@@ -71,31 +72,24 @@ object BSP extends ExternalModule {
 
   // creates a Json with the BSP connection details
   def createBspConnectionJson(): String = {
-    val millPath = sys.props.get("java.class.path")
+    val millPath = sys.props
+      .get("java.class.path")
       .getOrElse(throw new IllegalStateException("System property java.class.path not set"))
 
-    val millVersion = Util.millProperty("MILL_VERSION").getOrElse(BuildInfo.millVersion)
     write(
       BspConfigJson(
         "mill-bsp",
         Seq(
-          whichJava,
-          s"-DMILL_VERSION=$millVersion",
-          "-Djna.nosys=true",
-          "-cp",
-          millPath,
-          "mill.MillMain",
-          "mill.contrib.BSP/start"
+          "sh",
+          "-c",
+          s"env ${sys.env.map { case (k, v) => s""""$k=$v"""" }.toSeq.mkString(" ")} $millPath -i mill.contrib.BSP/start"
         ),
-        millVersion,
+        Util.millProperty("MILL_VERSION").getOrElse(BuildInfo.millVersion),
         bspProtocolVersion,
         languages
       )
     )
   }
-
-  // computes the path to the java executable
-  def whichJava: String = sys.props.getOrElse("JAVA_HOME", "java")
 
   /**
    * Computes a mill command which starts the mill-bsp
@@ -103,7 +97,7 @@ object BSP extends ExternalModule {
    * until a client connects and ends the connection
    * after the client sent an "exit" notification
    *
-    * @param ev Environment, used by mill to evaluate commands
+   * @param ev Environment, used by mill to evaluate commands
    * @return: mill.Command which executes the starting of the
    *          server
    */
@@ -131,7 +125,8 @@ object BSP extends ExternalModule {
           .setInput(stdin)
           .setLocalService(millServer)
           .setRemoteInterface(classOf[BuildClient])
-          .traceMessages(new PrintWriter((evaluator.rootModule.millSourcePath / ".bsp" / "mill.log").toIO))
+          .traceMessages(new PrintWriter(
+            (evaluator.rootModule.millSourcePath / ".bsp" / "mill.log").toIO))
           .setExecutorService(executor)
           .create()
         millServer.onConnectWithClient(launcher.getRemoteProxy)
@@ -140,14 +135,15 @@ object BSP extends ExternalModule {
         listening.get()
         ()
       } catch {
-        case _: CancellationException => T.log.error("The mill server was shut down.")
+        case _: CancellationException =>
+          T.log.error("The mill server was shut down.")
         case e: Exception =>
           T.log.error(
             s"""An exception occured while connecting to the client.
-              |Cause: ${e.getCause}
-              |Message: ${e.getMessage}
-              |Exception class: ${e.getClass}
-              |Stack Trace: ${e.getStackTrace}""".stripMargin
+               |Cause: ${e.getCause}
+               |Message: ${e.getMessage}
+               |Exception class: ${e.getClass}
+               |Stack Trace: ${e.getStackTrace}""".stripMargin
           )
       } finally {
         T.log.error("Shutting down executor")


### PR DESCRIPTION
This fixes:
- Some redness with the .sc files because if the missing Scala lib as dependency.
- The BSP server boot command to forward the env vars. That's useful when you set env vars like `JAVA_OPTS` or `COURSIER_REPOSITORIES`.

Thanks