### PR TITLE
Generate sourcemaps on scalajs 1.

### DIFF
--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -111,8 +111,13 @@ object HelloJSWorldTests extends TestSuite {
         case FastOpt => HelloJSWorld.helloJsWorld(scalaVersion, scalaJSVersion).fastOpt
       }
       val Right((result, evalCount)) = helloWorldEvaluator(task)
-      val output = ScalaJsUtils.runJS(result.path)
+      val jsFile = result.path
+      val output = ScalaJsUtils.runJS(jsFile)
       assert(output == "Hello Scala.js")
+      val sourceMap= jsFile / os.up / (jsFile.last + ".map")
+      assert(sourceMap.toIO.exists()) // sourceMap file was generated
+      assert(os.read(jsFile).contains("//# sourceMappingURL=out.js.map")) // jsFile references sourceMap
+      assert(os.read(sourceMap).contains("\"file\": \"out.js\",")) // sourceMap references jsFile
     }
 
     'fullOpt - {

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -116,8 +116,8 @@ object HelloJSWorldTests extends TestSuite {
       assert(output == "Hello Scala.js")
       val sourceMap= jsFile / os.up / (jsFile.last + ".map")
       assert(sourceMap.toIO.exists()) // sourceMap file was generated
-      assert(os.read(jsFile).contains("//# sourceMappingURL=out.js.map")) // jsFile references sourceMap
-      assert(os.read(sourceMap).contains("\"file\": \"out.js\",")) // sourceMap references jsFile
+      assert(os.read(jsFile).contains(s"//# sourceMappingURL=${sourceMap.toNIO.getFileName}")) // jsFile references sourceMap
+      assert(ujson.read(sourceMap.toIO).obj.get("file").exists(_.str == jsFile.toNIO.getFileName.toString)) // sourceMap references jsFile
     }
 
     'fullOpt - {

--- a/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
@@ -12,7 +12,6 @@ import org.scalajs.linker.{PathIRContainer, PathIRFile, PathOutputFile, Standard
 import org.scalajs.linker.interface.{ModuleKind => ScalaJSModuleKind, _}
 import org.scalajs.logging.ScalaConsoleLogger
 import org.scalajs.jsenv.{Input, JSEnv, RunConfig}
-import org.scalajs.jsenv.nodejs._
 import org.scalajs.jsenv.nodejs.NodeJSEnv.SourceMap
 import org.scalajs.testing.adapter.TestAdapter
 import org.scalajs.testing.adapter.{TestAdapterInitializer => TAI}
@@ -51,7 +50,12 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
     val sourceIRsFuture = Future.sequence(sources.toSeq.map(f => PathIRFile(f.toPath())))
     val irContainersPairs = PathIRContainer.fromClasspath(libraries.map(_.toPath()))
     val libraryIRsFuture = irContainersPairs.flatMap(pair => cache.cached(pair._1))
-    val linkerOutput = LinkerOutput(PathOutputFile(dest.toPath()))
+    val jsFile = dest.toPath()
+    val sourceMap = jsFile.resolveSibling(jsFile.getFileName + ".map")
+    val linkerOutput = LinkerOutput(PathOutputFile(jsFile))
+      .withJSFileURI(java.net.URI.create(jsFile.getFileName.toString))
+      .withSourceMap(PathOutputFile(sourceMap))
+      .withSourceMapURI(java.net.URI.create(sourceMap.getFileName.toString))
     val logger = new ScalaConsoleLogger
     val mainInitializer = Option(main).map { cls => ModuleInitializer.mainMethodWithArgs(cls, "main") }
     val testInitializer =


### PR DESCRIPTION
Sourcemaps were only being generated when using
`scalajs 0.6` but not for `scalajs 1`.

This changeset makes sure that we test that both
`fastOpt` and `fullOpt` will generate correct sourcemaps on all
scalajs supported versions.

Closes #884 

Context from gitter channel: https://gitter.im/lihaoyi/mill?at=5efcf211405be935cdd4e4c6