### PR TITLE
Redirect zinc log output to stderr

### DIFF
--- a/scalalib/worker/src/ZincWorkerImpl.scala
+++ b/scalalib/worker/src/ZincWorkerImpl.scala
@@ -384,7 +384,7 @@ class ZincWorkerImpl(compilerBridge: Either[
 
     val consoleAppender = ConsoleAppender(
       "ZincLogAppender",
-      ConsoleOut.printStreamOut(ctx.log.outputStream),
+      ConsoleOut.printStreamOut(ctx.log.errorStream),
       ctx.log.colored,
       ctx.log.colored,
       _ => None


### PR DESCRIPTION
The compiler output is a diagnostic message and should hence be printed to stderr.

This also allows users to redirect output when running applications directly from mill, without including any diagnostic information. E.g.

```
mill foo.run > out.txt
```