### PR TITLE
BSP: Provide mill source files

### DIFF
--- a/bsp/src/mill/bsp/MillBuildServer.scala
+++ b/bsp/src/mill/bsp/MillBuildServer.scala
@@ -133,7 +133,7 @@ class MillBuildServer(evaluator: Evaluator, bspVersion: String, serverVersion: S
       val items = dependencySourcesParams.getTargets.asScala
         .foldLeft(Seq.empty[DependencySourcesItem]) { (items, targetId) =>
           val all = if (targetId == millBuildTargetId)
-            getMillBuildClasspath(evaluator, source = true)
+            getMillBuildClasspath(evaluator, sources = true)
           else {
             val module = getModule(targetId, modules)
             val sources = evaluateInformativeTask(
@@ -350,7 +350,7 @@ class MillBuildServer(evaluator: Evaluator, bspVersion: String, serverVersion: S
         .foldLeft(Seq.empty[JavacOptionsItem]) { (items, targetId) =>
           val newItem =
             if (targetId == millBuildTargetId) {
-              val classpath = getMillBuildClasspath(evaluator, source = false)
+              val classpath = getMillBuildClasspath(evaluator, sources = false)
               Some(new JavacOptionsItem(
                 targetId,
                 Seq.empty.asJava,
@@ -391,7 +391,7 @@ class MillBuildServer(evaluator: Evaluator, bspVersion: String, serverVersion: S
         .foldLeft(Seq.empty[ScalacOptionsItem]) { (items, targetId) =>
           val newItem =
             if (targetId == millBuildTargetId) {
-              val classpath = getMillBuildClasspath(evaluator, source = false)
+              val classpath = getMillBuildClasspath(evaluator, sources = false)
               Some(new ScalacOptionsItem(
                 targetId,
                 Seq.empty.asJava,

--- a/bsp/src/mill/bsp/ModuleUtils.scala
+++ b/bsp/src/mill/bsp/ModuleUtils.scala
@@ -2,6 +2,7 @@ package mill.bsp
 
 import ammonite.runtime.SpecialClassLoader
 import ch.epfl.scala.bsp4j._
+import coursier.Resolve
 import java.net.URL
 import mill._
 import mill.api.Result.Success
@@ -9,15 +10,14 @@ import mill.api.{PathRef, Strict}
 import mill.define._
 import mill.eval.{Evaluator, _}
 import mill.scalajslib.ScalaJSModule
+import mill.scalalib._
 import mill.scalalib.Lib.{depToDependency, resolveDependencies, scalaRuntimeIvyDeps}
 import mill.scalalib.api.Util
-import mill.scalalib.{JavaModule, ScalaModule, TestModule}
 import mill.scalanativelib._
 import mill.util.Ctx
 import os.{Path, exists}
 import scala.collection.JavaConverters._
 import scala.util.Try
-import coursier.core.Repository
 
 /**
  * Utilities for translating the mill build into
@@ -86,9 +86,8 @@ object ModuleUtils {
     val scalaOrganization = "org.scala-lang"
     val scalaLibDep = scalaRuntimeIvyDeps(scalaOrganization, BuildInfo.scalaVersion)
 
-    val repos = Evaluator.evalOrElse(evaluator, T.task {
-        T.traverse(modules)(_.repositoriesTask)()
-      }, Seq.empty[Seq[Repository]])
+    val repos = Evaluator
+      .evalOrElse(evaluator, T.traverse(modules)(_.repositoriesTask), Seq.empty)
       .flatten
       .distinct
 
@@ -112,15 +111,24 @@ object ModuleUtils {
     target
   }
 
-  def getMillBuildClasspath(evaluator: Evaluator, source: Boolean): Seq[String] = {
-    val all = Try(evaluator.rootModule.getClass.getClassLoader.asInstanceOf[SpecialClassLoader]).fold(
+  def getMillBuildClasspath(evaluator: Evaluator, sources: Boolean): Seq[String] = {
+    val classpath = Try(evaluator.rootModule.getClass.getClassLoader.asInstanceOf[SpecialClassLoader]).fold(
       _ => Seq.empty,
       _.allJars
     )
-    val filtered =
-      if (source) all.filter(url => isSourceJar(url))
+
+    val millJars = resolveDependencies(
+      Resolve.defaultRepositories,
+      depToDependency(_, BuildInfo.scalaVersion),
+      Versions.millEmbeddedDeps,
+      sources = sources
+    ).asSuccess.toSeq.flatMap(_.value).map(_.path.toNIO.toUri.toURL)
+
+    val all = classpath ++ millJars
+    val binarySource =
+      if (sources) all.filter(url => isSourceJar(url))
       else all.filter(url => !isSourceJar(url))
-    filtered.filter(url => exists(Path(url.getFile))).map(_.toURI.toString)
+    binarySource.filter(url => exists(Path(url.getFile))).map(_.toURI.toString)
   }
 
   /**

--- a/bsp/src/mill/bsp/ModuleUtils.scala
+++ b/bsp/src/mill/bsp/ModuleUtils.scala
@@ -120,7 +120,7 @@ object ModuleUtils {
     val millJars = resolveDependencies(
       Resolve.defaultRepositories,
       depToDependency(_, BuildInfo.scalaVersion),
-      Versions.millEmbeddedDeps,
+      BuildInfo.millEmbeddedDeps.map(d => ivy"$d"),
       sources = sources
     ).asSuccess.toSeq.flatMap(_.value).map(_.path.toNIO.toUri.toURL)
 

--- a/build.sc
+++ b/build.sc
@@ -248,6 +248,7 @@ object scalalib extends MillModule {
 
   override def generatedSources = T{
     val dest = T.ctx.dest
+    val artifacts = T.traverse(dev.moduleDeps)(_.publishSelfDependency)()
     os.write(dest / "Versions.scala",
       s"""package mill.scalalib
         |
@@ -260,6 +261,8 @@ object scalalib extends MillModule {
         |  val ammonite = "${Deps.ammonite.dep.version}"
         |  /** Version of Zinc. */
         |  val zinc = "${Deps.zinc.dep.version}"
+        |  /** Dependency artifacts embedded in mill by default. */
+        |  val millEmbeddedDeps = ${artifacts.map(artifact => s"""ivy"${artifact.group}::${artifact.id}:${artifact.version}"""")}
         |}
         |
         |""".stripMargin)
@@ -687,7 +690,7 @@ def launcherScript(shellJvmArgs: Seq[String],
   )
 }
 
-object dev extends MillModule{
+object dev extends MillModule {
   def moduleDeps = Seq(scalalib, scalajslib, scalanativelib, bsp)
 
 

--- a/main/src/main/MillServerMain.scala
+++ b/main/src/main/MillServerMain.scala
@@ -2,9 +2,7 @@ package mill.main
 
 import java.io._
 import java.net.Socket
-
-import mill.MillMain
-
+import mill.{BuildInfo, MillMain}
 import scala.collection.JavaConverters._
 import org.scalasbt.ipcsocket._
 import mill.main.client._
@@ -124,7 +122,7 @@ class Server[T](lockBase: String,
     val argStream = new FileInputStream(lockBase + "/run")
     val interactive = argStream.read() != 0
     val clientMillVersion = Util.readString(argStream)
-    val serverMillVersion = sys.props("MILL_VERSION")
+    val serverMillVersion = BuildInfo.millVersion
     if (clientMillVersion != serverMillVersion) {
       stderr.println(s"Mill version changed ($serverMillVersion -> $clientMillVersion), re-starting server")
       java.nio.file.Files.write(

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -11,7 +11,7 @@ import mill.api.{Loose, Result, Strict}
 import mill.define._
 import mill.eval.{Evaluator, PathRef}
 import mill.modules.Util
-import mill.{T, scalalib}
+import mill.{BuildInfo, T, scalalib}
 import os.{Path, RelPath}
 import scala.util.Try
 import scala.xml.{Elem, MetaData, NodeSeq, Null, UnprefixedAttribute}
@@ -82,13 +82,11 @@ case class GenIdeaImpl(evaluator: Evaluator,
           }, Seq.empty[Seq[Repository]])
 
           val repos = moduleRepos.foldLeft(Set.empty[Repository])(_ ++ _) ++ Set(LocalRepositories.ivy2Local, Repositories.central)
-          val artifactNames = Seq("main-moduledefs", "main-api", "main-core", "scalalib", "scalajslib")
           val Result.Success(res) = scalalib.Lib.resolveDependencies(
             repos.toList,
             Lib.depToDependency(_, "2.13.2", ""),
-            for(name <- artifactNames)
-            yield ivy"com.lihaoyi::mill-$name:${sys.props("MILL_VERSION")}",
-            false,
+            Versions.millEmbeddedDeps,
+            sources = false,
             None,
             ctx
           )
@@ -98,9 +96,8 @@ case class GenIdeaImpl(evaluator: Evaluator,
             scalalib.Lib.resolveDependencies(
               repos.toList,
               Lib.depToDependency(_, "2.13.2", ""),
-              for(name <- artifactNames)
-              yield ivy"com.lihaoyi::mill-$name:${sys.props("MILL_VERSION")}",
-              true,
+              Versions.millEmbeddedDeps,
+              sources = true,
               None,
               ctx
             )

--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -82,10 +82,11 @@ case class GenIdeaImpl(evaluator: Evaluator,
           }, Seq.empty[Seq[Repository]])
 
           val repos = moduleRepos.foldLeft(Set.empty[Repository])(_ ++ _) ++ Set(LocalRepositories.ivy2Local, Repositories.central)
+          val millDeps = BuildInfo.millEmbeddedDeps.map(d => ivy"$d")
           val Result.Success(res) = scalalib.Lib.resolveDependencies(
             repos.toList,
             Lib.depToDependency(_, "2.13.2", ""),
-            Versions.millEmbeddedDeps,
+            millDeps,
             sources = false,
             None,
             ctx
@@ -96,7 +97,7 @@ case class GenIdeaImpl(evaluator: Evaluator,
             scalalib.Lib.resolveDependencies(
               repos.toList,
               Lib.depToDependency(_, "2.13.2", ""),
-              Versions.millEmbeddedDeps,
+              millDeps,
               sources = true,
               None,
               ctx

--- a/scalalib/src/Lib.scala
+++ b/scalalib/src/Lib.scala
@@ -36,7 +36,7 @@ object Lib{
                                   depToDependency: Dep => coursier.Dependency,
                                   deps: TraversableOnce[Dep],
                                   mapDependencies: Option[Dependency => Dependency] = None,
-                                  ctx: Option[mill.util.Ctx.Log] = None) = {
+                                  ctx: Option[mill.util.Ctx.Log] = None): (Seq[Dependency], Resolution) = {
     val depSeq = deps.toSeq
     mill.modules.Jvm.resolveDependenciesMetadata(
       repositories,


### PR DESCRIPTION
Not sure why the following does not bring in the dependencies anymore since `0.9.x`:
```
val classpath = Try(evaluator.rootModule.getClass.getClassLoader.asInstanceOf[SpecialClassLoader]).fold(
  _ => Seq.empty,
  _.allJars
)
```
So this is resolving the source files directly. Let me know if you have a better idea.