### PR TITLE
Omit the suffix in artifactName for cross modules

### DIFF
--- a/scalalib/src/MiscModule.scala
+++ b/scalalib/src/MiscModule.scala
@@ -16,6 +16,7 @@ trait CrossModuleBase extends ScalaModule {
   def scalaVersion = T{ crossScalaVersion }
 
   override def millSourcePath = super.millSourcePath / ammonite.ops.up
+  override def artifactName: T[String] = millModuleSegments.parts.init.mkString("-")
   implicit def crossSbtModuleResolver: Resolver[CrossModuleBase] = new Resolver[CrossModuleBase]{
     def resolve[V <: CrossModuleBase](c: Cross[V]): V = {
       crossScalaVersion.split('.')

--- a/scalalib/test/src/HelloWorldTests.scala
+++ b/scalalib/test/src/HelloWorldTests.scala
@@ -492,6 +492,13 @@ object HelloWorldTests extends TestSuite {
       }
     }
 
+    'artifactNameCross - {
+      workspaceTest(CrossHelloWorld) { eval =>
+        val Right((artifactName, _)) = eval.apply(CrossHelloWorld.core("2.13.1").artifactName)
+        assert(artifactName == "core")
+      }
+    }
+
     'runMain - {
       'runMainObject - workspaceTest(HelloWorld){eval =>
         val runResult = eval.outPath / 'core / 'runMain / 'dest / "hello-mill"


### PR DESCRIPTION
Users of mill (including me) struggle with publishing artifacts as soon as they start cross compiling between multiple Scala versions.
By default it will publish `Artifact(org,myproject-2.12.10_2.12,0.0.1-SNAPSHOT)` where we expect something like `Artifact(org,myproject_2.12,0.0.1-SNAPSHOT)`.
Here is an example: https://gitter.im/lihaoyi/mill?at=5f404a975580fa092b15a821

The usual fix is to override the `artifactName` as follows:
```
def artifactName = "myproject"
```

I personally get caught every time I start to cross compile a project and believe that doesn't look reasonable to ask the user to course correct the artifact name.

This proposal removes the added segment part in `artifactName` for `CrossModuleBase`.

cc @davesmith00000