### PR TITLE
Various Fixed for Windows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -50,7 +50,7 @@ jobs:
           git config --add user.email "mill-ci@localhost"
           ${{ matrix.buildcmd }}
 
-  test-windows:
+  build-windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -60,6 +60,21 @@ jobs:
         with:
           java-version: 8
       - run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i "{__.publishLocal,assembly,__.compile}"
+
+  test-windows:
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Test core
+        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i "{main,scalalib,scalajslib,scalanativelib,bsp}.__.test"
+      - name: Test contrib
+        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i "contrib._.test"
 
   publish-sonatype:
     if: github.repository == 'lihaoyi/mill' && github.ref == 'refs/heads/master'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -72,9 +72,9 @@ jobs:
         with:
           java-version: 8
       - name: Test core
-        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i "{main,scalalib,scalajslib,scalanativelib,bsp}.__.test"
+        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d "{main,scalalib,scalajslib,scalanativelib,bsp}.__.test"
       - name: Test contrib
-        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i "contrib._.test"
+        run: cmd /C %GITHUB_WORKSPACE%\ci\mill.bat -i -d "contrib._.test"
 
   publish-sonatype:
     if: github.repository == 'lihaoyi/mill' && github.ref == 'refs/heads/master'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -78,7 +78,7 @@ jobs:
 
   publish-sonatype:
     if: github.repository == 'lihaoyi/mill' && github.ref == 'refs/heads/master'
-    needs: [test, test-windows]
+    needs: [test, build-windows, test-windows]
 
     runs-on: ubuntu-latest
 

