### PR TITLE
GenIdea: fine-tuned scope calculation for dependencies

### DIFF
--- a/scalalib/src/GenIdeaImpl.scala
+++ b/scalalib/src/GenIdeaImpl.scala
@@ -479,13 +479,14 @@ case class GenIdeaImpl(evaluator: Evaluator,
             .mapValues(_.map(_._2))
             .map {
               case (lib, scopes) =>
+                val isCompile = scopes.contains(None)
                 val isProvided = scopes.contains(Some("PROVIDED"))
                 val isRuntime = scopes.contains(Some("RUNTIME"))
 
-                val finalScope = (isProvided, isRuntime) match {
-                  case (true, false) => Some("PROVIDED")
-                  case (false, true) => Some("RUNTIME")
-                  case _             => None
+                val finalScope = (isCompile, isProvided, isRuntime) match {
+                  case (_, true, false)     => Some("PROVIDED")
+                  case (false, false, true) => Some("RUNTIME")
+                  case _                    => None
                 }
 
                 ScopedOrd(lib, finalScope)

--- a/scalalib/test/resources/gen-idea-hello-world/build.sc
+++ b/scalalib/test/resources/gen-idea-hello-world/build.sc
@@ -11,9 +11,11 @@ trait HelloWorldModule extends scalalib.ScalaModule {
       ivy"org.slf4j:jcl-over-slf4j:1.7.25"
     )
     override def ivyDeps: Target[Agg[Dep]] = Agg(
-      ivy"org.slf4j:slf4j-api:1.7.25"
+      ivy"org.slf4j:slf4j-api:1.7.25",
+      ivy"ch.qos.logback:logback-core:1.2.3",
     )
     override def runIvyDeps: Target[Agg[Dep]] = Agg(
+      ivy"ch.qos.logback:logback-core:1.2.3",
       ivy"ch.qos.logback:logback-classic:1.2.3"
     )
   }

--- a/scalalib/test/resources/gen-idea-hello-world/idea_modules/helloworld.test.iml
+++ b/scalalib/test/resources/gen-idea-hello-world/idea_modules/helloworld.test.iml
@@ -12,7 +12,7 @@
         <orderEntry type="sourceFolder" forTests="false"/>
         <orderEntry type="library" scope="PROVIDED" name="jcl-over-slf4j-1.7.25.jar" level="project"/>
         <orderEntry type="library" scope="RUNTIME" name="logback-classic-1.2.3.jar" level="project"/>
-        <orderEntry type="library" scope="RUNTIME" name="logback-core-1.2.3.jar" level="project"/>
+        <orderEntry type="library" name="logback-core-1.2.3.jar" level="project"/>
         <orderEntry type="library" name="scala-library-2.12.4.jar" level="project"/>
         <orderEntry type="library" name="slf4j-api-1.7.25.jar" level="project"/>
         <orderEntry type="module" module-name="helloworld" exported=""/>


### PR DESCRIPTION
Fixes the case where runtime dependencies, which are also compile-time dependencies, are only mapped to RUNTIME scope in IntelliJ IDEA. 