### PR TITLE
Twirl enhancements

### DIFF
--- a/contrib/playlib/src/mill/playlib/Twirl.scala
+++ b/contrib/playlib/src/mill/playlib/Twirl.scala
@@ -7,21 +7,17 @@ trait Twirl extends TwirlModule with Layout {
 
   override def twirlSources=T.sources{ app() }
 
-  override def twirlAdditionalImports = Seq(
-    "_root_.play.twirl.api.TwirlFeatureImports._",
-    "_root_.play.twirl.api.TwirlHelperImports._",
-    "_root_.play.twirl.api.Html",
-    "_root_.play.twirl.api.JavaScript",
-    "_root_.play.twirl.api.Txt",
-    "_root_.play.twirl.api.Xml",
-    "models._",
-    "controllers._",
-    "play.api.i18n._",
-    "views.html._",
-    "play.api.templates.PlayMagic._",
-    "play.api.mvc._",
-    "play.api.data._"
-  )
+  override def twirlImports = T {
+    super.twirlImports() ++ Seq(
+      "models._",
+      "controllers._",
+      "play.api.i18n._",
+      "views.html._",
+      "play.api.templates.PlayMagic._",
+      "play.api.mvc._",
+      "play.api.data._"
+    )
+  }
 
   def twirlOutput = T{Seq(compileTwirl().classes)}
 

--- a/contrib/twirllib/src/TwirlModule.scala
+++ b/contrib/twirllib/src/TwirlModule.scala
@@ -37,6 +37,8 @@ trait TwirlModule extends mill.Module {
     TwirlWorkerApi.twirlWorker.defaultImports(twirlClasspath().map(_.path))
   }
 
+  def twirlFormats: T[Map[String, String]] = TwirlWorkerApi.twirlWorker.defaultFormats
+
   def twirlConstructorAnnotations: Seq[String] = Nil
 
   def twirlCodec: Codec = Codec(Properties.sourceEncoding)
@@ -50,6 +52,7 @@ trait TwirlModule extends mill.Module {
         twirlSources().map(_.path),
         T.dest,
         twirlImports(),
+        twirlFormats(),
         twirlConstructorAnnotations,
         twirlCodec,
         twirlInclusiveDot)

--- a/contrib/twirllib/src/TwirlModule.scala
+++ b/contrib/twirllib/src/TwirlModule.scala
@@ -33,7 +33,9 @@ trait TwirlModule extends mill.Module {
     )
   }
 
-  def twirlAdditionalImports: Seq[String] = Nil
+  def twirlImports: T[Seq[String]] = T {
+    TwirlWorkerApi.twirlWorker.defaultImports(twirlClasspath().map(_.path))
+  }
 
   def twirlConstructorAnnotations: Seq[String] = Nil
 
@@ -47,7 +49,7 @@ trait TwirlModule extends mill.Module {
         twirlClasspath().map(_.path),
         twirlSources().map(_.path),
         T.dest,
-        twirlAdditionalImports,
+        twirlImports(),
         twirlConstructorAnnotations,
         twirlCodec,
         twirlInclusiveDot)

--- a/contrib/twirllib/test/resources/hello-world-inclusive-dot/core/views/test.scala.svg
+++ b/contrib/twirllib/test/resources/hello-world-inclusive-dot/core/views/test.scala.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"></svg>

--- a/contrib/twirllib/test/resources/hello-world/core/views/test.scala.svg
+++ b/contrib/twirllib/test/resources/hello-world/core/views/test.scala.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"></svg>

