### PR TITLE
Bump coursier to 2.0.0-RC6-25

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -43,7 +43,7 @@ object Deps {
   val ammonite = ivy"com.lihaoyi:::ammonite:2.2.0"
   val scalametaTrees = ivy"org.scalameta::trees:4.3.7"
   val bloopConfig = ivy"ch.epfl.scala::bloop-config:1.4.0-RC1"
-  val coursier = ivy"io.get-coursier::coursier:2.0.0-RC6-15"
+  val coursier = ivy"io.get-coursier::coursier:2.0.0-RC6-25"
   val flywayCore = ivy"org.flywaydb:flyway-core:6.0.1"
   val graphvizJava = ivy"guru.nidi:graphviz-java:0.8.3"
   val ipcsocket = ivy"org.scala-sbt.ipcsocket:ipcsocket:1.0.0"


### PR DESCRIPTION
This version of coursier API includes access to licensing information of dependencies.