### PR TITLE
Cache Scala.js Linker to enable incremental linking

### DIFF
--- a/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/0.6/src/ScalaJSWorkerImpl.scala
@@ -9,12 +9,43 @@ import mill.scalajslib.api.{JsEnvConfig, ModuleKind}
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
-import org.scalajs.core.tools.linker.{ModuleInitializer, Semantics, StandardLinker, ModuleKind => ScalaJSModuleKind}
+import org.scalajs.core.tools.linker.{Linker, ModuleInitializer, Semantics, StandardLinker, ModuleKind => ScalaJSModuleKind}
 import org.scalajs.core.tools.logging.ScalaConsoleLogger
 import org.scalajs.jsenv._
 import org.scalajs.testadapter.TestAdapter
 
 class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
+  private case class LinkerInput(fullOpt: Boolean, moduleKind: ModuleKind, useECMAScript2015: Boolean)
+  private object ScalaJSLinker {
+    private var cache = Map.empty[LinkerInput, Linker]
+    def reuseOrCreate(input: LinkerInput): Linker =
+      cache.getOrElse(
+        input,
+        {
+          val newLinker = createLinker(input)
+          cache += (input -> newLinker)
+          newLinker
+        }
+      )
+    private def createLinker(input: LinkerInput): Linker = {
+      val semantics = input.fullOpt match {
+        case true => Semantics.Defaults.optimized
+        case false => Semantics.Defaults
+      }
+      val scalaJSModuleKind = input.moduleKind match {
+        case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
+        case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
+        case ModuleKind.ESModule => ScalaJSModuleKind.ESModule
+      }
+      val config = StandardLinker.Config()
+        .withOptimizer(input.fullOpt)
+        .withClosureCompilerIfAvailable(input.fullOpt)
+        .withSemantics(semantics)
+        .withModuleKind(scalaJSModuleKind)
+        .withESFeatures(_.withUseECMAScript2015(input.useECMAScript2015))
+      StandardLinker(config)
+    }
+  }
 
   def link(sources: Array[File],
            libraries: Array[File],
@@ -24,23 +55,7 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
            fullOpt: Boolean,
            moduleKind: ModuleKind,
            useECMAScript2015: Boolean) = {
-
-    val semantics = fullOpt match {
-        case true => Semantics.Defaults.optimized
-        case false => Semantics.Defaults
-    }
-    val scalaJSModuleKind = moduleKind match {
-      case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
-      case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
-      case ModuleKind.ESModule => ScalaJSModuleKind.ESModule
-    }
-    val config = StandardLinker.Config()
-      .withOptimizer(fullOpt)
-      .withClosureCompilerIfAvailable(fullOpt)
-      .withSemantics(semantics)
-      .withModuleKind(scalaJSModuleKind)
-      .withESFeatures(_.withUseECMAScript2015(useECMAScript2015))
-    val linker = StandardLinker(config)
+    val linker = ScalaJSLinker.reuseOrCreate(LinkerInput(fullOpt, moduleKind, useECMAScript2015))
     val sourceSJSIRs = sources.map(new FileVirtualScalaJSIRFile(_))
     val jars = libraries.map(jar => IRContainer.Jar(new FileVirtualBinaryFile(jar) with VirtualJarFile))
     val jarSJSIRs = jars.flatMap(_.jar.sjsirFiles)

--- a/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
@@ -17,6 +17,37 @@ import org.scalajs.testing.adapter.TestAdapter
 import org.scalajs.testing.adapter.{TestAdapterInitializer => TAI}
 
 class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
+  private case class LinkerInput(fullOpt: Boolean, moduleKind: ModuleKind, useECMAScript2015: Boolean)
+  private object ScalaJSLinker {
+    private var cache = Map.empty[LinkerInput, Linker]
+    def reuseOrCreate(input: LinkerInput): Linker =
+      cache.getOrElse(
+        input,
+        {
+          val newLinker = createLinker(input)
+          cache += (input -> newLinker)
+          newLinker
+        }
+      )
+    private def createLinker(input: LinkerInput): Linker = {
+      val semantics = input.fullOpt match {
+          case true => Semantics.Defaults.optimized
+          case false => Semantics.Defaults
+      }
+      val scalaJSModuleKind = input.moduleKind match {
+        case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
+        case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
+        case ModuleKind.ESModule => ScalaJSModuleKind.ESModule
+      }
+      val config = StandardConfig()
+        .withOptimizer(input.fullOpt)
+        .withClosureCompilerIfAvailable(input.fullOpt)
+        .withSemantics(semantics)
+        .withModuleKind(scalaJSModuleKind)
+        .withESFeatures(_.withUseECMAScript2015(input.useECMAScript2015))
+      StandardImpl.linker(config)
+    }
+  }
   def link(sources: Array[File],
            libraries: Array[File],
            dest: File,
@@ -26,22 +57,7 @@ class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
            moduleKind: ModuleKind,
            useECMAScript2015: Boolean) = {
     import scala.concurrent.ExecutionContext.Implicits.global
-    val semantics = fullOpt match {
-        case true => Semantics.Defaults.optimized
-        case false => Semantics.Defaults
-    }
-    val scalaJSModuleKind = moduleKind match {
-      case ModuleKind.NoModule => ScalaJSModuleKind.NoModule
-      case ModuleKind.CommonJSModule => ScalaJSModuleKind.CommonJSModule
-      case ModuleKind.ESModule => ScalaJSModuleKind.ESModule
-    }
-    val config = StandardConfig()
-      .withOptimizer(fullOpt)
-      .withClosureCompilerIfAvailable(fullOpt)
-      .withSemantics(semantics)
-      .withModuleKind(scalaJSModuleKind)
-      .withESFeatures(_.withUseECMAScript2015(useECMAScript2015))
-    val linker = StandardImpl.linker(config)
+    val linker = ScalaJSLinker.reuseOrCreate(LinkerInput(fullOpt, moduleKind, useECMAScript2015))
     val cache = StandardImpl.irFileCache().newCache
     val sourceIRsFuture = Future.sequence(sources.toSeq.map(f => PathIRFile(f.toPath())))
     val irContainersPairs = PathIRContainer.fromClasspath(libraries.map(_.toPath()))

--- a/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
+++ b/scalajslib/worker/1/src/ScalaJSWorkerImpl.scala
@@ -16,19 +16,20 @@ import org.scalajs.jsenv.nodejs.NodeJSEnv.SourceMap
 import org.scalajs.testing.adapter.TestAdapter
 import org.scalajs.testing.adapter.{TestAdapterInitializer => TAI}
 
+import scala.collection.mutable
+import scala.ref.WeakReference
+
 class ScalaJSWorkerImpl extends mill.scalajslib.api.ScalaJSWorkerApi {
   private case class LinkerInput(fullOpt: Boolean, moduleKind: ModuleKind, useECMAScript2015: Boolean)
   private object ScalaJSLinker {
-    private var cache = Map.empty[LinkerInput, Linker]
-    def reuseOrCreate(input: LinkerInput): Linker =
-      cache.getOrElse(
-        input,
-        {
-          val newLinker = createLinker(input)
-          cache += (input -> newLinker)
-          newLinker
-        }
-      )
+    private val cache = mutable.Map.empty[LinkerInput, WeakReference[Linker]]
+    def reuseOrCreate(input: LinkerInput): Linker = cache.get(input) match {
+      case Some(WeakReference(linker)) => linker
+      case _ =>
+        val newLinker = createLinker(input)
+        cache.update(input, WeakReference(newLinker))
+        newLinker
+    }
     private def createLinker(input: LinkerInput): Linker = {
       val semantics = input.fullOpt match {
           case true => Semantics.Defaults.optimized


### PR DESCRIPTION
Originated from [this message on gitter.im](https://gitter.im/scala-native/scala-native?at=5fb274fd2a354407152b54f3).
This should solve the problem.

This PR caches all the linkers separately. For now there are 12 combinations. But adding new parameters could explode the possibilities even more.
I did this so you can jump between different settings of fastOpt/fullOpt, ModuleKind without losing the incremental linking.