### PR TITLE
Passing args to launcher

### DIFF
--- a/docs/pages/1 - Intro to Mill.md
+++ b/docs/pages/1 - Intro to Mill.md
@@ -934,3 +934,15 @@ variable or `.mill-version` file.
 
 Come by our [Gitter Channel](https://gitter.im/lihaoyi/mill) if you want to ask
 questions or say hi!
+
+## Running Mill with custom JVM options
+
+It's possible to pass JVM options to the Mill launcher. To do this you need to create a `.mill-jvm-opts` file in your project's root. This file should contain JVM options (strings, starting with `-X`), one per line. All other lines will be ignored.
+
+For example, if your build requires a lot of memory and bigger stack size, your `.mill-jvm-opts` could look like this:
+```
+-Xss10m
+-Xmx10G
+```
+
+The file name for passing JVM options to the Mill launcher is configurable. If for some reason you don't want to use `.mill-jvm-opts` file name, add `MILL_JVM_OPTS_PATH` environment variable with any other file name.

--- a/main/client/src/mill/main/client/MillClientMain.java
+++ b/main/client/src/mill/main/client/MillClientMain.java
@@ -19,7 +19,7 @@ public class MillClientMain {
 	public static final int ExitServerCodeWhenVersionMismatch() { return 101; }
 
     static void initServer(String lockBase, boolean setJnaNoSys) throws IOException,URISyntaxException{
-        
+
         String selfJars = "";
         List<String> vmOptions = new ArrayList<>();
         String millOptionsPath = System.getProperty("MILL_OPTIONS_PATH");
@@ -49,6 +49,23 @@ public class MillClientMain {
         }
         if (setJnaNoSys) {
             vmOptions.add("-Djna.nosys=true");
+        }
+
+        String millJvmOptsPath = System.getProperty("MILL_JVM_OPTS_PATH");
+        if (millJvmOptsPath == null) {
+            millJvmOptsPath = ".mill-jvm-opts";
+        }
+
+        File millJvmOptsFile =  new File(millJvmOptsPath);
+        if (millJvmOptsFile.exists()) {
+            try (Scanner sc = new Scanner(millJvmOptsFile)) {
+                while (sc.hasNextLine()) {
+                    String arg = sc.nextLine();
+                    if (arg.startsWith("-X")) {
+                        vmOptions.add(arg);
+                    }
+                }
+            }
         }
 
         List<String> l = new ArrayList<>();


### PR DESCRIPTION
Hi. I'm trying to fix https://github.com/lihaoyi/mill/issues/577. The pull request is still in progress. I want to verify my solution before full implementation.

I propose to pass extra JVM arguments to the launcher through `.mill-args` file in the root of the project. sbt using the same approach with `.sbtopts` file.

At the current moment, only mill server on linux/macos could recognize `.mill-args` file. Support for windows and interactive mode is needed for full feature implementation.

What do you think about this solution?