### PR TITLE
Don't follow symlinks when checking permissions of files

### DIFF
--- a/main/api/src/mill/api/PathRef.scala
+++ b/main/api/src/mill/api/PathRef.scala
@@ -38,7 +38,7 @@ object PathRef {
           digest.update(path.toString.getBytes)
           if (!attrs.isDir) {
             if (isPosix) {
-              updateWithInt(os.perms(path).value)
+              updateWithInt(os.perms(path, followLinks = false).value)
             }
             if (quick) {
               val value = (attrs.mtime, attrs.size).hashCode()

--- a/main/test/src/api/PathRefTests.scala
+++ b/main/test/src/api/PathRefTests.scala
@@ -42,6 +42,27 @@ object PathRefTests extends TestSuite {
         check(quick = false)
       }
     }
+
+    'symlinks - {
+      def check(quick: Boolean) = withTmpDir{ tmpDir =>
+        // invalid symlink
+        os.symlink(tmpDir / "nolink", tmpDir / "nonexistant")
+
+        // symlink to empty dir
+        os.symlink(tmpDir / "emptylink", tmpDir / "empty")
+        os.makeDir(tmpDir / "empty")
+
+        // recursive symlinks
+        os.symlink(tmpDir / "rlink1", tmpDir / "rlink2")
+        os.symlink(tmpDir / "rlink2", tmpDir / "rlink1")
+
+        val sig1 = PathRef(tmpDir, quick).sig
+        val sig2 = PathRef(tmpDir, quick).sig
+        assert(sig1 == sig2)
+      }
+      check(quick = true)
+      check(quick = false)
+    }
   }
 
   private def withTmpDir[T](body: os.Path => T): T = {


### PR DESCRIPTION
There's no guarantee that the symlink is actually valid. Note that this is called in a loop that itself follows valid symlinks, so there should not be any files missed.