### PR TITLE
Adjust Docs to MainArgs Syntax for `--gpgArgs`

### DIFF
--- a/ci/release-maven.sh
+++ b/ci/release-maven.sh
@@ -15,7 +15,14 @@ rm -rf ~/.mill
 
 out/dev/assembly/dest/mill mill.scalalib.PublishModule/publishAll \
     --sonatypeCreds $SONATYPE_DEPLOY_USER:$SONATYPE_DEPLOY_PASSWORD \
-    --gpgArgs --passphrase=$SONATYPE_PGP_PASSWORD,--no-tty,--pinentry-mode,loopback,--batch,--yes,-a,-b \
+    --gpgArgs --passphrase=$SONATYPE_PGP_PASSWORD \
+    --gpgArgs --no-tty \
+    --gpgArgs --pinentry-mode \
+    --gpgArgs loopback \
+    --gpgArgs --batch \
+    --gpgArgs --yes \
+    --gpgArgs -a \
+    --gpgArgs -b \
     --publishArtifacts __.publishArtifacts \
     --readTimeout 600000 \
     --awaitTimeout 600000 \

--- a/docs/pages/3 - Common Project Layouts.md
+++ b/docs/pages/3 - Common Project Layouts.md
@@ -290,7 +290,11 @@ central via:
 mill mill.scalalib.PublishModule/publishAll \
         foo.publishArtifacts \
         lihaoyi:$SONATYPE_PASSWORD \
-        --gpgArgs --passphrase=$GPG_PASSWORD,--batch,--yes,-a,-b
+        --gpgArgs --passphrase=$GPG_PASSWORD \
+        --gpgArgs --batch \
+        --gpgArgs --yes \
+        --gpgArgs -a \
+        --gpgArgs -b
 ```
 
 This uploads them to `oss.sonatype.org` where you can log-in and stage/release
@@ -301,7 +305,11 @@ staging/release automatically:
 mill mill.scalalib.PublishModule/publishAll \
         foo.publishArtifacts \
         lihaoyi:$SONATYPE_PASSWORD \
-        --gpgArgs --passphrase=$GPG_PASSWORD,--batch,--yes,-a,-b \ 
+        --gpgArgs --passphrase=$GPG_PASSWORD \
+        --gpgArgs  --batch \
+        --gpgArgs  --yes \
+        --gpgArgs  -a \
+        --gpgArgs  -b \ 
         --release true
 ```
 
@@ -312,7 +320,11 @@ wildcard syntax:
 mill mill.scalalib.PublishModule/publishAll \
         __.publishArtifacts \
         lihaoyi:$SONATYPE_PASSWORD \
-        --gpgArgs --passphrase=$GPG_PASSWORD,--batch,--yes,-a,-b \ 
+        --gpgArgs --passphrase=$GPG_PASSWORD \
+        --gpgArgs --batch \
+        --gpgArgs --yes \
+        --gpgArgs -a \
+        --gpgArgs -b \ 
         --release true
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -203,7 +203,7 @@ and the [list of commits](https://github.com/lihaoyi/mill/compare/0.9.3...master
   [MainArgs](https://github.com/lihaoyi/mainargs) library
 * Note that the MainArgs replacement has some backwards incompatibilities: Short
   flags like `-i` can no longer be passed via `--i`, the `@doc("")` is now
-  `@arg(doc = "")`, `Seq[T]` parameters are now passed via repeated `--foo`
+  `@arg(doc = "")`, `Seq[T]` parameters such as `--gpgArgs` are now passed via repeated `--foo`
   flags rather than comma-separated.
 * Add the ability to relocate/shade files in `.assembly` [#947](https://github.com/lihaoyi/mill/pull/947)
 * Twirl enhancements [#952](https://github.com/lihaoyi/mill/pull/952)


### PR DESCRIPTION
With the move to MainArgs multiple arguments in a list are no longer
passed in as a comma separated list.

This commit reflects this change in the documentation and also updates
the release script accordingly, so that it will  work with mill 0.9.3.