### PR TITLE
Bloop: Also use compileModuleDeps to calc transitive classpath

### DIFF
--- a/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
+++ b/contrib/bloop/src/mill/contrib/bloop/BloopImpl.scala
@@ -380,9 +380,9 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
       .map(_.map(_.path).toSeq)
 
     def transitiveClasspath(m: JavaModule): Task[Seq[Path]] = T.task {
-      m.moduleDeps.map(classes) ++
+      (m.moduleDeps ++ m.compileModuleDeps).map(classes) ++
         m.unmanagedClasspath().map(_.path) ++
-        Task.traverse(m.moduleDeps)(transitiveClasspath)().flatten
+        Task.traverse(m.moduleDeps ++ m.compileModuleDeps)(transitiveClasspath)().flatten
     }
 
     val classpath = T
@@ -407,7 +407,7 @@ class BloopImpl(ev: () => Evaluator, wd: Path) extends ExternalModule { outer =>
         directory = module.millSourcePath.toNIO,
         workspaceDir = Some(wd.toNIO),
         sources = mSources,
-        dependencies = module.moduleDeps.map(name).toList,
+        dependencies = (module.moduleDeps ++ module.compileModuleDeps).map(name).toList,
         classpath = classpath().map(_.toNIO).toList,
         out = out(module).toNIO,
         classesDir = classes(module).toNIO,


### PR DESCRIPTION
Attempt to fix https://github.com/lihaoyi/mill/issues/990