### PR TITLE
Add missing trait in custom ZincWorkerModule example

### DIFF
--- a/docs/pages/2 - Configuring Mill.md
+++ b/docs/pages/2 - Configuring Mill.md
@@ -81,7 +81,7 @@ custom `ZincWorkerModule`, and override the `zincWorker` method in your
 ```scala
 import coursier.maven.MavenRepository
 
-object CustomZincWorkerModule extends ZincWorkerModule {
+object CustomZincWorkerModule extends ZincWorkerModule with CoursierModule {
   def repositories() = super.repositories ++ Seq(
     MavenRepository("https://oss.sonatype.org/content/repositories/releases")
   )


### PR DESCRIPTION
While following the instructions to use a custom `ZincWorkerModule`, things didn't compile until `CoursierModule` was added too. (It seems it's a self type of `ZincWorkerModule` now.) This PR updates the documentation accordingly.