### PR TITLE
Fix BSP,  avoid assumptions about Logger implementation

### DIFF
--- a/bsp/src/mill/bsp/BSP.scala
+++ b/bsp/src/mill/bsp/BSP.scala
@@ -64,7 +64,7 @@ object BSP extends ExternalModule {
     write(
       BspConfigJson(
         name = "mill-bsp",
-        argv = Seq(millPath, "-i", s"${BSP.getClass.getCanonicalName.split("[$]").head}/start"),
+        argv = Seq(millPath, "-i", "--disable-ticker", "--color", "false", s"${BSP.getClass.getCanonicalName.split("[$]").head}/start"),
         millVersion = Util.millProperty("MILL_VERSION").getOrElse(BuildInfo.millVersion),
         bspVersion = bspProtocolVersion,
         languages = languages
@@ -101,12 +101,13 @@ object BSP extends ExternalModule {
         BuildInfo.millVersion)
       val executor = Executors.newCachedThreadPool()
 
-      val stdin = System.in
-      val stdout = System.out
+      val logger = T.ctx.log
+      val in = logger.inStream
+      val out = logger.outputStream
       try {
         val launcher = new Launcher.Builder[BuildClient]()
-          .setOutput(stdout)
-          .setInput(stdin)
+          .setOutput(out)
+          .setInput(in)
           .setLocalService(millServer)
           .setRemoteInterface(classOf[BuildClient])
           .traceMessages(new PrintWriter(

--- a/main/core/src/eval/Evaluator.scala
+++ b/main/core/src/eval/Evaluator.scala
@@ -525,7 +525,7 @@ case class Evaluator(
 
   def resolveLogger(logPath: Option[os.Path], logger: Logger): Logger = logPath match{
     case None => logger
-    case Some(path) => MultiLogger(logger.colored, logger, new FileLogger(logger.colored, path, debugEnabled = true))
+    case Some(path) => MultiLogger(logger.colored, logger, new FileLogger(logger.colored, path, debugEnabled = true), logger.inStream)
   }
 
   /**

--- a/main/core/src/util/LinePrefixOutputStream.scala
+++ b/main/core/src/util/LinePrefixOutputStream.scala
@@ -33,12 +33,16 @@ class LinePrefixOutputStream(
     }
     buffer.write(b)
     if (b == '\n') {
-      out.synchronized{
-        out.write(buffer.toByteArray)
-      }
-      buffer.reset()
+      flush()
       isFirst = true
     }
   }
 
+  override def flush(): Unit = {
+    out.synchronized{
+      out.write(buffer.toByteArray)
+    }
+    buffer.reset()
+    super.flush()
+  }
 }

--- a/main/core/src/util/Loggers.scala
+++ b/main/core/src/util/Loggers.scala
@@ -204,17 +204,12 @@ class MultiStream(stream1: OutputStream, stream2: OutputStream) extends PrintStr
   }
 })
 
-case class MultiLogger(colored: Boolean, logger1: Logger, logger2: Logger) extends Logger {
+case class MultiLogger(colored: Boolean, logger1: Logger, logger2: Logger, inStream: InputStream) extends Logger {
 
 
   lazy val outputStream: PrintStream = new MultiStream(logger1.outputStream, logger2.outputStream)
 
   lazy val errorStream: PrintStream = new MultiStream(logger1.errorStream, logger2.errorStream)
-
-  lazy val inStream = Seq(logger1, logger2).collectFirst{case t: PrintLogger => t} match{
-    case Some(x) => x.inStream
-    case None => new ByteArrayInputStream(Array())
-  }
 
   def info(s: String) = {
     logger1.info(s)
@@ -255,5 +250,6 @@ case class ProxyLogger(logger: Logger) extends Logger {
   def error(s: String) = logger.error(s)
   def ticker(s: String) = logger.ticker(s)
   def debug(s: String) = logger.debug(s)
+
   override def close() = logger.close()
 }

--- a/main/src/main/MainRunner.scala
+++ b/main/src/main/MainRunner.scala
@@ -88,7 +88,7 @@ class MainRunner(val config: ammonite.main.Cli.Config,
       isRepl = false,
       printing = true,
       mainCfg => {
-        val logger = new PrintLogger(
+        val logger = PrintLogger(
           colored,
           disableTicker,
           colors,


### PR DESCRIPTION
Some use cases need to be able to emit exact strings to stdout, e.g. BSP.
For those cases, we need to be able to skip log decoration, e.g. colors and prefixes.

I don't know if this is the most elegant solution, but I think emitting logs without decoration is something third party tasks may also need to be able to do, so I added the capability to Logger. For Mill itself, the BSP server needs to be able to do it.