### PR TITLE
Support useECMAScript2015 option in ScalaJSModule

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -12,17 +12,17 @@ import mill.modules.Jvm.createAssembly
 object Deps {
 
   object Scalajs_0_6 {
-    val scalajsJsEnvs =  ivy"org.scala-js::scalajs-js-envs:0.6.32"
-    val scalajsSbtTestAdapter =  ivy"org.scala-js::scalajs-sbt-test-adapter:0.6.32"
-    val scalajsTools = ivy"org.scala-js::scalajs-tools:0.6.32"
+    val scalajsJsEnvs =  ivy"org.scala-js::scalajs-js-envs:0.6.33"
+    val scalajsSbtTestAdapter =  ivy"org.scala-js::scalajs-sbt-test-adapter:0.6.33"
+    val scalajsTools = ivy"org.scala-js::scalajs-tools:0.6.33"
   }
 
   object Scalajs_1 {
     val scalajsEnvJsdomNodejs =  ivy"org.scala-js::scalajs-env-jsdom-nodejs:1.1.0"
     val scalajsEnvNodejs =  ivy"org.scala-js::scalajs-env-nodejs:1.1.1"
     val scalajsEnvPhantomjs =  ivy"org.scala-js::scalajs-env-phantomjs:1.0.0"
-    val scalajsSbtTestAdapter = ivy"org.scala-js::scalajs-sbt-test-adapter:1.1.1"
-    val scalajsLinker = ivy"org.scala-js::scalajs-linker:1.1.1"
+    val scalajsSbtTestAdapter = ivy"org.scala-js::scalajs-sbt-test-adapter:1.3.1"
+    val scalajsLinker = ivy"org.scala-js::scalajs-linker:1.3.1"
   }
 
   object Scalanative_0_3 {

--- a/scalajslib/api/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/api/src/ScalaJSWorkerApi.scala
@@ -8,7 +8,8 @@ trait ScalaJSWorkerApi {
            main: String,
            testBridgeInit: Boolean,
            fullOpt: Boolean,
-           moduleKind: ModuleKind): Result[File]
+           moduleKind: ModuleKind,
+           useECMAScript2015: Boolean): Result[File]
 
   def run(config: JsEnvConfig, linkedFile: File): Unit
 
@@ -29,6 +30,7 @@ sealed trait ModuleKind
 object ModuleKind{
   object NoModule extends ModuleKind
   object CommonJSModule extends ModuleKind
+  object ESModule extends ModuleKind
 }
 
 

--- a/scalajslib/src/ScalaJSModule.scala
+++ b/scalajslib/src/ScalaJSModule.scala
@@ -75,7 +75,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       finalMainClassOpt().toOption,
       testBridgeInit = false,
       FastOpt,
-      moduleKind()
+      moduleKind(),
+      useECMAScript2015()
     )
   }
 
@@ -87,7 +88,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       finalMainClassOpt().toOption,
       testBridgeInit = false,
       FullOpt,
-      moduleKind()
+      moduleKind(),
+      useECMAScript2015()
     )
   }
 
@@ -121,7 +123,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
            mainClass: Option[String],
            testBridgeInit: Boolean,
            mode: OptimizeMode,
-           moduleKind: ModuleKind)(implicit ctx: Ctx): Result[PathRef] = {
+           moduleKind: ModuleKind,
+           useECMAScript2015: Boolean)(implicit ctx: Ctx): Result[PathRef] = {
     val outputPath = ctx.dest / "out.js"
 
     os.makeDir.all(ctx.dest)
@@ -141,7 +144,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       mainClass,
       testBridgeInit,
       mode == FullOpt,
-      moduleKind
+      moduleKind,
+      useECMAScript2015
     ).map(PathRef(_))
   }
 
@@ -167,6 +171,8 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
   def jsEnvConfig: T[JsEnvConfig] = T { JsEnvConfig.NodeJs() }
 
   def moduleKind: T[ModuleKind] = T { ModuleKind.NoModule }
+
+  def useECMAScript2015: T[Boolean] = false
 }
 
 trait TestScalaJSModule extends ScalaJSModule with TestModule {
@@ -190,7 +196,8 @@ trait TestScalaJSModule extends ScalaJSModule with TestModule {
       None,
       testBridgeInit = true,
       FastOpt,
-      moduleKind()
+      moduleKind(),
+      useECMAScript2015()
     )
   }
 

