### PR TITLE
Exclude trees from ammonite dep.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -41,6 +41,12 @@ object Deps {
 
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.0"
   val ammonite = ivy"com.lihaoyi:::ammonite:2.2.0"
+  // Exclude trees here to force the version of we have defined. We use this
+  // here instead of a `forceVersion()` on scalametaTrees since it's not
+  // respected in the POM causing issues for Coursier Mill users.
+  val ammoniteExcludingTrees = ammonite.exclude(
+    "org.scalameta" -> "trees_2.13"
+  )
   val scalametaTrees = ivy"org.scalameta::trees:4.3.7"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.4.0-RC1"
   val coursier = ivy"io.get-coursier::coursier:2.0.0-RC6-15"
@@ -161,8 +167,8 @@ object main extends MillModule {
     )
 
     def ivyDeps = Agg(
-      Deps.ammonite,
-      Deps.scalametaTrees.forceVersion(),
+      Deps.ammoniteExcludingTrees,
+      Deps.scalametaTrees,
       Deps.coursier,
       // Necessary so we can share the JNA classes throughout the build process
       Deps.jna,


### PR DESCRIPTION
The reason for doing this is to ensure that the version of
trees that mill wants is indeeed used instead of the newer
version that is being pulled in by ammonite-interp. Before
this was using `forceVersion()`, which was added https://github.com/lihaoyi/mill/compare/438ebc...6b492a, but by doing this the forced
version doesn't end up in the POM meaning that when someone
bootstraps/uses mill via coursier, they are getting the newer
trees, which is causing issues with how the main class is detected.

You can see we are getting `4.3.20` here instead of the _forced_ `4.3.7`:

```
❯ cs resolve mill | grep trees
org.scalameta:trees_2.13:4.3.20:default
```

This is coming from ammonite-interp:

```
❯ cs resolve mill --what-depends-on org.scalameta:trees_2.13
  Result:
└─ org.scalameta:trees_2.13:4.3.20
   ├─ com.lihaoyi:ammonite-interp_2.13.2:2.2.0
   │  ├─ com.lihaoyi:ammonite-repl_2.13.2:2.2.0
   │  │  └─ com.lihaoyi:ammonite_2.13.2:2.2.0
   │  │     └─ com.lihaoyi:mill-main-core_2.13:0.8.0
   │  │        └─ com.lihaoyi:mill-main_2.13:0.8.0
   │  │           └─ com.lihaoyi:mill-scalalib_2.13:0.8.0
   │  │              ├─ com.lihaoyi:mill-dev_2.13:0.8.0
   │  │              ├─ com.lihaoyi:mill-scalajslib_2.13:0.8.0
   │  │              │  └─ com.lihaoyi:mill-dev_2.13:0.8.0
   │  │              └─ com.lihaoyi:mill-scalanativelib_2.13:0.8.0
   │  │                 └─ com.lihaoyi:mill-dev_2.13:0.8.0
   │  └─ com.lihaoyi:ammonite_2.13.2:2.2.0
   │     └─ com.lihaoyi:mill-main-core_2.13:0.8.0
   │        └─ com.lihaoyi:mill-main_2.13:0.8.0
   │           └─ com.lihaoyi:mill-scalalib_2.13:0.8.0
   │              ├─ com.lihaoyi:mill-dev_2.13:0.8.0
   │              ├─ com.lihaoyi:mill-scalajslib_2.13:0.8.0
   │              │  └─ com.lihaoyi:mill-dev_2.13:0.8.0
   │              └─ com.lihaoyi:mill-scalanativelib_2.13:0.8.0
   │                 └─ com.lihaoyi:mill-dev_2.13:0.8.0
   └─ com.lihaoyi:mill-main-core_2.13:0.8.0 org.scalameta:trees_2.13:4.3.7 -> 4.3.20
      └─ com.lihaoyi:mill-main_2.13:0.8.0
         └─ com.lihaoyi:mill-scalalib_2.13:0.8.0
            ├─ com.lihaoyi:mill-dev_2.13:0.8.0
            ├─ com.lihaoyi:mill-scalajslib_2.13:0.8.0
            │  └─ com.lihaoyi:mill-dev_2.13:0.8.0
            └─ com.lihaoyi:mill-scalanativelib_2.13:0.8.0
               └─ com.lihaoyi:mill-dev_2.13:0.8.0
```

After this change you can see that now the desired `4.3.7` is here:
```
❯ cs resolve mill:0.8.0-2-b4e258 --what-depends-on org.scalameta:trees_2.13
  Result:
└─ org.scalameta:trees_2.13:4.3.7
   └─ com.lihaoyi:mill-main-core_2.13:0.8.0-2-b4e258
      └─ com.lihaoyi:mill-main_2.13:0.8.0-2-b4e258
         └─ com.lihaoyi:mill-scalalib_2.13:0.8.0-2-b4e258
            ├─ com.lihaoyi:mill-dev_2.13:0.8.0-2-b4e258
            ├─ com.lihaoyi:mill-scalajslib_2.13:0.8.0-2-b4e258
            │  └─ com.lihaoyi:mill-dev_2.13:0.8.0-2-b4e258
            └─ com.lihaoyi:mill-scalanativelib_2.13:0.8.0-2-b4e258
               └─ com.lihaoyi:mill-dev_2.13:0.8.0-2-b4e258
```

You can find more info about all of this in detail here: https://github.com/coursier/apps/issues/56 thanks to @alexarchambault and his investigative skills.