### PR TITLE
Add AWS Codeartifact contrib module

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -483,6 +483,10 @@ object contrib extends MillModule {
     override def compileModuleDeps = Seq(scalalib)
   }
 
+  object codeartifact extends MillModule {
+    override def compileModuleDeps = Seq(scalalib)
+  }
+
   object versionfile extends MillModule {
     override def compileModuleDeps = Seq(scalalib)
   }

--- a/contrib/codeartifact/src/mill/contrib/codeartifact/CodeArtifactPublisher.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/CodeArtifactPublisher.scala
@@ -1,0 +1,123 @@
+package mill.contrib.codeartifact
+
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
+
+import mill.api.Logger
+import mill.scalalib.publish.Artifact
+
+class CodeartifactPublisher(
+    releaseUri: String,
+    snapshotUri: String,
+    credentials: String,
+    readTimeout: Int,
+    connectTimeout: Int,
+    log: Logger
+) {
+  private val api = new CodeartifactHttpApi(
+    credentials,
+    readTimeout = readTimeout,
+    connectTimeout = connectTimeout
+  )
+
+  private def basePublishPath(artifact: Artifact) =
+    Seq(
+      artifact.group.replace(".", "/"),
+      artifact.id
+    ).mkString("/")
+
+  private def versionPublishPath(artifact: Artifact) =
+    s"${basePublishPath(artifact)}/${artifact.version}"
+
+  def publish(fileMapping: Seq[(os.Path, String)], artifact: Artifact): Unit = {
+    publishAll(fileMapping -> artifact)
+  }
+
+  private def currentTimeNumber() =
+    DateTimeFormatter
+      .ofPattern("yyyyMMddHHmmss")
+      .withZone(ZoneId.systemDefault())
+      .format(Instant.now())
+
+  private def mavenMetadata(artifact: Artifact) =
+    <metadata modelVersion="1.1.0">
+      <groupId>{artifact.group}</groupId>
+      <artifactId>{artifact.id}</artifactId>
+      <versioning>
+        <latest>{artifact.version}</latest>
+        <release>{artifact.version}</release>
+        <versions>
+          <version>{artifact.version}</version>
+        </versions>
+        <lastUpdated>{currentTimeNumber()}</lastUpdated>
+      </versioning>
+    </metadata>
+
+  def publishAll(artifacts: (Seq[(os.Path, String)], Artifact)*): Unit = {
+    log.info("arts: " + artifacts)
+    val mappings = for ((fileMapping0, artifact) <- artifacts) yield {
+      val publishPath = versionPublishPath(artifact)
+      val fileMapping = fileMapping0.map {
+        case (file, name) => (file, publishPath + "/" + name)
+      }
+
+      artifact -> fileMapping.map {
+        case (file, name) => name -> os.read.bytes(file)
+      }
+    }
+
+    val (snapshots, releases) = mappings.partition(_._1.isSnapshot)
+
+    if (snapshots.nonEmpty) {
+      publishToRepo(snapshotUri, snapshots.flatMap(_._2), snapshots.map(_._1))
+
+      val artifact = snapshots.head._1
+      api.upload(
+        s"$snapshotUri/${basePublishPath(artifact)}/maven-metadata.xml",
+        mavenMetadata(artifact).buildString(true).toArray.map(_.toByte)
+      )
+    }
+    if (releases.nonEmpty) {
+      publishToRepo(releaseUri, releases.flatMap(_._2), releases.map(_._1))
+
+      val artifact = releases.head._1
+      api.upload(
+        s"$releaseUri/${basePublishPath(artifact)}/maven-metadata.xml",
+        mavenMetadata(artifact).buildString(true).toArray.map(_.toByte)
+      )
+    }
+  }
+
+  private def publishToRepo(
+      repoUri: String,
+      payloads: Seq[(String, Array[Byte])],
+      artifacts: Seq[Artifact]
+  ): Unit = {
+    val publishResults = payloads.map {
+      case (fileName, data) =>
+        log.info(s"Uploading $fileName")
+        val resp = api.upload(s"$repoUri/$fileName", data)
+        resp
+    }
+    reportPublishResults(publishResults, artifacts)
+  }
+
+  private def reportPublishResults(
+      publishResults: Seq[requests.Response],
+      artifacts: Seq[Artifact]
+  ) = {
+    if (publishResults.forall(_.is2xx)) {
+      log.info(
+        s"Published ${artifacts.map(_.id).mkString(", ")} to AWS Codeartifact"
+      )
+    } else {
+      val errors = publishResults.filterNot(_.is2xx).map { response =>
+        s"Code: ${response.statusCode}, message: ${response.text()}"
+      }
+      throw new RuntimeException(
+        s"Failed to publish ${artifacts.map(_.id).mkString(", ")} to AWS Codeartifact. Errors: \n${errors
+          .mkString("\n")}"
+      )
+    }
+  }
+}

