### PR TITLE
ScalaPB additional args

### DIFF
--- a/contrib/scalapblib/src/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/ScalaPBModule.scala
@@ -3,7 +3,13 @@ package contrib.scalapblib
 
 import java.net.URI
 import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.{FileSystems, Files, Path, SimpleFileVisitor, StandardCopyOption}
+import java.nio.file.{
+  FileSystems,
+  Files,
+  Path,
+  SimpleFileVisitor,
+  StandardCopyOption
+}
 
 import coursier.MavenRepository
 import coursier.core.Version
@@ -15,12 +21,18 @@ import mill.api.Loose
 
 trait ScalaPBModule extends ScalaModule {
 
-  override def generatedSources = T { super.generatedSources() :+ compileScalaPB() }
+  override def generatedSources = T {
+    super.generatedSources() :+ compileScalaPB()
+  }
 
   override def ivyDeps = T {
     super.ivyDeps() ++
       Agg(ivy"com.thesamet.scalapb::scalapb-runtime:${scalaPBVersion()}") ++
-      (if (!scalaPBGrpc()) Agg() else Agg(ivy"com.thesamet.scalapb::scalapb-runtime-grpc:${scalaPBVersion()}"))
+      (if (!scalaPBGrpc()) Agg()
+       else
+         Agg(
+           ivy"com.thesamet.scalapb::scalapb-runtime-grpc:${scalaPBVersion()}"
+         ))
   }
 
   def scalaPBVersion: T[String]
@@ -45,16 +57,18 @@ trait ScalaPBModule extends ScalaModule {
   def scalaPBOptions: T[String] = T {
     (
       (if (scalaPBFlatPackage()) Seq("flat_package") else Seq.empty) ++
-      (if (scalaPBJavaConversions()) Seq("java_conversions") else Seq.empty) ++
-      (if (!scalaPBLenses()) Seq("no_lenses") else Seq.empty) ++
-      (if (scalaPBGrpc()) Seq("grpc") else Seq.empty) ++ (
-        if (!scalaPBSingleLineToProtoString()) Seq.empty else {
-          if (Version(scalaPBVersion()) >= Version("0.7.0"))
-            Seq("single_line_to_proto_string")
-          else
-            Seq("single_line_to_string")
-        }
-      )
+        (if (scalaPBJavaConversions()) Seq("java_conversions")
+         else Seq.empty) ++
+        (if (!scalaPBLenses()) Seq("no_lenses") else Seq.empty) ++
+        (if (scalaPBGrpc()) Seq("grpc") else Seq.empty) ++ (
+          if (!scalaPBSingleLineToProtoString()) Seq.empty
+          else {
+            if (Version(scalaPBVersion()) >= Version("0.7.0"))
+              Seq("single_line_to_proto_string")
+            else
+              Seq("single_line_to_string")
+          }
+        )
     ).mkString(",")
   }
 
@@ -71,19 +85,22 @@ trait ScalaPBModule extends ScalaModule {
 
   def scalaPBIncludePath: T[Seq[PathRef]] = T.sources { Seq.empty[PathRef] }
 
-  def scalaPBCustomArgs: T[Seq[String]] = T { Seq.empty[String] }
+  def scalaPBAdditionalArgs: T[Seq[String]] = T { Seq.empty[String] }
 
   def scalaPBProtoClasspath: T[Agg[PathRef]] = T {
     resolveDeps(T.task { transitiveCompileIvyDeps() ++ transitiveIvyDeps() })()
   }
 
   def scalaPBUnpackProto: T[PathRef] = T {
-    val cp   = scalaPBProtoClasspath()
+    val cp = scalaPBProtoClasspath()
     val dest = T.dest
     cp.foreach { ref =>
       val baseUri = "jar:" + ref.path.toIO.getCanonicalFile.toURI.toASCIIString
       val jarFs =
-        FileSystems.newFileSystem(URI.create(baseUri), new java.util.HashMap[String, String]())
+        FileSystems.newFileSystem(
+          URI.create(baseUri),
+          new java.util.HashMap[String, String]()
+        )
       try {
         import scala.collection.JavaConverters._
         jarFs.getRootDirectories.asScala.foreach { r =>
@@ -119,7 +136,7 @@ trait ScalaPBModule extends ScalaModule {
       scalaPBOptions(),
       T.dest,
       scalaPBIncludePath().map(_.path),
-      scalaPBCustomArgs()
+      scalaPBAdditionalArgs()
     )
   }
 
@@ -131,6 +148,5 @@ trait ScalaPBModule extends ScalaModule {
       compilationArgsScalaPB()
     )
   }
-
 
 }

--- a/contrib/scalapblib/src/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/ScalaPBModule.scala
@@ -19,6 +19,7 @@ import mill.scalalib.Lib.resolveDependencies
 import mill.scalalib._
 import mill.api.Loose
 
+/** @see [[http://www.lihaoyi.com/mill/page/contrib-modules.html#scalapb ScalaPB Module]] */
 trait ScalaPBModule extends ScalaModule {
 
   override def generatedSources = T {
@@ -35,6 +36,11 @@ trait ScalaPBModule extends ScalaModule {
          ))
   }
 
+  /**
+   * Override this to specify the scalaPB version to use.
+   *
+   *  @return A string representing the scalaPB version to use.
+   */
   def scalaPBVersion: T[String]
 
   def scalaPBFlatPackage: T[Boolean] = T { false }
@@ -129,6 +135,22 @@ trait ScalaPBModule extends ScalaModule {
     PathRef(dest)
   }
 
+  /**
+   * Builds the compilation arguments for scalaPBC.
+   *
+   *  To build the args this method fetches data from:
+   *
+   *    - scalaPBProtocPath
+   *    - scalaPBSources
+   *    - scalaPBOptions
+   *    - scalaPBIncludePath
+   *    - scalaPBAdditionalArgs
+   *
+   *  If you want to customize the arguments it is often better to override the
+   *  functions listed above instead of this one.
+   *
+   * @return a sequence of arguments to pass to compileScalaPB.
+   */
   def compilationArgsScalaPB: T[Seq[Seq[Seq[String]]]] = T {
     ScalaPBWorkerApi.scalaPBWorker.compilationArgs(
       scalaPBProtocPath(),
@@ -140,6 +162,12 @@ trait ScalaPBModule extends ScalaModule {
     )
   }
 
+  /**
+   * Calls scalaPBC (scalaPB compiler)
+   *
+   * @see See [[https://scalapb.github.io/docs/scalapbc ScalaPBC]] to know more.
+   * @return the destination path.
+   */
   def compileScalaPB: T[PathRef] = T.persistent {
     ScalaPBWorkerApi.scalaPBWorker.compile(
       scalaPBClasspath().map(_.path),

--- a/contrib/scalapblib/src/ScalaPBModule.scala
+++ b/contrib/scalapblib/src/ScalaPBModule.scala
@@ -91,6 +91,17 @@ trait ScalaPBModule extends ScalaModule {
 
   def scalaPBIncludePath: T[Seq[PathRef]] = T.sources { Seq.empty[PathRef] }
 
+  /**
+   * Additional arguments for scalaPBC.
+   *
+   *  If you'd like to pass additional arguments to the ScalaPB compiler directly,
+   *  you can override this task.
+   *
+   *  @see See [[http://www.lihaoyi.com/mill/page/contrib-modules.html#scalapb Configuration Options]] to
+   *       know more.
+   *  @return a sequence of Strings representing the additional arguments to append
+   *          (defaults to empty Seq[String]).
+   */
   def scalaPBAdditionalArgs: T[Seq[String]] = T { Seq.empty[String] }
 
   def scalaPBProtoClasspath: T[Agg[PathRef]] = T {

--- a/contrib/scalapblib/src/ScalaPBWorker.scala
+++ b/contrib/scalapblib/src/ScalaPBWorker.scala
@@ -34,7 +34,7 @@ class ScalaPBWorker {
    *
    *   - 1st seq to encapsulate the sources.
    *   - 2nd seq for proto files.
-   *   - 3rd seq for the args.
+   *   - 3rd seq for the scalaPBC args.
    */
   def compilationArgs(
     protocPath: Option[String],
@@ -74,7 +74,6 @@ class ScalaPBWorker {
 }
 
 trait ScalaPBWorkerApi {
-  // def compileScalaPB(source: File, scalaPBOptions: String, generatedDirectory: File, includes: Seq[os.Path], customArgs: Seq[String])
   def compileScalaPB(args: Seq[String])
 }
 

--- a/contrib/scalapblib/test/src/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/TutorialTests.scala
@@ -7,7 +7,8 @@ import utest.{TestSuite, Tests, assert, _}
 object TutorialTests extends TestSuite {
 
   trait TutorialBase extends TestUtil.BaseModule {
-    override def millSourcePath: os.Path = TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
+    override def millSourcePath: os.Path =
+      TestUtil.getSrcPathBase() / millOuterCtx.enclosing.split('.')
   }
 
   trait TutorialModule extends ScalaPBModule {
@@ -30,21 +31,23 @@ object TutorialTests extends TestSuite {
     }
   }
 
-  object TutorialWithCustomArgs extends TutorialBase {
+  object TutorialWithAdditionalArgs extends TutorialBase {
     object core extends TutorialModule {
-      override def scalaPBCustomArgs = Seq(
+      override def scalaPBAdditionalArgs = Seq(
         s"--zio_out=..."
       )
     }
   }
 
-  val resourcePath: os.Path = os.pwd / 'contrib / 'scalapblib / 'test / 'protobuf / 'tutorial
+  val resourcePath: os.Path =
+    os.pwd / 'contrib / 'scalapblib / 'test / 'protobuf / 'tutorial
 
   def protobufOutPath(eval: TestEvaluator): os.Path =
     eval.outPath / 'core / 'compileScalaPB / 'dest / 'com / 'example / 'tutorial
 
-  def workspaceTest[T](m: TestUtil.BaseModule)(t: TestEvaluator => T)
-                      (implicit tp: TestPath): T = {
+  def workspaceTest[T](
+      m: TestUtil.BaseModule
+  )(t: TestEvaluator => T)(implicit tp: TestPath): T = {
     val eval = new TestEvaluator(m)
     os.remove.all(m.millSourcePath)
     println(m.millSourcePath)
@@ -67,7 +70,8 @@ object TutorialTests extends TestSuite {
     'scalapbVersion - {
 
       'fromBuild - workspaceTest(Tutorial) { eval =>
-        val Right((result, evalCount)) = eval.apply(Tutorial.core.scalaPBVersion)
+        val Right((result, evalCount)) =
+          eval.apply(Tutorial.core.scalaPBVersion)
 
         assert(
           result == "0.7.4",
@@ -77,9 +81,9 @@ object TutorialTests extends TestSuite {
     }
 
 //     'compileScalaPB - {
-      // Broken in Travis due to
-      // protoc-jar: caught exception, retrying: java.io.IOException:
-      // Cannot run program "/dev/null": error=13, Permission denied
+    // Broken in Travis due to
+    // protoc-jar: caught exception, retrying: java.io.IOException:
+    // Cannot run program "/dev/null": error=13, Permission denied
 
 //       'calledDirectly - workspaceTest(Tutorial) { eval =>
 //         val Right((result, evalCount)) = eval.apply(Tutorial.core.compileScalaPB)
@@ -104,29 +108,29 @@ object TutorialTests extends TestSuite {
 //         assert(unchangedEvalCount == 0)
 //       }
 
-      // This throws a NullPointerException in coursier somewhere
-      //
-      // 'triggeredByScalaCompile - workspaceTest(Tutorial) { eval =>
-      //   val Right((_, evalCount)) = eval.apply(Tutorial.core.compile)
+    // This throws a NullPointerException in coursier somewhere
+    //
+    // 'triggeredByScalaCompile - workspaceTest(Tutorial) { eval =>
+    //   val Right((_, evalCount)) = eval.apply(Tutorial.core.compile)
 
-      //   val outPath = protobufOutPath(eval)
+    //   val outPath = protobufOutPath(eval)
 
-      //   val outputFiles = os.walk(outPath).filter(_.isFile)
+    //   val outputFiles = os.walk(outPath).filter(_.isFile)
 
-      //   val expectedSourcefiles = compiledSourcefiles.map(outPath / _)
+    //   val expectedSourcefiles = compiledSourcefiles.map(outPath / _)
 
-      //   assert(
-      //     outputFiles.nonEmpty,
-      //     outputFiles.forall(expectedSourcefiles.contains),
-      //     outputFiles.size == 3,
-      //     evalCount > 0
-      //   )
+    //   assert(
+    //     outputFiles.nonEmpty,
+    //     outputFiles.forall(expectedSourcefiles.contains),
+    //     outputFiles.size == 3,
+    //     evalCount > 0
+    //   )
 
-      //   // don't recompile if nothing changed
-      //   val Right((_, unchangedEvalCount)) = eval.apply(Tutorial.core.compile)
+    //   // don't recompile if nothing changed
+    //   val Right((_, unchangedEvalCount)) = eval.apply(Tutorial.core.compile)
 
-      //   assert(unchangedEvalCount == 0)
-      // }
+    //   assert(unchangedEvalCount == 0)
+    // }
 //     }
 
     'useExternalProtocCompiler - {
@@ -140,14 +144,16 @@ object TutorialTests extends TestSuite {
     }
 
     'compilationArgs - {
-      'calledWithCustomArgs - workspaceTest(TutorialWithCustomArgs) { eval =>
-        val result = eval.apply(TutorialWithCustomArgs.core.compilationArgsScalaPB)
-        result match {
-          case Right((seq, _)) =>
-            val args = seq.flatten
-            assert(args.head.exists(_.contains("--zio_out")))
-          case _ => assert(false)
-        }
+      'calledWithAdditionalArgs - workspaceTest(TutorialWithAdditionalArgs) {
+        eval =>
+          val result =
+            eval.apply(TutorialWithAdditionalArgs.core.compilationArgsScalaPB)
+          result match {
+            case Right((seq, _)) =>
+              val args = seq.flatten
+              assert(args.head.exists(_.contains("--zio_out")))
+            case _ => assert(false)
+          }
       }
     }
   }

--- a/contrib/scalapblib/test/src/TutorialTests.scala
+++ b/contrib/scalapblib/test/src/TutorialTests.scala
@@ -30,6 +30,14 @@ object TutorialTests extends TestSuite {
     }
   }
 
+  object TutorialWithCustomArgs extends TutorialBase {
+    object core extends TutorialModule {
+      override def scalaPBCustomArgs = Seq(
+        s"--zio_out=..."
+      )
+    }
+  }
+
   val resourcePath: os.Path = os.pwd / 'contrib / 'scalapblib / 'test / 'protobuf / 'tutorial
 
   def protobufOutPath(eval: TestEvaluator): os.Path =
@@ -69,10 +77,10 @@ object TutorialTests extends TestSuite {
     }
 
 //     'compileScalaPB - {
-      // Broken in Travis due to 
-      // protoc-jar: caught exception, retrying: java.io.IOException: 
+      // Broken in Travis due to
+      // protoc-jar: caught exception, retrying: java.io.IOException:
       // Cannot run program "/dev/null": error=13, Permission denied
-      
+
 //       'calledDirectly - workspaceTest(Tutorial) { eval =>
 //         val Right((result, evalCount)) = eval.apply(Tutorial.core.compileScalaPB)
 
@@ -128,6 +136,18 @@ object TutorialTests extends TestSuite {
       'calledWithWrongProtocFile - workspaceTest(TutorialWithProtoc) { eval =>
         val result = eval.apply(TutorialWithProtoc.core.compileScalaPB)
         assert(result.isLeft)
+      }
+    }
+
+    'compilationArgs - {
+      'calledWithCustomArgs - workspaceTest(TutorialWithCustomArgs) { eval =>
+        val result = eval.apply(TutorialWithCustomArgs.core.compilationArgsScalaPB)
+        result match {
+          case Right((seq, _)) =>
+            val args = seq.flatten
+            assert(args.head.exists(_.contains("--zio_out")))
+          case _ => assert(false)
+        }
       }
     }
   }

--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -707,7 +707,7 @@ example/
 
 * scalaPBProtocPath - A `Option[Path]` option which determines the protoc compiler to use. If `None`, a java embedded protoc will be used, if set to `Some` path, the given binary is used.
 
-If you'd like to configure the options that are passed to the ScalaPB compiler directly, you can override the `scalaPBOptions` task, for example:
+If you'd like to configure the [options](https://scalapb.github.io/docs/scalapbc#passing-generator-parameters) that are passed to the ScalaPB compiler directly, you can override the `scalaPBOptions` task, for example:
 
 ```scala
 // build.sc
@@ -722,6 +722,20 @@ object example extends ScalaPBModule {
 }
 ```
 
+If you'd like to pass additional arguments to the ScalaPB compiler directly, you can override the `scalaPBCustomArgs` task, for example:
+
+```scala
+// build.sc
+
+import $ivy.`com.lihaoyi::mill-contrib-scalapblib:$MILL_VERSION`
+import contrib.scalapblib._
+
+object example extends ScalaPBModule {
+  def scalaVersion = "2.12.6"
+  def scalaPBVersion = "0.7.4"
+  override def scalaPBCustomArgs = Seq(s"--zio_out=${T.dest.toIO.getCanonicalPath}")
+}
+```
 
 ## Scoverage
 

--- a/docs/pages/9 - Contrib Modules.md
+++ b/docs/pages/9 - Contrib Modules.md
@@ -722,7 +722,7 @@ object example extends ScalaPBModule {
 }
 ```
 
-If you'd like to pass additional arguments to the ScalaPB compiler directly, you can override the `scalaPBCustomArgs` task, for example:
+If you'd like to pass additional arguments to the ScalaPB compiler directly, you can override the `scalaPBAdditionalArgs` task, for example:
 
 ```scala
 // build.sc
@@ -733,7 +733,8 @@ import contrib.scalapblib._
 object example extends ScalaPBModule {
   def scalaVersion = "2.12.6"
   def scalaPBVersion = "0.7.4"
-  override def scalaPBCustomArgs = Seq(s"--zio_out=${T.dest.toIO.getCanonicalPath}")
+  override def scalaPBAdditionalArgs =
+    Seq(s"--zio_out=${T.dest.toIO.getCanonicalPath}")
 }
 ```
 


### PR DESCRIPTION
@lefou can you please review, and let me know if I'm missing something?

The plan with this change is to allow additional args for scalaPBC, this means I can just do this in my code for zio-grpc to work:

```
object example extends ScalaPBModule {
  def scalaVersion = "2.12.6"
  def scalaPBVersion = "0.7.4"

   override def scalaPBAdditionalArgs = Seq(
        s"--zio_out=${T.dest.toIO.getCanonicalPath}"
   )
}
```