### PR TITLE
Fix ScalaJS dependencies versions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -21,9 +21,10 @@ object Deps {
     val scalajsEnvJsdomNodejs =  ivy"org.scala-js::scalajs-env-jsdom-nodejs:1.1.0"
     val scalajsEnvNodejs =  ivy"org.scala-js::scalajs-env-nodejs:1.1.1"
     val scalajsEnvPhantomjs =  ivy"org.scala-js::scalajs-env-phantomjs:1.0.0"
-    val scalajsSbtTestAdapter = ivy"org.scala-js::scalajs-sbt-test-adapter:1.1.0"
-    val scalajsLinker = ivy"org.scala-js::scalajs-linker:1.1.0"
+    val scalajsSbtTestAdapter = ivy"org.scala-js::scalajs-sbt-test-adapter:1.1.1"
+    val scalajsLinker = ivy"org.scala-js::scalajs-linker:1.1.1"
   }
+
   object Scalanative_0_3 {
     val scalanativeTools = ivy"org.scala-native::tools:0.3.9"
     val scalanativeUtil = ivy"org.scala-native::util:0.3.9"

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -52,8 +52,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       case "1" =>
         Seq(
           ivy"org.scala-js::scalajs-linker:${scalaJSVersion()}",
-          ivy"org.scala-js::scalajs-env-nodejs:${scalaJSVersion()}",
-          ivy"org.scala-js::scalajs-env-jsdom-nodejs:${scalaJSVersion()}",
+          ivy"org.scala-js::scalajs-env-nodejs:1.1.1",
+          ivy"org.scala-js::scalajs-env-jsdom-nodejs:1.1.0",
           ivy"org.scala-js::scalajs-env-phantomjs:1.0.0"
         )
     }

--- a/scalajslib/test/src/HelloJSWorldTests.scala
+++ b/scalajslib/test/src/HelloJSWorldTests.scala
@@ -24,7 +24,7 @@ object HelloJSWorldTests extends TestSuite {
 
   object HelloJSWorld extends TestUtil.BaseModule {
     val scalaVersions = Seq("2.13.2", "2.12.11", "2.11.12")
-    val scalaJSVersions = Seq("1.1.0", "1.0.0", "0.6.33")
+    val scalaJSVersions = Seq("1.1.1", "1.0.1", "0.6.33")
     val matrix = for {
       scala <- scalaVersions
       scalaJS <- scalaJSVersions
@@ -143,8 +143,8 @@ object HelloJSWorldTests extends TestSuite {
         assert(result.id == artifactId)
       }
       'artifactId_06 - testArtifactId(HelloJSWorld.scalaVersions.head, "0.6.33", "hello-js-world_sjs0.6_2.13")
-      'artifactId_10 - testArtifactId(HelloJSWorld.scalaVersions.head, "1.0.0", "hello-js-world_sjs1_2.13")
-      'artifactId_1 - testArtifactId(HelloJSWorld.scalaVersions.head, "1.1.0", "hello-js-world_sjs1_2.13")
+      'artifactId_10 - testArtifactId(HelloJSWorld.scalaVersions.head, "1.0.1", "hello-js-world_sjs1_2.13")
+      'artifactId_1 - testArtifactId(HelloJSWorld.scalaVersions.head, "1.1.1", "hello-js-world_sjs1_2.13")
     }
 
     def runTests(testTask: define.NamedTask[(String, Seq[TestRunner.Result])]): Map[String, Map[String, TestRunner.Result]] = {


### PR DESCRIPTION
I noticed that the ScalaJS build doesn't work with ScalaJS 1.0.1.
This is because it derives the `scalajs-env-nodejs` and `scalajs-env-jsdom-nodejs` dependencies from the ScalaJS version instead of using fixed versions, since they are not tied to the ScalaJS version. 