### PR TITLE
Adds ScoverageReport for multi-module projects

### DIFF
--- a/contrib/scoverage/src/ScoverageReport.scala
+++ b/contrib/scoverage/src/ScoverageReport.scala
@@ -1,0 +1,106 @@
+package mill.contrib.scoverage
+
+import mill.contrib.scoverage.api.ScoverageReportWorkerApi.ReportType
+import mill.define.{Command, Module, Task}
+import mill.eval.Evaluator
+import mill.main.RunScript
+import mill.{PathRef, T}
+import os.Path
+
+/** Allows the aggregation of coverage reports across multi-module projects.
+ *
+ * Once tests have been run across all modules, this collects reports from
+ * all modules that extend [[mill.contrib.scoverage.ScoverageModule]]. Simply
+ * define a module that extends [[mill.contrib.scoverage.ScoverageReport]] and
+ * call one of the available "report all" functions.
+ *
+ * For example, define the following `scoverage` module and use the relevant
+ * reporting option to generate a report:
+ * {{{
+ * object scoverage extends ScoverageReport {
+ *   override def scalaVersion     = "<scala-version>"
+ *   override def scoverageVersion = "<scoverage-version>"
+ * }
+ * }}}
+ *
+ * - mill __.test                     # run tests for all modules
+ * - mill scoverage.htmlReportAll     # generates report in html format for all modules
+ * - mill scoverage.xmlReportAll      # generates report in xml format for all modules
+ * - mill scoverage.consoleReportAll  # reports to the console for all modules
+ *
+ * The aggregated report will be available at either `out/scoverage/htmlReportAll/dest/`
+ * for html reports or `out/scoverage/xmlReportAll/dest/` for xml reports.
+ */
+trait ScoverageReport extends Module {
+  outer =>
+  def scalaVersion: T[String]
+
+  def scoverageVersion: T[String]
+
+  def scoverageReportWorkerModule: ScoverageReportWorker.type = ScoverageReportWorker
+
+  /** We use this only to get access to the right classpaths */
+  object workerModule extends ScoverageModule {
+    override def scalaVersion = outer.scalaVersion
+
+    override def scoverageVersion = outer.scoverageVersion
+  }
+
+  /** Generates report in html format for all modules */
+  def htmlReportAll(
+    evaluator: Evaluator,
+    sources: String     = "__.allSources",
+    dataTargets: String = "__.scoverage.data"
+  ): Command[PathRef] = T.command {
+    reportTask(evaluator, ReportType.Html, sources, dataTargets)()
+  }
+
+  /** Generates report in xml format for all modules */
+  def xmlReportAll(
+    evaluator: Evaluator,
+    sources: String     = "__.allSources",
+    dataTargets: String = "__.scoverage.data"
+  ): Command[PathRef] = T.command {
+    reportTask(evaluator, ReportType.Xml, sources, dataTargets)()
+  }
+
+  /** Reports to the console for all modules */
+  def consoleReportAll(
+    evaluator: Evaluator,
+    sources: String     = "__.allSources",
+    dataTargets: String = "__.scoverage.data"
+  ): Command[PathRef] = T.command {
+    reportTask(evaluator, ReportType.Console, sources, dataTargets)()
+  }
+
+  def reportTask(evaluator: Evaluator, reportType: ReportType, sources: String, dataTargets: String): Task[PathRef] = {
+    val sourcesTasks: Seq[Task[Seq[PathRef]]] = RunScript.resolveTasks(
+      mill.main.ResolveTasks,
+      evaluator,
+      Seq(sources),
+      multiSelect = false
+    ) match {
+      case Left(err)    => throw new Exception(err)
+      case Right(tasks) => tasks.asInstanceOf[Seq[Task[Seq[PathRef]]]]
+    }
+    val dataTasks: Seq[Task[PathRef]] = RunScript.resolveTasks(
+      mill.main.ResolveTasks,
+      evaluator,
+      Seq(dataTargets),
+      multiSelect = false
+    ) match {
+      case Left(err)    => throw new Exception(err)
+      case Right(tasks) => tasks.asInstanceOf[Seq[Task[PathRef]]]
+    }
+
+    T.task {
+      val sourcePaths: Seq[Path] = T.sequence(sourcesTasks)().flatten.map(_.path)
+      val dataPaths: Seq[Path]   = T.sequence(dataTasks)().map(_.path)
+      scoverageReportWorkerModule
+        .scoverageReportWorker()
+        .bridge(workerModule.toolsClasspath().map(_.path))
+        .report(reportType, sourcePaths, dataPaths)
+      PathRef(T.dest)
+    }
+  }
+}

--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -634,7 +634,7 @@ object app extends ScalaModule with RouterModule {
 ## Proguard
 
 This module allows [Proguard](https://www.guardsquare.com/en/products/proguard/manual/introduction) to be used in Mill builds.
-ProGuard is a Java class file shrinker, optimizer, obfuscator, and preverifier. 
+ProGuard is a Java class file shrinker, optimizer, obfuscator, and preverifier.
 
 By default, all four steps - shrink, optimize, obfuscate, verify - are run, but this can be configured through task options.
 Any additional options can be specified as a list of strings with `additionalOptions`. The full list of proguard options
@@ -765,6 +765,31 @@ The measurement data is by default available at `out/foo/scoverage/data/dest`,
 the html report is saved in `out/foo/scoverage/htmlReport/dest/`,
 and the xml report is saved in `out/foo/scoverage/xmlReport/dest/`.
 
+### Multi-module projects
+
+If you're using Scoverage on a project with multiple modules then an additonal
+module, `ScoverageReport`, is available to help aggregate the reports from all
+`ScoverageModule`s.
+
+Simply define a `scoverage` module at the root of your project as shown:
+```scala
+  object scoverage extends ScoverageReport {
+    override def scalaVersion     = "<scala-version>"
+    override def scoverageVersion = "<scoverage-version>"
+  }
+```
+
+This provides you with various reporting functions:
+
+```
+mill __.test                     # run tests for all modules
+mill scoverage.htmlReportAll     # generates report in html format for all modules
+mill scoverage.xmlReportAll      # generates report in xml format for all modules
+mill scoverage.consoleReportAll  # reports to the console for all modules
+```
+
+The aggregated report will be available at either `out/scoverage/htmlReportAll/dest/`
+for html reports or `out/scoverage/xmlReportAll/dest/` for xml reports.
 
 ## TestNG
 


### PR DESCRIPTION
This is a module we've been using for a couple of months now that's been working well, originally suggested by @lefou on Gitter [here](https://gitter.im/lihaoyi/mill?at=5f5f7d8df969413294e55466). It allows scoverage to be run across multiple modules and then aggregated into a single report. This is particularly useful if you need a single report for SonarQube or other analysis tools and so contributing it back here.

Thanks @lefou for the help!

