### PR TITLE
Revert "Update ipcsocket to 1.3.0 (#1057)"

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -51,6 +51,7 @@ object Deps {
   val coursier = ivy"io.get-coursier::coursier:2.0.9"
   val flywayCore = ivy"org.flywaydb:flyway-core:6.5.7"
   val graphvizJava = ivy"guru.nidi:graphviz-java:0.18.0"
+  // Warning: Avoid ipcsocket version 1.3.0, as it caused many failures on CI
   val ipcsocket = ivy"org.scala-sbt.ipcsocket:ipcsocket:1.0.1"
   val ipcsocketExcludingJna = ipcsocket.exclude(
     "net.java.dev.jna" -> "jna",

--- a/build.sc
+++ b/build.sc
@@ -51,7 +51,7 @@ object Deps {
   val coursier = ivy"io.get-coursier::coursier:2.0.9"
   val flywayCore = ivy"org.flywaydb:flyway-core:6.5.7"
   val graphvizJava = ivy"guru.nidi:graphviz-java:0.18.0"
-  val ipcsocket = ivy"org.scala-sbt.ipcsocket:ipcsocket:1.3.0"
+  val ipcsocket = ivy"org.scala-sbt.ipcsocket:ipcsocket:1.0.1"
   val ipcsocketExcludingJna = ipcsocket.exclude(
     "net.java.dev.jna" -> "jna",
     "net.java.dev.jna" -> "jna-platform"


### PR DESCRIPTION
This reverts commit 058479d8f2f794a1e536a170d31b5bc332b8d7c5.

We have various issue with failing CI builds, and I suspect this commit the culprit

Here is a typical output:

```
-------------------------------- Running Tests --------------------------------
java.io.IOException: Error closing -1 for /tmp/398711886632860139/io
	at org.scalasbt.ipcsocket.UnixDomainSocket$UnixDomainSocketInputStream.read(UnixDomainSocket.java:144)
	at mill.main.client.ProxyStreamPumper.run(ProxyStreamPumper.java:29)
	at java.lang.Thread.run(Thread.java:748)
1 targets failed
main.test.test java.lang.Exception: Interactive Subprocess Failed (exit code 1)
    mill.modules.Jvm$.runSubprocess(Jvm.scala:102)
    mill.modules.Jvm$.runSubprocess(Jvm.scala:66)
    mill.scalalib.TestModule.$anonfun$testTask$1(JavaModule.scala:660)
    mill.define.ApplyerGenerated.$anonfun$zipMap$10(ApplicativeGenerated.scala:23)
    mill.define.Task$MappedDest.evaluate(Task.scala:391)
```