--- a/scalajslib/src/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/ScalaJSWorkerApi.scala
@@ -37,7 +37,8 @@ class ScalaJSWorker {
            main: Option[String],
            testBridgeInit: Boolean,
            fullOpt: Boolean,
-           moduleKind: ModuleKind)
+           moduleKind: ModuleKind,
+           useECMAScript2015: Boolean)
           (implicit ctx: Ctx.Home): Result[os.Path] = {
     bridge(toolsClasspath).link(
       sources.items.map(_.toIO).toArray,
@@ -46,7 +47,8 @@ class ScalaJSWorker {
       main.orNull,
       testBridgeInit,
       fullOpt,
-      moduleKind
+      moduleKind,
+      useECMAScript2015
     ).map(os.Path(_))
   }
 

--- a/scalajslib/test/src/MultiModuleTests.scala
+++ b/scalajslib/test/src/MultiModuleTests.scala
@@ -13,8 +13,8 @@ object MultiModuleTests extends TestSuite {
 
   object MultiModule extends TestUtil.BaseModule {
     trait BaseModule extends ScalaJSModule {
-      def scalaVersion = "2.12.4"
-      def scalaJSVersion = "0.6.32"
+      def scalaVersion = "2.13.3"
+      def scalaJSVersion = "0.6.33"
     }
 
     object client extends BaseModule {
@@ -23,7 +23,7 @@ object MultiModuleTests extends TestSuite {
       override def mainClass = Some("Main")
       object test extends Tests {
         def testFrameworks = Seq("utest.runner.Framework")
-        override def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.6.3")
+        override def ivyDeps = Agg(ivy"com.lihaoyi::utest::0.7.5")
       }
     }
 
@@ -49,7 +49,7 @@ object MultiModuleTests extends TestSuite {
       val runOutput = ScalaJsUtils.runJS(linked.path)
       assert(
         evalCount > 0,
-        runOutput == "Hello from Scala.js, result is: 3"
+        runOutput == "Hello from Scala.js, result is: 3\n"
       )
     }
 

--- a/scalajslib/test/src/ScalaJsUtils.scala
+++ b/scalajslib/test/src/ScalaJsUtils.scala
@@ -1,25 +1,7 @@
 package mill.scalajslib
 
-import java.io.{FileReader, StringWriter}
-import javax.script.{ScriptContext, ScriptEngineManager}
-
 object ScalaJsUtils {
-  /* TODO Using Nashorn means that we do not support ECMAScript 2015, which
-   * forces ScalaJSWorkerImpl to always use ES 5.1. We should a different
-   * engine, perhaps Scala.js' own JSEnv, to perform these tests.
-   */
   def runJS(path: os.Path): String = {
-    val engineManager = new ScriptEngineManager(null)
-    val engine = engineManager.getEngineByName("nashorn")
-    val console = new Console
-    val bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE)
-    bindings.put("console", console)
-    engine.eval(new FileReader(path.toIO))
-    console.out.toString
+    os.proc("node", path).call().out.text
   }
-}
-
-class Console {
-  val out = new StringWriter()
-  def log(s: String): Unit = out.append(s)
 }

--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -23,7 +23,7 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
            testBridgeInit: Boolean, // ignored in 0.6
            fullOpt: Boolean,
            moduleKind: ModuleKind,
-           useECMAScript2015: Boolean /* ignored in 0.6 */) = {
+           useECMAScript2015: Boolean) = {
 
     val semantics = fullOpt match {
         case true => Semantics.Defaults.optimized

--- a/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
@@ -23,7 +23,8 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
            main: String,
            testBridgeInit: Boolean,
            fullOpt: Boolean,
-           moduleKind: ModuleKind) = {
+           moduleKind: ModuleKind,
+           useECMAScript2015: Boolean) = {
     import scala.concurrent.ExecutionContext.Implicits.global
     val semantics = fullOpt match {
         case true => Semantics.Defaults.optimized
@@ -32,19 +33,14 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
     val scalaJSModuleKind = moduleKind match {
       case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
       case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
+      case ModuleKind.ESModule => ScalaJSModuleKind.ESModule
     }
-    /* TODO We currently force ECMAScript 5.1, because the *tests* of
-     * scalajslib use Nashorn (see ScalaJsUtils.scala) which does not support
-     * ES 2015. This should at least be turned into a configuration option, but
-     * also we should change ScalaJsUtils to support ES 2015, for example by
-     * using Scala.js' own NodeJSEnv to perform the tests.
-     */
     val config = StandardConfig()
       .withOptimizer(fullOpt)
       .withClosureCompilerIfAvailable(fullOpt)
       .withSemantics(semantics)
       .withModuleKind(scalaJSModuleKind)
-      .withESFeatures(_.withUseECMAScript2015(false))
+      .withESFeatures(_.withUseECMAScript2015(useECMAScript2015))
     val linker = StandardImpl.linker(config)
     val cache = StandardImpl.irFileCache().newCache
     val sourceIRsFuture = Future.sequence(sources.toSeq.map(f => PathIRFile(f.toPath())))


### PR DESCRIPTION
- Support ESModule ModuleKind
- Update Scala.js 0.6 to 0.6.33
- Update Scala.js 1 to 1.3.1
- Add useECMAScript215 to test matrix just for last version
- Update Scala versions it tests
- Update ScalaJsUtils to use node.js instead of nashorn
  The initial idea was to use the NodeJSEnv from Scala.js to run the
  tests. But this created a problem since adding a particular NodeJSEnv
  to the classpath broke the other version of Scala.js linking. For example
  using NodeJSEnv from Scala.js 1.3.1 made fastOpt in Scala.js 0.6 break.
  So at the end the function is just calling "node" using `os.proc`