--- a/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactHttpApi.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactHttpApi.scala
@@ -1,0 +1,28 @@
+package mill.contrib.codeartifact
+
+import scala.concurrent.duration._
+
+class CodeartifactHttpApi(
+    credentials: String,
+    readTimeout: Int,
+    connectTimeout: Int
+) {
+  val http = requests.Session(
+    readTimeout = readTimeout,
+    connectTimeout = connectTimeout,
+    maxRedirects = 0,
+    check = false
+  )
+
+  private val uploadTimeout = 5.minutes.toMillis.toInt
+
+  def upload(uri: String, data: Array[Byte]): requests.Response = {
+    http.put(
+      uri,
+      readTimeout = uploadTimeout,
+      headers = Seq("Content-Type" -> "application/octet-stream"),
+      auth = new requests.RequestAuth.Basic("aws", credentials),
+      data = data
+    )
+  }
+}

--- a/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
+++ b/contrib/codeartifact/src/mill/contrib/codeartifact/CodeartifactPublishModule.scala
@@ -1,0 +1,65 @@
+package mill.contrib.codeartifact
+
+import mill._, scalalib._, define.ExternalModule, publish.Artifact
+
+trait CodeartifactPublishModule extends PublishModule {
+  def codeartifactUri: String
+
+  def codeartifactSnapshotUri: String
+
+  def publishCodeartifact(
+      credentials: String,
+      publish: Boolean = true,
+      codeartifactUri: String = codeartifactUri,
+      codeartifactSnapshotUri: String = codeartifactSnapshotUri,
+      readTimeout: Int = 60000,
+      connectTimeout: Int = 5000
+  ): define.Command[Unit] =
+    T.command {
+      val PublishModule.PublishData(artifactInfo, artifacts) =
+        publishArtifacts()
+
+      new CodeartifactPublisher(
+        codeartifactUri,
+        codeartifactSnapshotUri,
+        credentials,
+        readTimeout,
+        connectTimeout,
+        T.log
+      ).publish(artifacts.map { case (a, b) => (a.path, b) }, artifactInfo)
+    }
+}
+
+object CodeartifactPublishModule extends ExternalModule {
+  def publishAll(
+      credentials: String,
+      codeartifactUri: String,
+      codeartifactSnapshotUri: String,
+      publishArtifacts: mill.main.Tasks[PublishModule.PublishData],
+      readTimeout: Int = 60000,
+      connectTimeout: Int = 5000
+  ) =
+    T.command {
+
+      val x: Seq[(Seq[(os.Path, String)], Artifact)] =
+        T.sequence(publishArtifacts.value)().map {
+          case PublishModule.PublishData(a, s) =>
+            (s.map { case (p, f) => (p.path, f) }, a)
+        }
+      new CodeartifactPublisher(
+        codeartifactUri,
+        codeartifactSnapshotUri,
+        credentials,
+        readTimeout,
+        connectTimeout,
+        T.log
+      ).publishAll(
+        x: _*
+      )
+    }
+
+  implicit def millScoptTargetReads[T] = new mill.main.Tasks.Scopt[T]()
+
+  lazy val millDiscover: mill.define.Discover[this.type] =
+    mill.define.Discover[this.type]
+}

--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -207,7 +207,7 @@ object mymodule extends CodeartifactPublishModule {
 
 Then in your terminal:
 ```
-export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain domain-name --domain-owner domain-owner-id --query authorizationToken --output text --profile profile-name`
+$ export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain domain-name --domain-owner domain-owner-id --query authorizationToken --output text --profile profile-name`
 $ mill mymodule.publishCodeartifact --credentials '$CODEARTIFACT_AUTH_TOKEN'
 ```
 

--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -188,6 +188,28 @@ mill mill.bsp.BSP/install
 being thrown during the evaluation of tasks, a bug not easy to reproduce.
 In this case it is recommended to refresh the bsp project.
 
+## Codeartifact
+
+This plugin allows publishing to AWS Codeartifact.
+
+### Quickstart
+```scala
+import $ivy.`com.lihaoyi::mill-contrib-codeartifact:$MILL_VERSION`
+import mill.contrib.codeartifact.CodeartifactPublishModule
+
+object mymodule extends CodeartifactPublishModule {
+  def codeartifactUri: String = "https://domain-name-domain-owner-id.d.codeartifact.region.amazonaws.com/maven/repo-name"
+  def codeartifactSnapshotUri: String = "https://domain-name-domain-owner-id.d.codeartifact.region.amazonaws.com/maven/snapshot-repo-name"
+
+  ...
+}
+```
+
+Then in your terminal:
+```
+export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain domain-name --domain-owner domain-owner-id --query authorizationToken --output text --profile profile-name`
+$ mill mymodule.publishCodeartifact --credentials '$CODEARTIFACT_AUTH_TOKEN'
+```
 
 ## Docker
 


### PR DESCRIPTION
This allows Mill projects to deploy to AWS Codeartifact. It functions similarly to the Artifactory PublishModule. Its credentials value is a Codeartifact auth token.