### PR TITLE
scala 2.13.4+zinc 1.5.0 M3 bump

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -77,7 +77,7 @@ object Deps {
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.2.2"
   val upickle = ivy"com.lihaoyi::upickle:1.2.2"
   val utest = ivy"com.lihaoyi::utest:0.7.5"
-  val zinc = ivy"org.scala-sbt::zinc:1.4.4"
+  val zinc = ivy"org.scala-sbt::zinc:1.5.0-M3"
   val bsp = ivy"ch.epfl.scala:bsp4j:2.0.0-M13"
   val jarjarabrams = ivy"com.eed3si9n.jarjarabrams::jarjar-abrams-core:0.3.0"
 }

--- a/build.sc
+++ b/build.sc
@@ -13,7 +13,7 @@ import mill.modules.Jvm.createAssembly
 object Deps {
 
   // The Scala version to use
-  val scalaVersion = "2.13.3"
+  val scalaVersion = "2.13.4"
   // The Scala 2.12.x version to use for some workers
   val workerScalaVersion212 = "2.12.10"
 


### PR DESCRIPTION
- Bump Scala to 2.13.4
- Bump zinc to 1.5.0-M3

Zinc 1.4.4 seems to conflict with Scala 2.13.4, at least on CI, Java 8, Ubuntu.
