### PR TITLE
Add support for Scala 3

### DIFF
--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -51,9 +51,9 @@ object CompilationResult {
 case class CompilationResult(analysisFile: os.Path, classes: PathRef)
 
 object Util {
-  def isDotty0(scalaVersion: String) = scalaVersion.startsWith("0.")
-  def isDotty3(scalaVersion: String) = scalaVersion.startsWith("3.")
-  def isDotty(scalaVersion: String) = isDotty0(scalaVersion) || isDotty3(scalaVersion)
+  def isDotty(scalaVersion: String) = scalaVersion.startsWith("0.")
+  def isScala3(scalaVersion: String) = scalaVersion.startsWith("3.")
+  def isDottyOrScala3(scalaVersion: String) = isDotty(scalaVersion) || isScala3(scalaVersion)
 
   // eg, grepJar(classPath, name = "scala-library", versionPrefix = "2.13.")
   // return first path in `classPath` that match:

--- a/scalalib/api/src/ZincWorkerApi.scala
+++ b/scalalib/api/src/ZincWorkerApi.scala
@@ -51,9 +51,9 @@ object CompilationResult {
 case class CompilationResult(analysisFile: os.Path, classes: PathRef)
 
 object Util {
-  def isDotty(scalaVersion: String) =
-    scalaVersion.startsWith("0.") ||
-    scalaVersion.startsWith("3.")
+  def isDotty0(scalaVersion: String) = scalaVersion.startsWith("0.")
+  def isDotty3(scalaVersion: String) = scalaVersion.startsWith("3.")
+  def isDotty(scalaVersion: String) = isDotty0(scalaVersion) || isDotty3(scalaVersion)
 
   // eg, grepJar(classPath, name = "scala-library", versionPrefix = "2.13.")
   // return first path in `classPath` that match:
@@ -82,7 +82,8 @@ object Util {
   val PartialVersion = raw"""(\d+)\.(\d+)\.*""".r
   val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
   val MinorSnapshotVersion = raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
-  val DottyVersion = raw"""(0|3)\.(\d+)\.(\d+).*""".r
+  val DottyVersion = raw"""0\.(\d+)\.(\d+).*""".r
+  val Scala3Version = raw"""3\.(\d+)\.(\d+)-(\w+).*""".r
   val DottyNightlyVersion = raw"""(0|3)\.(\d+)\.(\d+)-bin-(.*)-NIGHTLY""".r
   val TypelevelVersion = raw"""(\d+)\.(\d+)\.(\d+)-bin-typelevel.*""".r
 
@@ -90,7 +91,8 @@ object Util {
   def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
       case ReleaseVersion(major, minor, _) => s"$major.$minor"
       case MinorSnapshotVersion(major, minor, _) => s"$major.$minor"
-      case DottyVersion("0", minor, _) => s"0.$minor"
+      case DottyVersion(minor, _) => s"0.$minor"
+      case Scala3Version(minor, patch, milestone) => s"3.$minor.$patch-$milestone"
       case TypelevelVersion(major, minor, _) => s"$major.$minor"
       case _ => scalaVersion
   }
@@ -140,7 +142,8 @@ object Util {
   /** @return true if the compiler bridge can be downloaded as an already compiled jar */
   def isBinaryBridgeAvailable(scalaVersion: String) = scalaVersion match {
       case DottyNightlyVersion(major, minor, _, _) => major.toInt > 0 || minor.toInt >= 14 // 0.14.0-bin or more (not 0.13.0-bin)
-      case DottyVersion(major, minor, _) => major.toInt > 0 || minor.toInt >= 13 // 0.13.0-RC1 or more
+      case DottyVersion(minor, _) => minor.toInt >= 13 // 0.13.0-RC1 or more
+      case Scala3Version(_, _, _) => true
       case _ => false
   }
 }

--- a/scalalib/src/Dep.scala
+++ b/scalalib/src/Dep.scala
@@ -5,7 +5,7 @@ import upickle.default.{macroRW, ReadWriter => RW}
 import CrossVersion._
 
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
-  import mill.scalalib.api.Util.{isDotty, DottyVersion, Scala3Version}
+  import mill.scalalib.api.Util.{isDottyOrScala3, DottyVersion, Scala3Version}
 
   def artifactName(binaryVersion: String, fullVersion: String, platformSuffix: String) = {
     val suffix = cross.suffixString(binaryVersion, fullVersion, platformSuffix)
@@ -54,7 +54,7 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
     */
   def withDottyCompat(scalaVersion: String): Dep =
     cross match {
-      case cross: Binary if isDotty(scalaVersion) =>
+      case cross: Binary if isDottyOrScala3(scalaVersion) =>
         val compatSuffix =
           scalaVersion match {
             case Scala3Version(_, _, _) =>

--- a/scalalib/src/Dep.scala
+++ b/scalalib/src/Dep.scala
@@ -5,7 +5,7 @@ import upickle.default.{macroRW, ReadWriter => RW}
 import CrossVersion._
 
 case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
-  import mill.scalalib.api.Util.{isDotty, DottyVersion}
+  import mill.scalalib.api.Util.{isDotty, DottyVersion, Scala3Version}
 
   def artifactName(binaryVersion: String, fullVersion: String, platformSuffix: String) = {
     val suffix = cross.suffixString(binaryVersion, fullVersion, platformSuffix)
@@ -57,9 +57,9 @@ case class Dep(dep: coursier.Dependency, cross: CrossVersion, force: Boolean) {
       case cross: Binary if isDotty(scalaVersion) =>
         val compatSuffix =
           scalaVersion match {
-            case DottyVersion("3", _) =>
+            case Scala3Version(_, _, _) =>
               "_2.13"
-            case DottyVersion("0", minor, patch) =>
+            case DottyVersion(minor, patch) =>
               if (minor.toInt > 18 || minor.toInt == 18 && patch.toInt >= 1)
                 "_2.13"
               else

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -70,9 +70,13 @@ object Lib{
     )
   }
   def scalaCompilerIvyDeps(scalaOrganization: String, scalaVersion: String) =
-    if (mill.scalalib.api.Util.isDotty(scalaVersion))
+    if (mill.scalalib.api.Util.isDotty0(scalaVersion))
       Agg(
         ivy"$scalaOrganization::dotty-compiler:$scalaVersion".forceVersion()
+      )
+    else if (mill.scalalib.api.Util.isDotty3(scalaVersion))
+      Agg(
+        ivy"$scalaOrganization::scala3-compiler:$scalaVersion".forceVersion()
       )
     else
       Agg(
@@ -81,19 +85,29 @@ object Lib{
       )
 
   def scalaDocIvyDeps(scalaOrganization: String, scalaVersion: String) =
-    if (mill.scalalib.api.Util.isDotty(scalaVersion))
+    if (mill.scalalib.api.Util.isDotty0(scalaVersion))
       Agg(
         ivy"$scalaOrganization::dotty-doc:$scalaVersion".forceVersion()
+      )
+    else if (mill.scalalib.api.Util.isDotty3(scalaVersion))
+      Agg(
+        ivy"$scalaOrganization::scala3-doc:$scalaVersion".forceVersion()
       )
     else
       // in Scala <= 2.13, the scaladoc tool is included in the compiler
       scalaCompilerIvyDeps(scalaOrganization, scalaVersion)
 
   def scalaRuntimeIvyDeps(scalaOrganization: String, scalaVersion: String) =
-    if (mill.scalalib.api.Util.isDotty(scalaVersion))
+    if (mill.scalalib.api.Util.isDotty0(scalaVersion)) {
       Agg(
         // note that dotty-library has a binary version suffix, hence the :: is necessary here
         ivy"$scalaOrganization::dotty-library:$scalaVersion".forceVersion()
+      )
+    }
+    else if (mill.scalalib.api.Util.isDotty3(scalaVersion))
+      Agg(
+        // note that dotty-library has a binary version suffix, hence the :: is necessary here
+        ivy"$scalaOrganization::scala3-library:$scalaVersion".forceVersion()
       )
     else
       Agg(

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -70,11 +70,11 @@ object Lib{
     )
   }
   def scalaCompilerIvyDeps(scalaOrganization: String, scalaVersion: String) =
-    if (mill.scalalib.api.Util.isDotty0(scalaVersion))
+    if (mill.scalalib.api.Util.isDotty(scalaVersion))
       Agg(
         ivy"$scalaOrganization::dotty-compiler:$scalaVersion".forceVersion()
       )
-    else if (mill.scalalib.api.Util.isDotty3(scalaVersion))
+    else if (mill.scalalib.api.Util.isScala3(scalaVersion))
       Agg(
         ivy"$scalaOrganization::scala3-compiler:$scalaVersion".forceVersion()
       )
@@ -85,11 +85,11 @@ object Lib{
       )
 
   def scalaDocIvyDeps(scalaOrganization: String, scalaVersion: String) =
-    if (mill.scalalib.api.Util.isDotty0(scalaVersion))
+    if (mill.scalalib.api.Util.isDotty(scalaVersion))
       Agg(
         ivy"$scalaOrganization::dotty-doc:$scalaVersion".forceVersion()
       )
-    else if (mill.scalalib.api.Util.isDotty3(scalaVersion))
+    else if (mill.scalalib.api.Util.isScala3(scalaVersion))
       Agg(
         ivy"$scalaOrganization::scala3-doc:$scalaVersion".forceVersion()
       )
@@ -98,13 +98,13 @@ object Lib{
       scalaCompilerIvyDeps(scalaOrganization, scalaVersion)
 
   def scalaRuntimeIvyDeps(scalaOrganization: String, scalaVersion: String) =
-    if (mill.scalalib.api.Util.isDotty0(scalaVersion)) {
+    if (mill.scalalib.api.Util.isDotty(scalaVersion)) {
       Agg(
         // note that dotty-library has a binary version suffix, hence the :: is necessary here
         ivy"$scalaOrganization::dotty-library:$scalaVersion".forceVersion()
       )
     }
-    else if (mill.scalalib.api.Util.isDotty3(scalaVersion))
+    else if (mill.scalalib.api.Util.isScala3(scalaVersion))
       Agg(
         // note that dotty-library has a binary version suffix, hence the :: is necessary here
         ivy"$scalaOrganization::scala3-library:$scalaVersion".forceVersion()

--- a/scalalib/src/ScalaModule.scala
+++ b/scalalib/src/ScalaModule.scala
@@ -6,7 +6,7 @@ import mill.define.{Command, Target, Task, TaskModule}
 import mill.eval.{PathRef, Result}
 import mill.modules.Jvm
 import mill.modules.Jvm.createJar
-import mill.scalalib.api.Util.isDotty
+import mill.scalalib.api.Util.{ isDotty, isDotty0, isDotty3 }
 import Lib._
 import mill.api.Loose.Agg
 import mill.api.DummyInputStream
@@ -29,7 +29,7 @@ trait ScalaModule extends JavaModule { outer =>
     * @return
     */
   def scalaOrganization: T[String] = T {
-    if (isDotty(scalaVersion()))
+    if (isDotty0(scalaVersion()))
       "ch.epfl.lamp"
     else
       "org.scala-lang"
@@ -55,8 +55,10 @@ trait ScalaModule extends JavaModule { outer =>
 
   override def mapDependencies = T.task{ d: coursier.Dependency =>
     val artifacts =
-      if (isDotty(scalaVersion()))
+      if (isDotty0(scalaVersion()))
         Set("dotty-library", "dotty-compiler")
+      else if (isDotty3(scalaVersion()))
+        Set("scala3-library", "scala3-compiler")
       else
         Set("scala-library", "scala-compiler", "scala-reflect")
     if (!artifacts(d.module.name.value)) d

--- a/scalalib/src/ZincWorkerModule.scala
+++ b/scalalib/src/ZincWorkerModule.scala
@@ -5,7 +5,7 @@ import mill.T
 import mill.api.{Ctx, FixSizedCache, KeyedLockedCache}
 import mill.define.{Command, Discover, ExternalModule, Worker}
 import mill.scalalib.Lib.resolveDependencies
-import mill.scalalib.api.Util.{isBinaryBridgeAvailable, isDotty}
+import mill.scalalib.api.Util.{isBinaryBridgeAvailable, isDotty, isDotty0}
 import mill.scalalib.api.ZincWorkerApi
 import mill.util.JsonFormatters._
 
@@ -83,7 +83,9 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
     val (bridgeDep, bridgeName, bridgeVersion) =
       if (isDotty(scalaVersion0)) {
         val org = scalaOrganization
-        val name = "dotty-sbt-bridge"
+        val name =
+          if (isDotty0(scalaVersion0)) "dotty-sbt-bridge"
+          else "scala3-sbt-bridge"
         val version = scalaVersion
         (ivy"$org:$name:$version", name, version)
       } else {

--- a/scalalib/src/ZincWorkerModule.scala
+++ b/scalalib/src/ZincWorkerModule.scala
@@ -5,7 +5,7 @@ import mill.T
 import mill.api.{Ctx, FixSizedCache, KeyedLockedCache}
 import mill.define.{Command, Discover, ExternalModule, Worker}
 import mill.scalalib.Lib.resolveDependencies
-import mill.scalalib.api.Util.{isBinaryBridgeAvailable, isDotty, isDotty0}
+import mill.scalalib.api.Util.{isBinaryBridgeAvailable, isDottyOrScala3, isDotty}
 import mill.scalalib.api.ZincWorkerApi
 import mill.util.JsonFormatters._
 
@@ -81,10 +81,10 @@ trait ZincWorkerModule extends mill.Module with OfflineSupportModule { self: Cou
     }
 
     val (bridgeDep, bridgeName, bridgeVersion) =
-      if (isDotty(scalaVersion0)) {
+      if (isDottyOrScala3(scalaVersion0)) {
         val org = scalaOrganization
         val name =
-          if (isDotty0(scalaVersion0)) "dotty-sbt-bridge"
+          if (isDotty(scalaVersion0)) "dotty-sbt-bridge"
           else "scala3-sbt-bridge"
         val version = scalaVersion
         (ivy"$org:$name:$version", name, version)

--- a/scalalib/worker/src/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/ZincWorkerImpl.scala
@@ -9,7 +9,7 @@ import java.util.jar.JarFile
 
 import mill.api.Loose.Agg
 import mill.api.{BuildProblemReporter, IO, Info, KeyedLockedCache, PathRef, Problem, ProblemPosition, Severity, Warn}
-import mill.scalalib.api.Util.{grepJar, isDotty, scalaBinaryVersion}
+import mill.scalalib.api.Util.{grepJar, isDotty, isDotty0, isDotty3, scalaBinaryVersion}
 import mill.scalalib.api.{CompilationResult, ZincWorkerApi}
 import sbt.internal.inc._
 import sbt.internal.util.{ConsoleAppender, ConsoleLogger, ConsoleOut, MainAppender}
@@ -343,8 +343,10 @@ class ZincWorkerImpl(compilerBridge: Either[
 
     compilerCache.withCachedValue(compilersSig){
       val compilerJar =
-        if (isDotty(scalaVersion))
+        if (isDotty0(scalaVersion))
           grepJar(compilerClasspath, s"dotty-compiler_${scalaBinaryVersion(scalaVersion)}", scalaVersion)
+        else if (isDotty3(scalaVersion))
+          grepJar(compilerClasspath, s"scala3-compiler_${scalaBinaryVersion(scalaVersion)}", scalaVersion)
         else
           compilerJarNameGrep(compilerClasspath, scalaVersion)
 

--- a/scalalib/worker/src/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/ZincWorkerImpl.scala
@@ -9,7 +9,7 @@ import java.util.jar.JarFile
 
 import mill.api.Loose.Agg
 import mill.api.{BuildProblemReporter, IO, Info, KeyedLockedCache, PathRef, Problem, ProblemPosition, Severity, Warn}
-import mill.scalalib.api.Util.{grepJar, isDotty, isDotty0, isDotty3, scalaBinaryVersion}
+import mill.scalalib.api.Util.{grepJar, isDotty, isDottyOrScala3, isScala3, scalaBinaryVersion}
 import mill.scalalib.api.{CompilationResult, ZincWorkerApi}
 import sbt.internal.inc._
 import sbt.internal.util.{ConsoleAppender, ConsoleLogger, ConsoleOut, MainAppender}
@@ -115,7 +115,7 @@ class ZincWorkerImpl(compilerBridge: Either[
       compilerClasspath,
       scalacPluginClasspath
     ) { compilers: Compilers =>
-      if (isDotty(scalaVersion)) {
+      if (isDottyOrScala3(scalaVersion)) {
         val dottydocClass = compilers.scalac().scalaInstance().loader().loadClass("dotty.tools.dottydoc.DocDriver")
         val dottydocMethod = dottydocClass.getMethod("process", classOf[Array[String]])
         val reporter = dottydocMethod.invoke(dottydocClass.newInstance(), args.toArray)
@@ -160,7 +160,7 @@ class ZincWorkerImpl(compilerBridge: Either[
       (Seq("javac") ++ argsArray).!
     } else if (allScala) {
       val compilerMain = classloader.loadClass(
-        if (isDotty(scalaVersion)) "dotty.tools.dotc.Main"
+        if (isDottyOrScala3(scalaVersion)) "dotty.tools.dotc.Main"
         else "scala.tools.nsc.Main"
       )
       compilerMain
@@ -343,9 +343,9 @@ class ZincWorkerImpl(compilerBridge: Either[
 
     compilerCache.withCachedValue(compilersSig){
       val compilerJar =
-        if (isDotty0(scalaVersion))
+        if (isDotty(scalaVersion))
           grepJar(compilerClasspath, s"dotty-compiler_${scalaBinaryVersion(scalaVersion)}", scalaVersion)
-        else if (isDotty3(scalaVersion))
+        else if (isScala3(scalaVersion))
           grepJar(compilerClasspath, s"scala3-compiler_${scalaBinaryVersion(scalaVersion)}", scalaVersion)
         else
           compilerJarNameGrep(compilerClasspath, scalaVersion)
@@ -357,7 +357,7 @@ class ZincWorkerImpl(compilerBridge: Either[
           compilerClasspath,
           // we don't support too outdated dotty versions
           // and because there will be no scala 2.14, so hardcode "2.13." here is acceptable
-          if (isDotty(scalaVersion)) "2.13." else scalaVersion
+          if (isDottyOrScala3(scalaVersion)) "2.13." else scalaVersion
         ).toIO,
         compilerJar = compilerJar.toIO,
         allJars = combinedCompilerJars,


### PR DESCRIPTION
This PR is a blocker for lampepfl/dotty#9917. We have a bunch of libraries compiled with Mill in the Dotty community build, and we'd rather not disable them during the artefacts naming change.

@lihaoyi what's the policy on the Mill nightly builds? How soon will we be able to use this change in a nightly build once this is merged?