### PR TITLE
Allow test classes with constructor parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ output/
 .DS_STORE
 .idea_modules
 .idea
+.vscode/
 out/
 /.bloop/
 /.metals/

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -133,7 +133,7 @@ object Lib{
       else listClassFiles(base).flatMap { path =>
         val cls = cl.loadClass(path.stripSuffix(".class").replace('/', '.'))
         val publicConstructorCount =
-          cls.getConstructors.count(c => c.getParameterCount == 0 && Modifier.isPublic(c.getModifiers))
+          cls.getConstructors.count(c => Modifier.isPublic(c.getModifiers))
 
         if (Modifier.isAbstract(cls.getModifiers) || cls.isInterface || publicConstructorCount > 1) {
           None


### PR DESCRIPTION
This PR removes a filter from the test discovery that ignores classes that have parameters in their constructor. I think this is problematic as it is perfectly valid for tests to have constructor parameters depending on the test framework, and so this should be a decision made by the testing framework rather than the build tool.

Here's an example where I encountered this issue recently: https://github.com/disneystreaming/weaver-test/issues/113. After running these tests again with the changes made in this PR the example tests shown in that issue now pass.

I've attempted to verify that these changes are compatible with other test frameworks. With some fairly basic examples uTest and Scalatest both seem to continue to work as expected. I'd be happy to verify the changes against other test frameworks if you have any further suggestions.

Thanks