--- a/main/client/src/mill/main/client/Util.java
+++ b/main/client/src/mill/main/client/Util.java
@@ -4,12 +4,14 @@ package mill.main.client;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
 public class Util {
     public static boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
     public static boolean isJava9OrAbove = !System.getProperty("java.specification.version").startsWith("1.");
+    private static Charset utf8 = Charset.forName("UTF-8");
 
     // Windows named pipe prefix (see https://github.com/sbt/ipcsocket/blob/v1.0.0/README.md)
     // Win32NamedPipeServerSocket automatically adds this as a prefix (if it is not already is prefixed),
@@ -60,8 +62,8 @@ public class Util {
 
     public static String readString(InputStream inputStream) throws IOException {
         // Result is between 0 and 255, hence the loop.
-        int length = readInt(inputStream);
-        byte[] arr = new byte[length];
+        final int length = readInt(inputStream);
+        final byte[] arr = new byte[length];
         int total = 0;
         while(total < length){
             int res = inputStream.read(arr, total, length-total);
@@ -70,11 +72,11 @@ public class Util {
                 total += res;
             }
         }
-        return new String(arr);
+        return new String(arr, utf8);
     }
 
     public static void writeString(OutputStream outputStream, String string) throws IOException {
-        byte[] bytes = string.getBytes();
+        final byte[] bytes = string.getBytes(utf8);
         writeInt(outputStream, bytes.length);
         outputStream.write(bytes);
     }

--- a/main/client/test/src/mill/main/client/ClientTests.java
+++ b/main/client/test/src/mill/main/client/ClientTests.java
@@ -58,7 +58,7 @@ public class ClientTests {
         Util.writeString(o, example);
         ByteArrayInputStream i = new ByteArrayInputStream(o.toByteArray());
         String s = Util.readString(i);
-        expectEquals(example, s);
+        expectEquals(example, s, "String as bytes: ["+example.getBytes()+"] differs from expected: ["+s.getBytes()+"]");
         expectEquals(i.available(), 0);
     }
 

--- a/main/client/test/src/mill/main/client/ClientTests.java
+++ b/main/client/test/src/mill/main/client/ClientTests.java
@@ -1,5 +1,6 @@
 package mill.main.client;
 
+import static de.tobiasroeser.lambdatest.Expect.expectEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -57,8 +58,8 @@ public class ClientTests {
         Util.writeString(o, example);
         ByteArrayInputStream i = new ByteArrayInputStream(o.toByteArray());
         String s = Util.readString(i);
-        assertEquals(example, s);
-        assertEquals(i.available(), 0);
+        expectEquals(example, s);
+        expectEquals(i.available(), 0);
     }
 
     public byte[] readSamples(String ...samples) throws Exception{

--- a/main/client/test/src/mill/main/client/ClientTests.java
+++ b/main/client/test/src/mill/main/client/ClientTests.java
@@ -65,7 +65,7 @@ public class ClientTests {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         for(String sample: samples) {
             byte[] bytes = java.nio.file.Files.readAllBytes(
-                java.nio.file.Paths.get(getClass().getResource(sample).getFile())
+                java.nio.file.Paths.get(getClass().getResource(sample).toURI())
             );
             out.write(bytes);
         }

--- a/main/src/modules/Jvm.scala
+++ b/main/src/modules/Jvm.scala
@@ -65,12 +65,16 @@ object Jvm {
                     envArgs: Map[String, String] = Map.empty,
                     mainArgs: Seq[String] = Seq.empty,
                     workingDir: os.Path = null,
-                    background: Boolean = false): Unit = {
+                    background: Boolean = false)
+                   (implicit ctx: Ctx): Unit = {
+
     val args =
       Vector(javaExe) ++
         jvmArgs ++
         Vector("-cp", classPath.mkString(java.io.File.pathSeparator), mainClass) ++
         mainArgs
+
+    ctx.log.debug(s"Run subprocess with args: ${args.map(a => s"'${a}''").mkString(" ")}")
 
     if (background) spawnSubprocess(args, envArgs, workingDir)
     else runSubprocess(args, envArgs, workingDir)

--- a/main/src/modules/Jvm.scala
+++ b/main/src/modules/Jvm.scala
@@ -34,16 +34,27 @@ object Jvm {
                     (implicit ctx: Ctx) = {
 
     val commandArgs =
-      Vector("java") ++
-      jvmArgs ++
-      Vector("-cp", classPath.mkString(java.io.File.pathSeparator), mainClass) ++
-      mainArgs
+      Vector(javaExe) ++
+        jvmArgs ++
+        Vector("-cp", classPath.mkString(java.io.File.pathSeparator), mainClass) ++
+        mainArgs
 
     val workingDir1 = Option(workingDir).getOrElse(ctx.dest)
     os.makeDir.all(workingDir1)
 
     os.proc(commandArgs).call(cwd = workingDir1, env = envArgs)
   }
+
+  def javaExe: String =
+    sys.props
+      .get("java.home")
+      .to(LazyList)
+      .map(new File(_).getAbsoluteFile())
+      .flatMap(d => Seq(new File(d, "bin/java"), new File(d, "bin/java.exe")))
+      .filter(f => f.exists())
+      .map(_.getAbsolutePath())
+      .headOption
+      .getOrElse("java")
 
   /**
     * Runs a JVM subprocess with the given configuration and streams
@@ -57,10 +68,10 @@ object Jvm {
                     workingDir: os.Path = null,
                     background: Boolean = false): Unit = {
     val args =
-      Vector("java") ++
-      jvmArgs ++
-      Vector("-cp", classPath.mkString(java.io.File.pathSeparator), mainClass) ++
-      mainArgs
+      Vector(javaExe) ++
+        jvmArgs ++
+        Vector("-cp", classPath.mkString(java.io.File.pathSeparator), mainClass) ++
+        mainArgs
 
     if (background) spawnSubprocess(args, envArgs, workingDir)
     else runSubprocess(args, envArgs, workingDir)

--- a/main/src/modules/Jvm.scala
+++ b/main/src/modules/Jvm.scala
@@ -16,6 +16,7 @@ import mill.api.IO
 import mill.api.Loose.Agg
 import mill.modules.Assembly.{AppendEntry, WriteOnceEntry}
 import scala.collection.mutable
+import scala.util.Properties.isWin
 import scala.jdk.CollectionConverters._
 import upickle.default.{ReadWriter => RW}
 
@@ -48,13 +49,11 @@ object Jvm {
   def javaExe: String =
     sys.props
       .get("java.home")
-      .to(LazyList)
-      .map(new File(_).getAbsoluteFile())
-      .flatMap(d => Seq(new File(d, "bin/java"), new File(d, "bin/java.exe")))
+      .map(h =>
+        if(isWin) new File(h, "bin\\java.exe")
+        else new File(h, "bin/java"))
       .filter(f => f.exists())
-      .map(_.getAbsolutePath())
-      .headOption
-      .getOrElse("java")
+      .fold("java")(_.getAbsolutePath())
 
   /**
     * Runs a JVM subprocess with the given configuration and streams


### PR DESCRIPTION
Various fixes only shown on Windows, probably also elsewhere.

* Fixed string stream writer/reader used for mill client-server communication, by using an explicit charset for byte conversion
* Avoid `java.nio.file.Paths.get(url.getFile())` in favour of `java.nio.file.Paths.get(url.toURI())` as the latter handles windows paths with leading drive letters well
* Improved CI setup for Windows
* Better run/spawn of Java sub-processes by selecting the same Java executable which is used by mill

We still have some CI failures on Windows, as we need some of these fixed in mill before we can benefit from it. Expect more PRs.

Probably related issues:
* https://github.com/lihaoyi/mill/issues/781
* https://github.com/lihaoyi/mill/issues/874
* https://github.com/lihaoyi/mill/issues/646
* https://github.com/lihaoyi/mill/issues/1098