### PR TITLE
Do not remove out.js, let linker overwrite existing file

### DIFF
--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -125,7 +125,6 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
     val outputPath = ctx.dest / "out.js"
 
     os.makeDir.all(ctx.dest)
-    os.remove.all(outputPath)
 
     val classpath = runClasspath.map(_.path)
     val sjsirFiles = classpath


### PR DESCRIPTION
Usually during development I run continuous compilation
```
$ ./mill -w webapp.fastOpt
```
and webpack dev server which watches js output for changes and refreshes the page if any.

Webpack dev server doesn't like when the file it is watching disappears. In such cases dev servers fails with an error.

```
ERROR in ../out/client/fastOpt/dest/out.js
Module build failed (from ./node_modules/react-hot-loader/webpack.js):
Error: ENOENT: no such file or directory, open '/workspace/webapp/out/client/fastOpt/dest/out.js'
```