--- a/contrib/twirllib/test/src/HelloWorldTests.scala
+++ b/contrib/twirllib/test/src/HelloWorldTests.scala
@@ -21,7 +21,7 @@ object HelloWorldTests extends TestSuite {
   object HelloWorld extends HelloBase {
 
     object core extends HelloWorldModule {
-      override def twirlAdditionalImports: Seq[String] = testAdditionalImports
+      override def twirlImports = super.twirlImports() ++ testAdditionalImports
       override def twirlConstructorAnnotations: Seq[String] = testConstructorAnnotations
     }
 

--- a/contrib/twirllib/test/src/HelloWorldTests.scala
+++ b/contrib/twirllib/test/src/HelloWorldTests.scala
@@ -22,6 +22,7 @@ object HelloWorldTests extends TestSuite {
 
     object core extends HelloWorldModule {
       override def twirlImports = super.twirlImports() ++ testAdditionalImports
+      override def twirlFormats = super.twirlFormats() ++ Map("svg" -> "play.twirl.api.HtmlFormat")
       override def twirlConstructorAnnotations: Seq[String] = testConstructorAnnotations
     }
 
@@ -31,6 +32,7 @@ object HelloWorldTests extends TestSuite {
 
     object core extends HelloWorldModule {
       override def twirlInclusiveDot: Boolean = true
+      override def twirlFormats = super.twirlFormats() ++ Map("svg" -> "play.twirl.api.HtmlFormat")
     }
 
   }
@@ -51,8 +53,9 @@ object HelloWorldTests extends TestSuite {
   }
 
   def compileClassfiles: Seq[os.RelPath] = Seq[os.RelPath](
-    os.rel / "hello.template.scala",
-    os.rel / "wrapper.template.scala"
+    os.rel / 'html / "hello.template.scala",
+    os.rel / 'html / "wrapper.template.scala",
+    os.rel / 'svg / "test.template.scala"
   )
 
   def expectedDefaultImports: Seq[String] = Seq(
@@ -92,14 +95,14 @@ object HelloWorldTests extends TestSuite {
 
       val outputFiles = os.walk(result.classes.path).filter(_.last.endsWith(".scala"))
       val expectedClassfiles = compileClassfiles.map(
-        eval.outPath / 'core / 'compileTwirl / 'dest / 'html / _
+        eval.outPath / 'core / 'compileTwirl / 'dest / _
       )
 
       assert(
         result.classes.path == eval.outPath / 'core / 'compileTwirl / 'dest,
         outputFiles.nonEmpty,
         outputFiles.forall(expectedClassfiles.contains),
-        outputFiles.size == 2,
+        outputFiles.size == 3,
         evalCount > 0,
         outputFiles.forall { p =>
           val lines = os.read.lines(p).map(_.trim)
@@ -124,7 +127,7 @@ object HelloWorldTests extends TestSuite {
 
       val outputFiles = os.walk(result.classes.path).filter(_.last.endsWith(".scala"))
       val expectedClassfiles = compileClassfiles.map( name =>
-        eval.outPath / 'core / 'compileTwirl / 'dest / 'html / name.toString().replace(".template.scala", "$$TwirlInclusiveDot.template.scala")
+        eval.outPath / 'core / 'compileTwirl / 'dest / name / os.RelPath.up / name.last.replace(".template.scala", "$$TwirlInclusiveDot.template.scala")
       )
 
       println(s"outputFiles: $outputFiles")
@@ -133,7 +136,7 @@ object HelloWorldTests extends TestSuite {
         result.classes.path == eval.outPath / 'core / 'compileTwirl / 'dest,
         outputFiles.nonEmpty,
         outputFiles.forall(expectedClassfiles.contains),
-        outputFiles.size == 2,
+        outputFiles.size == 3,
         evalCount > 0,
         outputFiles.filter(_.toString().contains("hello.template.scala")).forall { p =>
           val lines = os.read.lines(p).map(_.trim)


### PR DESCRIPTION
This aims to bring the twirl module closer to parity with the twirl SBT plugin. It adds support for:

- Overriding full set of twirl template imports rather than just appending additional imports onto the default set
  - Renames `twirlAdditionalImports` to `twirlImports`
  - Sets the default value to `play.japi.twirl.compiler.TwirlCompiler.DEFAULT_IMPORTS`
- Overriding set of twirl extensions/formats that will be compiled
  - Adds `def twirlFormats: T[Map[String, String]]` to define a mapping from extension to class name
  - Sets the default value to
    ```scala
    Map(
      "html" -> "play.twirl.api.HtmlFormat",
      "xml" -> "play.twirl.api.XmlFormat",
      "js" -> "play.twirl.api.JavaScriptFormat",
      "txt" -> "play.twirl.api.TxtFormat")
    ```