### PR TITLE
Move `Bloop` object into mill.contrib.bloop package

### DIFF
--- a/contrib/bloop/src/mill/contrib/Bloop.scala
+++ b/contrib/bloop/src/mill/contrib/Bloop.scala
@@ -1,10 +1,7 @@
 package mill.contrib
 
 import mill.eval.Evaluator
-import os.pwd
 import mill.contrib.bloop.BloopImpl
 
-/**
-  * Usage : `mill mill.contrib.Bloop/install`
-  */
-object Bloop extends BloopImpl(Evaluator.currentEvaluator.get, pwd)
+@deprecated("Use mill.contrib.bloop.Bloop instead", since = "> 0.8.0")
+object Bloop extends BloopImpl(Evaluator.currentEvaluator.get, os.pwd)

--- a/contrib/bloop/src/mill/contrib/bloop/Bloop.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/Bloop.scala
@@ -1,0 +1,8 @@
+package mill.contrib.bloop
+
+import mill.eval.Evaluator
+
+/**
+  * Usage : `mill mill.contrib.bloop.Bloop/install`
+  */
+object Bloop extends BloopImpl(Evaluator.currentEvaluator.get, os.pwd)

--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -15,7 +15,7 @@ import os.pwd
 
 /**
   * Implementation of the Bloop related tasks. Inherited by the
-  * `mill.contrib.Bloop` object, and usable in tests by passing
+  * `mill.contrib.bloop.Bloop` object, and usable in tests by passing
   * a custom evaluator.
   */
 class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>

--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -104,7 +104,7 @@ import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
 Then in your terminal :
 
 ```
-> mill mill.contrib.Bloop/install
+> mill mill.contrib.bloop.Bloop/install
 ```
 
 It generate correct bloop config for any `JavaModule`, `ScalaModule`,
@@ -119,7 +119,7 @@ the deserialised configuration for that particular module:
 // build.sc
 import mill._
 import mill.scalalib._
-import mill.contrib.Bloop
+import mill.contrib.bloop.Bloop
 
 object MyModule extends ScalaModule with Bloop.Module {
   def myTask = T { bloop.config() }


### PR DESCRIPTION
We want to avoid package split situations.